### PR TITLE
Allow to create ParticipantSid from String in user module (#250)

### DIFF
--- a/livekit/src/room/id.rs
+++ b/livekit/src/room/id.rs
@@ -7,7 +7,7 @@ const PARTICIPANT_PREFIX: &str = "PA_";
 const TRACK_PREFIX: &str = "TR_";
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub struct ParticipantSid(String);
+pub struct ParticipantSid(pub String);
 
 #[derive(Clone, Default, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct ParticipantIdentity(pub String);


### PR DESCRIPTION
Hey, I want test/use this livekit-rust-sdk in c++ code.
To do this I create internal-rust-layer to expose some functionality, and extract it to c++.
I came across a problem to create ParticipantSid from String in user module,
therefore i purpose to add 'pub' in declaration of ParticipantSid.
Do you think it is ok, or I should choose other way?