### PR TITLE
ffi: fix panic when publishing data while room is closed

### DIFF
--- a/livekit-ffi/src/server/room.rs
+++ b/livekit-ffi/src/server/room.rs
@@ -205,20 +205,19 @@ impl RoomInner {
         let destination_sids = publish.destination_sids;
         let async_id = server.next_id();
 
-        self.data_tx
-            .send(FfiDataPacket {
-                payload: DataPacket {
-                    payload: data.to_vec(), // Avoid copy?
-                    kind: kind.into(),
-                    topic: publish.topic,
-                    destination_sids: destination_sids
-                        .into_iter()
-                        .map(|str| str.try_into().unwrap())
-                        .collect(),
-                },
-                async_id,
-            })
-            .map_err(|_| FfiError::InvalidRequest("failed to send data packet".into()))?;
+        // Ignore result, if the channel is closed, it means the room has been closed
+        let _ = self.data_tx.send(FfiDataPacket {
+            payload: DataPacket {
+                payload: data.to_vec(), // Avoid copy?
+                kind: kind.into(),
+                topic: publish.topic,
+                destination_sids: destination_sids
+                    .into_iter()
+                    .map(|str| str.try_into().unwrap())
+                    .collect(),
+            },
+            async_id,
+        });
 
         Ok(proto::PublishDataResponse { async_id })
     }

--- a/livekit-ffi/src/server/room.rs
+++ b/livekit-ffi/src/server/room.rs
@@ -220,7 +220,7 @@ impl RoomInner {
             server.async_runtime.spawn(async move {
                 let cb = proto::PublishDataCallback {
                     async_id,
-                    error: Some(err.to_string()),
+                    error: Some("failed to send data, room closed".into()),
                 };
 
                 let _ = server

--- a/livekit-ffi/src/server/room.rs
+++ b/livekit-ffi/src/server/room.rs
@@ -220,7 +220,7 @@ impl RoomInner {
             server.async_runtime.spawn(async move {
                 let cb = proto::PublishDataCallback {
                     async_id,
-                    error: Some("failed to send data, room closed".into()),
+                    error: Some(format!("failed to send data, room closed: {}", err).into()),
                 };
 
                 let _ = server


### PR DESCRIPTION
Instead of panic, it'll send an error on the Python side