### PR TITLE
feat: bump to protocol 9

### DIFF
--- a/livekit-api/src/signal_client/mod.rs
+++ b/livekit-api/src/signal_client/mod.rs
@@ -33,7 +33,7 @@ pub type SignalEvents = mpsc::UnboundedReceiver<SignalEvent>;
 pub type SignalResult<T> = Result<T, SignalError>;
 
 pub const JOIN_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
-pub const PROTOCOL_VERSION: u32 = 8;
+pub const PROTOCOL_VERSION: u32 = 9;
 
 #[derive(Error, Debug)]
 pub enum SignalError {


### PR DESCRIPTION
seems like this is already supported by the Rust SDK
https://github.com/livekit/client-sdk-js/pull/605/files