### PR TITLE
Add rustfmt.toml configuration and re-format everything + fix basic warnings

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,36 @@
+name: Rust Formatting
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  formatting:
+    name: Check Formatting
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || !github.event.pull_request.draft
+
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2023-12-30
+          components: rustfmt
+
+      - name: Cargo fmt
+        run: |
+          cargo fmt -- --check

--- a/libwebrtc/src/audio_source.rs
+++ b/libwebrtc/src/audio_source.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::imp::audio_source as imp_as;
 use livekit_protocol::enum_dispatch;
+
+use crate::imp::audio_source as imp_as;
 
 #[derive(Default, Debug)]
 pub struct AudioSourceOptions {
@@ -41,9 +42,10 @@ impl RtcAudioSource {
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod native {
+    use std::fmt::{Debug, Formatter};
+
     use super::*;
     use crate::{audio_frame::AudioFrame, RtcError};
-    use std::fmt::{Debug, Formatter};
 
     #[derive(Clone)]
     pub struct NativeAudioSource {
@@ -62,9 +64,7 @@ pub mod native {
             sample_rate: u32,
             num_channels: u32,
         ) -> NativeAudioSource {
-            Self {
-                handle: imp_as::NativeAudioSource::new(options, sample_rate, num_channels),
-            }
+            Self { handle: imp_as::NativeAudioSource::new(options, sample_rate, num_channels) }
         }
 
         pub async fn capture_frame(&self, frame: &AudioFrame<'_>) -> Result<(), RtcError> {

--- a/libwebrtc/src/audio_stream.rs
+++ b/libwebrtc/src/audio_stream.rs
@@ -16,13 +16,16 @@ use crate::imp::audio_stream as stream_imp;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod native {
-    use super::stream_imp;
-    use crate::audio_frame::AudioFrame;
-    use crate::audio_track::RtcAudioTrack;
-    use std::fmt::{Debug, Formatter};
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
+    use std::{
+        fmt::{Debug, Formatter},
+        pin::Pin,
+        task::{Context, Poll},
+    };
+
     use tokio_stream::Stream;
+
+    use super::stream_imp;
+    use crate::{audio_frame::AudioFrame, audio_track::RtcAudioTrack};
 
     pub struct NativeAudioStream {
         pub(crate) handle: stream_imp::NativeAudioStream,
@@ -30,17 +33,13 @@ pub mod native {
 
     impl Debug for NativeAudioStream {
         fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-            f.debug_struct("NativeAudioStream")
-                .field("track", &self.track())
-                .finish()
+            f.debug_struct("NativeAudioStream").field("track", &self.track()).finish()
         }
     }
 
     impl NativeAudioStream {
         pub fn new(audio_track: RtcAudioTrack) -> Self {
-            Self {
-                handle: stream_imp::NativeAudioStream::new(audio_track),
-            }
+            Self { handle: stream_imp::NativeAudioStream::new(audio_track) }
         }
 
         pub fn track(&self) -> RtcAudioTrack {

--- a/libwebrtc/src/audio_track.rs
+++ b/libwebrtc/src/audio_track.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::imp::audio_track as imp_at;
-use crate::media_stream_track::media_stream_track;
-use crate::media_stream_track::RtcTrackState;
 use std::fmt::Debug;
+
+use crate::{
+    imp::audio_track as imp_at,
+    media_stream_track::{media_stream_track, RtcTrackState},
+};
 
 #[derive(Clone)]
 pub struct RtcAudioTrack {

--- a/libwebrtc/src/data_channel.rs
+++ b/libwebrtc/src/data_channel.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{imp::data_channel as dc_imp, rtp_parameters::Priority};
-use serde::Deserialize;
 use std::{fmt::Debug, str::Utf8Error};
+
+use serde::Deserialize;
 use thiserror::Error;
+
+use crate::{imp::data_channel as dc_imp, rtp_parameters::Priority};
 
 #[derive(Clone, Debug)]
 pub struct DataChannelInit {

--- a/libwebrtc/src/ice_candidate.rs
+++ b/libwebrtc/src/ice_candidate.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{imp::ice_candidate as imp_ic, session_description::SdpParseError};
 use std::fmt::Debug;
+
+use crate::{imp::ice_candidate as imp_ic, session_description::SdpParseError};
 
 pub struct IceCandidate {
     pub(crate) handle: imp_ic::IceCandidate,
@@ -49,8 +50,6 @@ impl ToString for IceCandidate {
 
 impl Debug for IceCandidate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("IceCandidate")
-            .field("candidate", &self.to_string())
-            .finish()
+        f.debug_struct("IceCandidate").field("candidate", &self.to_string()).finish()
     }
 }

--- a/libwebrtc/src/lib.rs
+++ b/libwebrtc/src/lib.rs
@@ -64,10 +64,9 @@ pub mod video_track;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod native {
-    pub use crate::imp::audio_resampler;
-    pub use crate::imp::frame_cryptor;
-    pub use crate::imp::yuv_helper;
     pub use webrtc_sys::webrtc::ffi::create_random_uuid;
+
+    pub use crate::imp::{audio_resampler, frame_cryptor, yuv_helper};
 }
 
 #[cfg(target_os = "android")]

--- a/libwebrtc/src/media_stream.rs
+++ b/libwebrtc/src/media_stream.rs
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::audio_track::RtcAudioTrack;
-use crate::imp::media_stream as imp_ms;
-use crate::video_track::RtcVideoTrack;
 use std::fmt::Debug;
+
+use crate::{audio_track::RtcAudioTrack, imp::media_stream as imp_ms, video_track::RtcVideoTrack};
 
 #[derive(Clone)]
 pub struct MediaStream {

--- a/libwebrtc/src/media_stream_track.rs
+++ b/libwebrtc/src/media_stream_track.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::audio_track::RtcAudioTrack;
-use crate::video_track::RtcVideoTrack;
 use livekit_protocol::enum_dispatch;
+
+use crate::{audio_track::RtcAudioTrack, video_track::RtcVideoTrack};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RtcTrackState {

--- a/libwebrtc/src/native/audio_resampler.rs
+++ b/libwebrtc/src/native/audio_resampler.rs
@@ -21,9 +21,7 @@ pub struct AudioResampler {
 
 impl Default for AudioResampler {
     fn default() -> Self {
-        Self {
-            sys_handle: sys_ar::ffi::create_audio_resampler(),
-        }
+        Self { sys_handle: sys_ar::ffi::create_audio_resampler() }
     }
 }
 
@@ -37,10 +35,7 @@ impl AudioResampler {
         dst_num_channels: u32,
         dst_sample_rate: u32,
     ) -> &'a [i16] {
-        assert!(
-            src.len() >= (samples_per_channel * num_channels) as usize,
-            "src buffer too small"
-        );
+        assert!(src.len() >= (samples_per_channel * num_channels) as usize, "src buffer too small");
 
         unsafe {
             let len = self.sys_handle.pin_mut().remix_and_resample(

--- a/libwebrtc/src/native/audio_stream.rs
+++ b/libwebrtc/src/native/audio_stream.rs
@@ -12,15 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::audio_frame::AudioFrame;
-use crate::audio_track::RtcAudioTrack;
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
 use cxx::SharedPtr;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
 use tokio::sync::mpsc;
 use tokio_stream::Stream;
 use webrtc_sys::audio_track as sys_at;
+
+use crate::{audio_frame::AudioFrame, audio_track::RtcAudioTrack};
 
 pub struct NativeAudioStream {
     native_sink: SharedPtr<sys_at::ffi::NativeAudioSink>,
@@ -39,11 +42,7 @@ impl NativeAudioStream {
         let audio = unsafe { sys_at::ffi::media_to_audio(audio_track.sys_handle()) };
         audio.add_sink(&native_sink);
 
-        Self {
-            native_sink,
-            audio_track,
-            frame_rx,
-        }
+        Self { native_sink, audio_track, frame_rx }
     }
 
     pub fn track(&self) -> RtcAudioTrack {

--- a/libwebrtc/src/native/audio_track.rs
+++ b/libwebrtc/src/native/audio_track.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::media_stream_track::impl_media_stream_track;
-use crate::media_stream_track::RtcTrackState;
 use cxx::SharedPtr;
 use sys_at::ffi::audio_to_media;
 use webrtc_sys::audio_track as sys_at;
+
+use super::media_stream_track::impl_media_stream_track;
+use crate::media_stream_track::RtcTrackState;
 
 #[derive(Clone)]
 pub struct RtcAudioTrack {

--- a/libwebrtc/src/native/frame_cryptor.rs
+++ b/libwebrtc/src/native/frame_cryptor.rs
@@ -1,10 +1,13 @@
+use std::sync::Arc;
+
 use cxx::SharedPtr;
 use parking_lot::Mutex;
-use std::sync::Arc;
 use webrtc_sys::frame_cryptor::{self as sys_fc};
 
-use crate::peer_connection_factory::PeerConnectionFactory;
-use crate::{rtp_receiver::RtpReceiver, rtp_sender::RtpSender};
+use crate::{
+    peer_connection_factory::PeerConnectionFactory, rtp_receiver::RtpReceiver,
+    rtp_sender::RtpSender,
+};
 
 pub type OnStateChange = Box<dyn FnMut(String, EncryptionState) + Send + Sync>;
 
@@ -40,9 +43,7 @@ pub struct KeyProvider {
 
 impl KeyProvider {
     pub fn new(options: KeyProviderOptions) -> Self {
-        Self {
-            sys_handle: sys_fc::ffi::new_key_provider(options.into()),
-        }
+        Self { sys_handle: sys_fc::ffi::new_key_provider(options.into()) }
     }
 
     pub fn set_shared_key(&self, key_index: i32, key: Vec<u8>) -> bool {
@@ -96,14 +97,9 @@ impl FrameCryptor {
             key_provider.sys_handle,
             sender.handle.sys_handle,
         );
-        let fc = Self {
-            observer: observer.clone(),
-            sys_handle: sys_handle.clone(),
-        };
+        let fc = Self { observer: observer.clone(), sys_handle: sys_handle.clone() };
         fc.sys_handle
-            .register_observer(Box::new(sys_fc::RtcFrameCryptorObserverWrapper::new(
-                observer,
-            )));
+            .register_observer(Box::new(sys_fc::RtcFrameCryptorObserverWrapper::new(observer)));
         fc
     }
 
@@ -122,14 +118,9 @@ impl FrameCryptor {
             key_provider.sys_handle,
             receiver.handle.sys_handle,
         );
-        let fc = Self {
-            observer: observer.clone(),
-            sys_handle: sys_handle.clone(),
-        };
+        let fc = Self { observer: observer.clone(), sys_handle: sys_handle.clone() };
         fc.sys_handle
-            .register_observer(Box::new(sys_fc::RtcFrameCryptorObserverWrapper::new(
-                observer,
-            )));
+            .register_observer(Box::new(sys_fc::RtcFrameCryptorObserverWrapper::new(observer)));
         fc
     }
 

--- a/libwebrtc/src/native/ice_candidate.rs
+++ b/libwebrtc/src/native/ice_candidate.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::ice_candidate as ic;
-use crate::session_description::SdpParseError;
 use cxx::SharedPtr;
 use webrtc_sys::jsep as sys_jsep;
+
+use crate::{ice_candidate as ic, session_description::SdpParseError};
 
 #[derive(Clone)]
 pub struct IceCandidate {
@@ -35,9 +35,7 @@ impl IceCandidate {
         );
 
         match res {
-            Ok(sys_handle) => Ok(ic::IceCandidate {
-                handle: IceCandidate { sys_handle },
-            }),
+            Ok(sys_handle) => Ok(ic::IceCandidate { handle: IceCandidate { sys_handle } }),
             Err(e) => Err(unsafe { sys_jsep::ffi::SdpParseError::from(e.what()).into() }),
         }
     }

--- a/libwebrtc/src/native/media_stream.rs
+++ b/libwebrtc/src/native/media_stream.rs
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::audio_track;
-use crate::imp::audio_track::RtcAudioTrack;
-use crate::imp::video_track::RtcVideoTrack;
-use crate::video_track;
 use cxx::SharedPtr;
 use webrtc_sys::media_stream as sys_ms;
+
+use crate::{
+    audio_track,
+    imp::{audio_track::RtcAudioTrack, video_track::RtcVideoTrack},
+    video_track,
+};
 
 #[derive(Clone)]
 pub struct MediaStream {
@@ -33,9 +35,7 @@ impl MediaStream {
         self.sys_handle
             .get_audio_tracks()
             .into_iter()
-            .map(|t| audio_track::RtcAudioTrack {
-                handle: RtcAudioTrack { sys_handle: t.ptr },
-            })
+            .map(|t| audio_track::RtcAudioTrack { handle: RtcAudioTrack { sys_handle: t.ptr } })
             .collect()
     }
 
@@ -43,9 +43,7 @@ impl MediaStream {
         self.sys_handle
             .get_video_tracks()
             .into_iter()
-            .map(|t| video_track::RtcVideoTrack {
-                handle: RtcVideoTrack { sys_handle: t.ptr },
-            })
+            .map(|t| video_track::RtcVideoTrack { handle: RtcVideoTrack { sys_handle: t.ptr } })
             .collect()
     }
 }

--- a/libwebrtc/src/native/media_stream_track.rs
+++ b/libwebrtc/src/native/media_stream_track.rs
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::audio_track;
-use crate::imp::audio_track::RtcAudioTrack;
-use crate::imp::video_track::RtcVideoTrack;
-use crate::media_stream_track::MediaStreamTrack;
-use crate::media_stream_track::RtcTrackState;
-use crate::video_track;
 use cxx::SharedPtr;
-use webrtc_sys::audio_track::ffi::media_to_audio;
-use webrtc_sys::media_stream_track as sys_mst;
-use webrtc_sys::video_track::ffi::media_to_video;
-use webrtc_sys::{MEDIA_TYPE_AUDIO, MEDIA_TYPE_VIDEO};
+use webrtc_sys::{
+    audio_track::ffi::media_to_audio, media_stream_track as sys_mst,
+    video_track::ffi::media_to_video, MEDIA_TYPE_AUDIO, MEDIA_TYPE_VIDEO,
+};
+
+use crate::{
+    audio_track,
+    imp::{audio_track::RtcAudioTrack, video_track::RtcVideoTrack},
+    media_stream_track::{MediaStreamTrack, RtcTrackState},
+    video_track,
+};
 
 impl From<sys_mst::ffi::TrackState> for RtcTrackState {
     fn from(state: sys_mst::ffi::TrackState) -> Self {
@@ -39,15 +40,11 @@ pub fn new_media_stream_track(
 ) -> MediaStreamTrack {
     if sys_handle.kind() == MEDIA_TYPE_AUDIO {
         MediaStreamTrack::Audio(audio_track::RtcAudioTrack {
-            handle: RtcAudioTrack {
-                sys_handle: unsafe { media_to_audio(sys_handle) },
-            },
+            handle: RtcAudioTrack { sys_handle: unsafe { media_to_audio(sys_handle) } },
         })
     } else if sys_handle.kind() == MEDIA_TYPE_VIDEO {
         MediaStreamTrack::Video(video_track::RtcVideoTrack {
-            handle: RtcVideoTrack {
-                sys_handle: unsafe { media_to_video(sys_handle) },
-            },
+            handle: RtcVideoTrack { sys_handle: unsafe { media_to_video(sys_handle) } },
         })
     } else {
         panic!("unknown track kind")

--- a/libwebrtc/src/native/mod.rs
+++ b/libwebrtc/src/native/mod.rs
@@ -19,6 +19,7 @@ pub mod audio_source;
 pub mod audio_stream;
 pub mod audio_track;
 pub mod data_channel;
+pub mod frame_cryptor;
 pub mod ice_candidate;
 pub mod media_stream;
 pub mod media_stream_track;
@@ -34,12 +35,10 @@ pub mod video_source;
 pub mod video_stream;
 pub mod video_track;
 pub mod yuv_helper;
-pub mod frame_cryptor;
 
-use crate::MediaType;
-use crate::{RtcError, RtcErrorType};
-use webrtc_sys::rtc_error as sys_err;
-use webrtc_sys::webrtc as sys_rtc;
+use webrtc_sys::{rtc_error as sys_err, webrtc as sys_rtc};
+
+use crate::{MediaType, RtcError, RtcErrorType};
 
 impl From<sys_err::ffi::RtcErrorType> for RtcErrorType {
     fn from(value: sys_err::ffi::RtcErrorType) -> Self {
@@ -52,10 +51,7 @@ impl From<sys_err::ffi::RtcErrorType> for RtcErrorType {
 
 impl From<sys_err::ffi::RtcError> for RtcError {
     fn from(value: sys_err::ffi::RtcError) -> Self {
-        Self {
-            error_type: value.error_type.into(),
-            message: value.message,
-        }
+        Self { error_type: value.error_type.into(), message: value.message }
     }
 }
 

--- a/libwebrtc/src/native/peer_connection_factory.rs
+++ b/libwebrtc/src/native/peer_connection_factory.rs
@@ -12,26 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::audio_source::native::NativeAudioSource;
-use crate::audio_track::RtcAudioTrack;
-use crate::imp::audio_track as imp_at;
-use crate::imp::peer_connection as imp_pc;
-use crate::imp::video_track as imp_vt;
-use crate::peer_connection::PeerConnection;
-use crate::peer_connection_factory::RtcConfiguration;
-use crate::rtp_parameters::RtpCapabilities;
-use crate::video_source::native::NativeVideoSource;
-use crate::video_track::RtcVideoTrack;
-use crate::MediaType;
-use crate::RtcError;
-use cxx::SharedPtr;
-use cxx::UniquePtr;
+use std::sync::Arc;
+
+use cxx::{SharedPtr, UniquePtr};
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
-use std::sync::Arc;
-use webrtc_sys::peer_connection_factory as sys_pcf;
-use webrtc_sys::rtc_error as sys_err;
-use webrtc_sys::webrtc as sys_rtc;
+use webrtc_sys::{peer_connection_factory as sys_pcf, rtc_error as sys_err, webrtc as sys_rtc};
+
+use crate::{
+    audio_source::native::NativeAudioSource,
+    audio_track::RtcAudioTrack,
+    imp::{audio_track as imp_at, peer_connection as imp_pc, video_track as imp_vt},
+    peer_connection::PeerConnection,
+    peer_connection_factory::RtcConfiguration,
+    rtp_parameters::RtpCapabilities,
+    video_source::native::NativeVideoSource,
+    video_track::RtcVideoTrack,
+    MediaType, RtcError,
+};
 
 lazy_static! {
     static ref LOG_SINK: Mutex<Option<UniquePtr<sys_rtc::ffi::LogSink>>> = Default::default();
@@ -47,18 +45,13 @@ impl Default for PeerConnectionFactory {
         let mut log_sink = LOG_SINK.lock();
         if log_sink.is_none() {
             *log_sink = Some(sys_rtc::ffi::new_log_sink(|msg, _| {
-                let msg = msg
-                    .strip_suffix("\r\n")
-                    .or(msg.strip_suffix('\n'))
-                    .unwrap_or(&msg);
+                let msg = msg.strip_suffix("\r\n").or(msg.strip_suffix('\n')).unwrap_or(&msg);
 
                 log::debug!("{}", msg);
             }));
         }
 
-        Self {
-            sys_handle: sys_pcf::ffi::create_peer_connection_factory(),
-        }
+        Self { sys_handle: sys_pcf::ffi::create_peer_connection_factory() }
     }
 }
 
@@ -70,9 +63,7 @@ impl PeerConnectionFactory {
         let observer = Arc::new(imp_pc::PeerObserver::default());
         let res = self.sys_handle.create_peer_connection(
             config.into(),
-            Box::new(sys_pcf::PeerConnectionObserverWrapper::new(
-                observer.clone(),
-            )),
+            Box::new(sys_pcf::PeerConnectionObserverWrapper::new(observer.clone())),
         );
 
         match res {
@@ -104,15 +95,11 @@ impl PeerConnectionFactory {
     }
 
     pub fn get_rtp_sender_capabilities(&self, media_type: MediaType) -> RtpCapabilities {
-        self.sys_handle
-            .rtp_sender_capabilities(media_type.into())
-            .into()
+        self.sys_handle.rtp_sender_capabilities(media_type.into()).into()
     }
 
     pub fn get_rtp_receiver_capabilities(&self, media_type: MediaType) -> RtpCapabilities {
-        self.sys_handle
-            .rtp_receiver_capabilities(media_type.into())
-            .into()
+        self.sys_handle.rtp_receiver_capabilities(media_type.into()).into()
     }
 }
 

--- a/libwebrtc/src/native/rtp_parameters.rs
+++ b/libwebrtc/src/native/rtp_parameters.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use webrtc_sys::{rtp_parameters as sys_rp, webrtc as sys_webrtc};
+
 use crate::rtp_parameters::*;
-use webrtc_sys::rtp_parameters as sys_rp;
-use webrtc_sys::webrtc as sys_webrtc;
 
 impl From<sys_webrtc::ffi::Priority> for Priority {
     fn from(value: sys_webrtc::ffi::Priority) -> Self {
@@ -30,11 +30,7 @@ impl From<sys_webrtc::ffi::Priority> for Priority {
 
 impl From<sys_rp::ffi::RtpExtension> for RtpHeaderExtensionParameters {
     fn from(value: sys_rp::ffi::RtpExtension) -> Self {
-        Self {
-            uri: value.uri,
-            id: value.id,
-            encrypted: value.encrypt,
-        }
+        Self { uri: value.uri, id: value.id, encrypted: value.encrypt }
     }
 }
 
@@ -42,11 +38,7 @@ impl From<sys_rp::ffi::RtpParameters> for RtpParameters {
     fn from(value: sys_rp::ffi::RtpParameters) -> Self {
         Self {
             codecs: value.codecs.into_iter().map(Into::into).collect(),
-            header_extensions: value
-                .header_extensions
-                .into_iter()
-                .map(Into::into)
-                .collect(),
+            header_extensions: value.header_extensions.into_iter().map(Into::into).collect(),
             rtcp: value.rtcp.into(),
         }
     }
@@ -65,10 +57,7 @@ impl From<sys_rp::ffi::RtpCodecParameters> for RtpCodecParameters {
 
 impl From<sys_rp::ffi::RtcpParameters> for RtcpParameters {
     fn from(value: sys_rp::ffi::RtcpParameters) -> Self {
-        Self {
-            cname: value.cname,
-            reduced_size: value.reduced_size,
-        }
+        Self { cname: value.cname, reduced_size: value.reduced_size }
     }
 }
 
@@ -76,9 +65,7 @@ impl From<sys_rp::ffi::RtpEncodingParameters> for RtpEncodingParameters {
     fn from(value: sys_rp::ffi::RtpEncodingParameters) -> Self {
         Self {
             active: value.active,
-            max_bitrate: value
-                .has_max_bitrate_bps
-                .then_some(value.max_bitrate_bps as u64),
+            max_bitrate: value.has_max_bitrate_bps.then_some(value.max_bitrate_bps as u64),
             max_framerate: value.has_max_framerate.then_some(value.max_framerate),
             priority: value.network_priority.into(),
             rid: value.rid,
@@ -120,10 +107,7 @@ impl From<sys_rp::ffi::RtpCodecCapability> for RtpCodecCapability {
 
 impl From<sys_rp::ffi::RtpHeaderExtensionCapability> for RtpHeaderExtensionCapability {
     fn from(value: sys_rp::ffi::RtpHeaderExtensionCapability) -> Self {
-        Self {
-            direction: value.direction.into(),
-            uri: value.uri,
-        }
+        Self { direction: value.direction.into(), uri: value.uri }
     }
 }
 
@@ -131,11 +115,7 @@ impl From<sys_rp::ffi::RtpCapabilities> for RtpCapabilities {
     fn from(value: sys_rp::ffi::RtpCapabilities) -> Self {
         Self {
             codecs: value.codecs.into_iter().map(Into::into).collect(),
-            header_extensions: value
-                .header_extensions
-                .into_iter()
-                .map(Into::into)
-                .collect(),
+            header_extensions: value.header_extensions.into_iter().map(Into::into).collect(),
         }
     }
 }
@@ -153,11 +133,7 @@ impl From<Priority> for sys_webrtc::ffi::Priority {
 
 impl From<RtpHeaderExtensionParameters> for sys_rp::ffi::RtpExtension {
     fn from(value: RtpHeaderExtensionParameters) -> Self {
-        Self {
-            uri: value.uri,
-            id: value.id,
-            encrypt: value.encrypted,
-        }
+        Self { uri: value.uri, id: value.id, encrypt: value.encrypted }
     }
 }
 
@@ -165,11 +141,7 @@ impl From<RtpParameters> for sys_rp::ffi::RtpParameters {
     fn from(value: RtpParameters) -> Self {
         Self {
             codecs: value.codecs.into_iter().map(Into::into).collect(),
-            header_extensions: value
-                .header_extensions
-                .into_iter()
-                .map(Into::into)
-                .collect(),
+            header_extensions: value.header_extensions.into_iter().map(Into::into).collect(),
             encodings: Vec::new(),
             rtcp: value.rtcp.into(),
             transaction_id: "".to_string(),

--- a/libwebrtc/src/native/rtp_receiver.rs
+++ b/libwebrtc/src/native/rtp_receiver.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::imp::media_stream_track::new_media_stream_track;
-use crate::media_stream_track::MediaStreamTrack;
-use crate::rtp_parameters::RtpParameters;
-use crate::stats::RtcStats;
-use crate::{RtcError, RtcErrorType};
 use cxx::SharedPtr;
 use tokio::sync::oneshot;
 use webrtc_sys::rtp_receiver as sys_rr;
+
+use crate::{
+    imp::media_stream_track::new_media_stream_track, media_stream_track::MediaStreamTrack,
+    rtp_parameters::RtpParameters, stats::RtcStats, RtcError, RtcErrorType,
+};
 
 #[derive(Clone)]
 pub struct RtpReceiver {
@@ -41,10 +41,7 @@ impl RtpReceiver {
         let ctx = Box::new(sys_rr::ReceiverContext(Box::new(tx)));
 
         self.sys_handle.get_stats(ctx, |ctx, stats| {
-            let tx = ctx
-                .0
-                .downcast::<oneshot::Sender<Result<Vec<RtcStats>, RtcError>>>()
-                .unwrap();
+            let tx = ctx.0.downcast::<oneshot::Sender<Result<Vec<RtcStats>, RtcError>>>().unwrap();
 
             if stats.is_empty() {
                 let _ = tx.send(Ok(vec![]));

--- a/libwebrtc/src/native/rtp_transceiver.rs
+++ b/libwebrtc/src/native/rtp_transceiver.rs
@@ -12,18 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::imp::rtp_receiver::RtpReceiver;
-use crate::imp::rtp_sender::RtpSender;
-use crate::rtp_parameters::RtpCodecCapability;
-use crate::rtp_receiver;
-use crate::rtp_sender;
-use crate::rtp_transceiver::RtpTransceiverDirection;
-use crate::rtp_transceiver::RtpTransceiverInit;
-use crate::RtcError;
 use cxx::SharedPtr;
-use webrtc_sys::rtc_error as sys_err;
-use webrtc_sys::rtp_transceiver as sys_rt;
-use webrtc_sys::webrtc as sys_webrtc;
+use webrtc_sys::{rtc_error as sys_err, rtp_transceiver as sys_rt, webrtc as sys_webrtc};
+
+use crate::{
+    imp::{rtp_receiver::RtpReceiver, rtp_sender::RtpSender},
+    rtp_parameters::RtpCodecCapability,
+    rtp_receiver, rtp_sender,
+    rtp_transceiver::{RtpTransceiverDirection, RtpTransceiverInit},
+    RtcError,
+};
 
 impl From<sys_webrtc::ffi::RtpTransceiverDirection> for RtpTransceiverDirection {
     fn from(value: sys_webrtc::ffi::RtpTransceiverDirection) -> Self {
@@ -79,19 +77,11 @@ impl RtpTransceiver {
     }
 
     pub fn sender(&self) -> rtp_sender::RtpSender {
-        rtp_sender::RtpSender {
-            handle: RtpSender {
-                sys_handle: self.sys_handle.sender(),
-            },
-        }
+        rtp_sender::RtpSender { handle: RtpSender { sys_handle: self.sys_handle.sender() } }
     }
 
     pub fn receiver(&self) -> rtp_receiver::RtpReceiver {
-        rtp_receiver::RtpReceiver {
-            handle: RtpReceiver {
-                sys_handle: self.sys_handle.receiver(),
-            },
-        }
+        rtp_receiver::RtpReceiver { handle: RtpReceiver { sys_handle: self.sys_handle.receiver() } }
     }
 
     pub fn set_codec_preferences(&self, codecs: Vec<RtpCodecCapability>) -> Result<(), RtcError> {

--- a/libwebrtc/src/native/session_description.rs
+++ b/libwebrtc/src/native/session_description.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::session_description::{self, SdpParseError, SdpType};
 use cxx::UniquePtr;
 use webrtc_sys::jsep as sys_jsep;
+
+use crate::session_description::{self, SdpParseError, SdpType};
 
 impl From<sys_jsep::ffi::SdpType> for SdpType {
     fn from(sdp_type: sys_jsep::ffi::SdpType) -> Self {
@@ -41,10 +42,7 @@ impl From<SdpType> for sys_jsep::ffi::SdpType {
 
 impl From<sys_jsep::ffi::SdpParseError> for SdpParseError {
     fn from(e: sys_jsep::ffi::SdpParseError) -> Self {
-        Self {
-            line: e.line,
-            description: e.description,
-        }
+        Self { line: e.line, description: e.description }
     }
 }
 
@@ -79,8 +77,6 @@ impl ToString for SessionDescription {
 
 impl Clone for SessionDescription {
     fn clone(&self) -> Self {
-        SessionDescription {
-            sys_handle: self.sys_handle.clone(),
-        }
+        SessionDescription { sys_handle: self.sys_handle.clone() }
     }
 }

--- a/libwebrtc/src/native/video_source.rs
+++ b/libwebrtc/src/native/video_source.rs
@@ -12,31 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::video_frame::{I420Buffer, VideoBuffer, VideoFrame};
-use crate::video_source::VideoResolution;
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
 use cxx::SharedPtr;
 use parking_lot::Mutex;
-use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use webrtc_sys::video_frame as vf_sys;
-use webrtc_sys::video_frame::ffi::VideoRotation;
-use webrtc_sys::video_track as vt_sys;
+use webrtc_sys::{video_frame as vf_sys, video_frame::ffi::VideoRotation, video_track as vt_sys};
+
+use crate::{
+    video_frame::{I420Buffer, VideoBuffer, VideoFrame},
+    video_source::VideoResolution,
+};
 
 impl From<vt_sys::ffi::VideoResolution> for VideoResolution {
     fn from(res: vt_sys::ffi::VideoResolution) -> Self {
-        Self {
-            width: res.width,
-            height: res.height,
-        }
+        Self { width: res.width, height: res.height }
     }
 }
 
 impl From<VideoResolution> for vt_sys::ffi::VideoResolution {
     fn from(res: VideoResolution) -> Self {
-        Self {
-            width: res.width,
-            height: res.height,
-        }
+        Self { width: res.width, height: res.height }
     }
 }
 
@@ -74,19 +72,13 @@ impl NativeVideoSource {
                     }
 
                     let mut builder = vf_sys::ffi::new_video_frame_builder();
-                    builder
-                        .pin_mut()
-                        .set_rotation(VideoRotation::VideoRotation0);
-                    builder
-                        .pin_mut()
-                        .set_video_frame_buffer(i420.as_ref().sys_handle());
+                    builder.pin_mut().set_rotation(VideoRotation::VideoRotation0);
+                    builder.pin_mut().set_video_frame_buffer(i420.as_ref().sys_handle());
 
                     let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
                     builder.pin_mut().set_timestamp_us(now.as_micros() as i64);
 
-                    source
-                        .sys_handle
-                        .on_captured_frame(&builder.pin_mut().build());
+                    source.sys_handle.on_captured_frame(&builder.pin_mut().build());
                 }
             }
         });
@@ -104,9 +96,7 @@ impl NativeVideoSource {
 
         let mut builder = vf_sys::ffi::new_video_frame_builder();
         builder.pin_mut().set_rotation(frame.rotation.into());
-        builder
-            .pin_mut()
-            .set_video_frame_buffer(frame.buffer.as_ref().sys_handle());
+        builder.pin_mut().set_video_frame_buffer(frame.buffer.as_ref().sys_handle());
 
         if frame.timestamp_us == 0 {
             // If the timestamp is set to 0, default to now
@@ -116,8 +106,7 @@ impl NativeVideoSource {
             builder.pin_mut().set_timestamp_us(frame.timestamp_us);
         }
 
-        self.sys_handle
-            .on_captured_frame(&builder.pin_mut().build());
+        self.sys_handle.on_captured_frame(&builder.pin_mut().build());
     }
 
     pub fn video_resolution(&self) -> VideoResolution {

--- a/libwebrtc/src/native/video_stream.rs
+++ b/libwebrtc/src/native/video_stream.rs
@@ -12,16 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::video_frame::new_video_frame_buffer;
-use crate::video_frame::{BoxVideoFrame, VideoFrame};
-use crate::video_track::RtcVideoTrack;
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
 use cxx::{SharedPtr, UniquePtr};
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
 use tokio::sync::mpsc;
 use tokio_stream::Stream;
 use webrtc_sys::video_track as sys_vt;
+
+use super::video_frame::new_video_frame_buffer;
+use crate::{
+    video_frame::{BoxVideoFrame, VideoFrame},
+    video_track::RtcVideoTrack,
+};
 
 pub struct NativeVideoStream {
     native_sink: SharedPtr<sys_vt::ffi::NativeVideoSink>,
@@ -40,11 +46,7 @@ impl NativeVideoStream {
         let video = unsafe { sys_vt::ffi::media_to_video(video_track.sys_handle()) };
         video.add_sink(&native_sink);
 
-        Self {
-            native_sink,
-            video_track,
-            frame_rx,
-        }
+        Self { native_sink, video_track, frame_rx }
     }
 
     pub fn track(&self) -> RtcVideoTrack {

--- a/libwebrtc/src/native/video_track.rs
+++ b/libwebrtc/src/native/video_track.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::media_stream_track::impl_media_stream_track;
-use crate::media_stream_track::RtcTrackState;
 use cxx::SharedPtr;
 use sys_vt::ffi::video_to_media;
 use webrtc_sys::video_track as sys_vt;
+
+use super::media_stream_track::impl_media_stream_track;
+use crate::media_stream_track::RtcTrackState;
 
 #[derive(Clone)]
 pub struct RtcVideoTrack {

--- a/libwebrtc/src/peer_connection.rs
+++ b/libwebrtc/src/peer_connection.rs
@@ -12,19 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::data_channel::{DataChannel, DataChannelInit};
-use crate::ice_candidate::IceCandidate;
-use crate::imp::peer_connection as imp_pc;
-use crate::media_stream::MediaStream;
-use crate::media_stream_track::MediaStreamTrack;
-use crate::peer_connection_factory::RtcConfiguration;
-use crate::rtp_receiver::RtpReceiver;
-use crate::rtp_sender::RtpSender;
-use crate::rtp_transceiver::{RtpTransceiver, RtpTransceiverInit};
-use crate::session_description::SessionDescription;
-use crate::stats::RtcStats;
-use crate::{MediaType, RtcError};
 use std::fmt::Debug;
+
+use crate::{
+    data_channel::{DataChannel, DataChannelInit},
+    ice_candidate::IceCandidate,
+    imp::peer_connection as imp_pc,
+    media_stream::MediaStream,
+    media_stream_track::MediaStreamTrack,
+    peer_connection_factory::RtcConfiguration,
+    rtp_receiver::RtpReceiver,
+    rtp_sender::RtpSender,
+    rtp_transceiver::{RtpTransceiver, RtpTransceiverInit},
+    session_description::SessionDescription,
+    stats::RtcStats,
+    MediaType, RtcError,
+};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum PeerConnectionState {
@@ -270,10 +273,10 @@ impl Debug for PeerConnection {
 
 #[cfg(test)]
 mod tests {
-    use crate::peer_connection::*;
-    use crate::peer_connection_factory::*;
     use log::trace;
     use tokio::sync::mpsc;
+
+    use crate::{peer_connection::*, peer_connection_factory::*};
 
     #[tokio::test]
     async fn create_pc() {
@@ -309,9 +312,7 @@ mod tests {
             alice_dc_tx.send(dc).unwrap();
         })));
 
-        let bob_dc = bob
-            .create_data_channel("test_dc", DataChannelInit::default())
-            .unwrap();
+        let bob_dc = bob.create_data_channel("test_dc", DataChannelInit::default()).unwrap();
 
         let offer = bob.create_offer(OfferOptions::default()).await.unwrap();
         trace!("Bob offer: {:?}", offer);
@@ -332,9 +333,7 @@ mod tests {
         let (data_tx, mut data_rx) = mpsc::unbounded_channel::<String>();
         let alice_dc = alice_dc_rx.recv().await.unwrap();
         alice_dc.on_message(Some(Box::new(move |buffer| {
-            data_tx
-                .send(String::from_utf8_lossy(buffer.data).to_string())
-                .unwrap();
+            data_tx.send(String::from_utf8_lossy(buffer.data).to_string()).unwrap();
         })));
 
         bob_dc.send(b"This is a test", true).unwrap();

--- a/libwebrtc/src/peer_connection_factory.rs
+++ b/libwebrtc/src/peer_connection_factory.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::imp::peer_connection_factory as imp_pcf;
-use crate::peer_connection::PeerConnection;
-use crate::rtp_parameters::RtpCapabilities;
-use crate::MediaType;
-use crate::RtcError;
 use std::fmt::Debug;
+
+use crate::{
+    imp::peer_connection_factory as imp_pcf, peer_connection::PeerConnection,
+    rtp_parameters::RtpCapabilities, MediaType, RtcError,
+};
 
 #[derive(Debug, Clone)]
 pub struct IceServer {
@@ -86,10 +86,10 @@ impl PeerConnectionFactory {
 
 pub mod native {
     use super::PeerConnectionFactory;
-    use crate::audio_source::native::NativeAudioSource;
-    use crate::audio_track::RtcAudioTrack;
-    use crate::video_source::native::NativeVideoSource;
-    use crate::video_track::RtcVideoTrack;
+    use crate::{
+        audio_source::native::NativeAudioSource, audio_track::RtcAudioTrack,
+        video_source::native::NativeVideoSource, video_track::RtcVideoTrack,
+    };
 
     pub trait PeerConnectionFactoryExt {
         fn create_video_track(&self, label: &str, source: NativeVideoSource) -> RtcVideoTrack;

--- a/libwebrtc/src/prelude.rs
+++ b/libwebrtc/src/prelude.rs
@@ -12,31 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use crate::audio_frame::AudioFrame;
-pub use crate::audio_source::{AudioSourceOptions, RtcAudioSource};
-pub use crate::audio_track::RtcAudioTrack;
-pub use crate::data_channel::{
-    DataBuffer, DataChannel, DataChannelError, DataChannelInit, DataChannelState,
+pub use crate::{
+    audio_frame::AudioFrame,
+    audio_source::{AudioSourceOptions, RtcAudioSource},
+    audio_track::RtcAudioTrack,
+    data_channel::{DataBuffer, DataChannel, DataChannelError, DataChannelInit, DataChannelState},
+    ice_candidate::IceCandidate,
+    media_stream::MediaStream,
+    media_stream_track::{MediaStreamTrack, RtcTrackState},
+    peer_connection::{
+        AnswerOptions, IceConnectionState, IceGatheringState, OfferOptions, PeerConnection,
+        PeerConnectionState, SignalingState,
+    },
+    peer_connection_factory::{
+        ContinualGatheringPolicy, IceServer, IceTransportsType, PeerConnectionFactory,
+        RtcConfiguration,
+    },
+    rtp_parameters::*,
+    rtp_receiver::RtpReceiver,
+    rtp_sender::RtpSender,
+    rtp_transceiver::{RtpTransceiver, RtpTransceiverDirection, RtpTransceiverInit},
+    session_description::{SdpType, SessionDescription},
+    video_frame::{
+        BoxVideoBuffer, BoxVideoFrame, I010Buffer, I420ABuffer, I420Buffer, I422Buffer, I444Buffer,
+        NV12Buffer, VideoBuffer, VideoBufferType, VideoFormatType, VideoFrame, VideoRotation,
+    },
+    video_source::{RtcVideoSource, VideoResolution},
+    video_track::RtcVideoTrack,
+    MediaType, RtcError, RtcErrorType,
 };
-pub use crate::ice_candidate::IceCandidate;
-pub use crate::media_stream::MediaStream;
-pub use crate::media_stream_track::{MediaStreamTrack, RtcTrackState};
-pub use crate::peer_connection::{
-    AnswerOptions, IceConnectionState, IceGatheringState, OfferOptions, PeerConnection,
-    PeerConnectionState, SignalingState,
-};
-pub use crate::peer_connection_factory::{
-    ContinualGatheringPolicy, IceServer, IceTransportsType, PeerConnectionFactory, RtcConfiguration,
-};
-pub use crate::rtp_parameters::*;
-pub use crate::rtp_receiver::RtpReceiver;
-pub use crate::rtp_sender::RtpSender;
-pub use crate::rtp_transceiver::{RtpTransceiver, RtpTransceiverDirection, RtpTransceiverInit};
-pub use crate::session_description::{SdpType, SessionDescription};
-pub use crate::video_frame::{
-    BoxVideoBuffer, BoxVideoFrame, I010Buffer, I420ABuffer, I420Buffer, I422Buffer, I444Buffer,
-    NV12Buffer, VideoBuffer, VideoBufferType, VideoFormatType, VideoFrame, VideoRotation,
-};
-pub use crate::video_source::{RtcVideoSource, VideoResolution};
-pub use crate::video_track::RtcVideoTrack;
-pub use crate::{MediaType, RtcError, RtcErrorType};

--- a/libwebrtc/src/rtp_sender.rs
+++ b/libwebrtc/src/rtp_sender.rs
@@ -48,8 +48,6 @@ impl RtpSender {
 
 impl Debug for RtpSender {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RtpReceiver")
-            .field("cname", &self.parameters().rtcp.cname)
-            .finish()
+        f.debug_struct("RtpReceiver").field("cname", &self.parameters().rtcp.cname).finish()
     }
 }

--- a/libwebrtc/src/rtp_transceiver.rs
+++ b/libwebrtc/src/rtp_transceiver.rs
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::imp::rtp_transceiver as imp_rt;
-use crate::rtp_parameters::{RtpCodecCapability, RtpEncodingParameters};
-use crate::rtp_receiver::RtpReceiver;
-use crate::rtp_sender::RtpSender;
-use crate::RtcError;
 use std::fmt::Debug;
+
+use crate::{
+    imp::rtp_transceiver as imp_rt,
+    rtp_parameters::{RtpCodecCapability, RtpEncodingParameters},
+    rtp_receiver::RtpReceiver,
+    rtp_sender::RtpSender,
+    RtcError,
+};
 
 #[derive(Debug, Clone)]
 pub struct RtpTransceiverInit {

--- a/libwebrtc/src/session_description.rs
+++ b/libwebrtc/src/session_description.rs
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::imp::session_description as sd_imp;
 use std::{
     fmt::{Debug, Display},
     str::FromStr,
 };
+
 use thiserror::Error;
+
+use crate::imp::session_description as sd_imp;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum SdpType {
@@ -83,8 +85,6 @@ impl ToString for SessionDescription {
 
 impl Debug for SessionDescription {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SessionDescription")
-            .field("sdp_type", &self.sdp_type())
-            .finish()
+        f.debug_struct("SessionDescription").field("sdp_type", &self.sdp_type()).finish()
     }
 }

--- a/libwebrtc/src/stats.rs
+++ b/libwebrtc/src/stats.rs
@@ -1,12 +1,14 @@
-use crate::data_channel::DataChannelState;
-use serde::Deserialize;
 use std::collections::HashMap;
+
+use serde::Deserialize;
+
+use crate::data_channel::DataChannelState;
 
 /// Values from https://www.w3.org/TR/webrtc-stats/ (NOTE: Some of the structs are not in the SPEC
 /// but inside libwebrtc)
 /// serde will handle the magic of correctly deserializing the json into our structs.
-/// The enums values are inside encapsulated inside option because we're not sure about their default values (So we
-/// default to None instead of an arbitrary value)
+/// The enums values are inside encapsulated inside option because we're not sure about their
+/// default values (So we default to None instead of an arbitrary value)
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type")]

--- a/libwebrtc/src/video_frame.rs
+++ b/libwebrtc/src/video_frame.rs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::imp::video_frame as vf_imp;
 use std::fmt::Debug;
+
 use thiserror::Error;
+
+use crate::imp::video_frame as vf_imp;
 
 #[derive(Debug, Error)]
 pub enum SinkError {
@@ -134,9 +136,7 @@ macro_rules! new_buffer_type {
 
             #[cfg(not(target_arch = "wasm32"))]
             fn to_i420(&self) -> I420Buffer {
-                I420Buffer {
-                    handle: self.handle.to_i420(),
-                }
+                I420Buffer { handle: self.handle.to_i420() }
             }
 
             #[cfg(not(target_arch = "wasm32"))]
@@ -218,11 +218,7 @@ impl I420Buffer {
     }
 
     pub fn strides(&self) -> (u32, u32, u32) {
-        (
-            self.handle.stride_y(),
-            self.handle.stride_u(),
-            self.handle.stride_v(),
-        )
+        (self.handle.stride_y(), self.handle.stride_u(), self.handle.stride_v())
     }
 
     pub fn data(&self) -> (&[u8], &[u8], &[u8]) {
@@ -304,11 +300,7 @@ impl I422Buffer {
     }
 
     pub fn strides(&self) -> (u32, u32, u32) {
-        (
-            self.handle.stride_y(),
-            self.handle.stride_u(),
-            self.handle.stride_v(),
-        )
+        (self.handle.stride_y(), self.handle.stride_u(), self.handle.stride_v())
     }
 
     pub fn data(&self) -> (&[u8], &[u8], &[u8]) {
@@ -351,11 +343,7 @@ impl I444Buffer {
     }
 
     pub fn strides(&self) -> (u32, u32, u32) {
-        (
-            self.handle.stride_y(),
-            self.handle.stride_u(),
-            self.handle.stride_v(),
-        )
+        (self.handle.stride_y(), self.handle.stride_u(), self.handle.stride_v())
     }
 
     pub fn data(&self) -> (&[u8], &[u8], &[u8]) {
@@ -398,11 +386,7 @@ impl I010Buffer {
     }
 
     pub fn strides(&self) -> (u32, u32, u32) {
-        (
-            self.handle.stride_y(),
-            self.handle.stride_u(),
-            self.handle.stride_v(),
-        )
+        (self.handle.stride_y(), self.handle.stride_u(), self.handle.stride_v())
     }
 
     pub fn data(&self) -> (&[u16], &[u16], &[u16]) {
@@ -459,8 +443,9 @@ impl NV12Buffer {
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod native {
-    use super::{vf_imp, I420Buffer, VideoBuffer, VideoBufferType, VideoFormatType};
     use std::fmt::Debug;
+
+    use super::{vf_imp, I420Buffer, VideoBuffer, VideoBufferType, VideoFormatType};
 
     new_buffer_type!(NativeBuffer, Native, as_native);
 

--- a/libwebrtc/src/video_source.rs
+++ b/libwebrtc/src/video_source.rs
@@ -40,9 +40,10 @@ impl RtcVideoSource {
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod native {
+    use std::fmt::{Debug, Formatter};
+
     use super::*;
     use crate::video_frame::{VideoBuffer, VideoFrame};
-    use std::fmt::{Debug, Formatter};
 
     #[derive(Clone)]
     pub struct NativeVideoSource {
@@ -63,9 +64,7 @@ pub mod native {
 
     impl NativeVideoSource {
         pub fn new(resolution: VideoResolution) -> Self {
-            Self {
-                handle: vs_imp::NativeVideoSource::new(resolution),
-            }
+            Self { handle: vs_imp::NativeVideoSource::new(resolution) }
         }
 
         pub fn capture_frame<T: AsRef<dyn VideoBuffer>>(&self, frame: &VideoFrame<T>) {

--- a/libwebrtc/src/video_stream.rs
+++ b/libwebrtc/src/video_stream.rs
@@ -19,13 +19,16 @@ use crate::imp::video_stream as stream_imp;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod native {
-    use super::stream_imp;
-    use crate::video_frame::BoxVideoFrame;
-    use crate::video_track::RtcVideoTrack;
-    use std::fmt::Debug;
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
+    use std::{
+        fmt::Debug,
+        pin::Pin,
+        task::{Context, Poll},
+    };
+
     use tokio_stream::Stream;
+
+    use super::stream_imp;
+    use crate::{video_frame::BoxVideoFrame, video_track::RtcVideoTrack};
 
     pub struct NativeVideoStream {
         pub(crate) handle: stream_imp::NativeVideoStream,
@@ -33,17 +36,13 @@ pub mod native {
 
     impl Debug for NativeVideoStream {
         fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-            f.debug_struct("NativeVideoStream")
-                .field("track", &self.track())
-                .finish()
+            f.debug_struct("NativeVideoStream").field("track", &self.track()).finish()
         }
     }
 
     impl NativeVideoStream {
         pub fn new(video_track: RtcVideoTrack) -> Self {
-            Self {
-                handle: stream_imp::NativeVideoStream::new(video_track),
-            }
+            Self { handle: stream_imp::NativeVideoStream::new(video_track) }
         }
 
         pub fn track(&self) -> RtcVideoTrack {

--- a/libwebrtc/src/video_track.rs
+++ b/libwebrtc/src/video_track.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::imp::video_track as imp_vt;
-use crate::media_stream_track::media_stream_track;
-use crate::media_stream_track::RtcTrackState;
 use std::fmt::Debug;
+
+use crate::{
+    imp::video_track as imp_vt,
+    media_stream_track::{media_stream_track, RtcTrackState},
+};
 
 #[derive(Clone)]
 pub struct RtcVideoTrack {

--- a/livekit-api/src/access_token.rs
+++ b/livekit-api/src/access_token.rs
@@ -12,15 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::get_env_keys;
+use std::{
+    env,
+    fmt::Debug,
+    ops::Add,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
 use jsonwebtoken::{self, DecodingKey, EncodingKey, Header};
 use serde::{Deserialize, Serialize};
-use std::env;
-use std::fmt::Debug;
-use std::ops::Add;
-use std::time::Duration;
-use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
+
+use crate::get_env_keys;
 
 pub const DEFAULT_TTL: Duration = Duration::from_secs(3600 * 6); // 6 hours
 
@@ -208,18 +211,13 @@ pub struct TokenVerifier {
 
 impl Debug for TokenVerifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("TokenVerifier")
-            .field("api_key", &self.api_key)
-            .finish()
+        f.debug_struct("TokenVerifier").field("api_key", &self.api_key).finish()
     }
 }
 
 impl TokenVerifier {
     pub fn with_api_key(api_key: &str, api_secret: &str) -> Self {
-        Self {
-            api_key: api_key.to_owned(),
-            api_secret: api_secret.to_owned(),
-        }
+        Self { api_key: api_key.to_owned(), api_secret: api_secret.to_owned() }
     }
 
     pub fn new() -> Result<Self, AccessTokenError> {
@@ -245,8 +243,9 @@ impl TokenVerifier {
 
 #[cfg(test)]
 mod tests {
-    use super::{AccessToken, TokenVerifier, VideoGrants};
     use std::time::Duration;
+
+    use super::{AccessToken, TokenVerifier, VideoGrants};
 
     const TEST_API_KEY: &str = "myapikey";
     const TEST_API_SECRET: &str = "thiskeyistotallyunsafe";

--- a/livekit-api/src/services/egress.rs
+++ b/livekit-api/src/services/egress.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{ServiceBase, ServiceResult, LIVEKIT_PACKAGE};
-use crate::services::twirp_client::TwirpClient;
-use crate::{access_token::VideoGrants, get_env_keys};
 use livekit_protocol as proto;
+
+use super::{ServiceBase, ServiceResult, LIVEKIT_PACKAGE};
+use crate::{access_token::VideoGrants, get_env_keys, services::twirp_client::TwirpClient};
 
 #[derive(Default, Clone, Debug)]
 pub struct RoomCompositeOptions {
@@ -115,10 +115,7 @@ impl EgressClient {
                     image_outputs,
                     output: None, // Deprecated
                 },
-                self.base.auth_header(VideoGrants {
-                    room_record: true,
-                    ..Default::default()
-                })?,
+                self.base.auth_header(VideoGrants { room_record: true, ..Default::default() })?,
             )
             .await
             .map_err(Into::into)
@@ -149,10 +146,7 @@ impl EgressClient {
                     output: None, // Deprecated
                     await_start_signal: options.await_start_signal,
                 },
-                self.base.auth_header(VideoGrants {
-                    room_record: true,
-                    ..Default::default()
-                })?,
+                self.base.auth_header(VideoGrants { room_record: true, ..Default::default() })?,
             )
             .await
             .map_err(Into::into)
@@ -182,10 +176,7 @@ impl EgressClient {
                     image_outputs,
                     output: None, // Deprecated
                 },
-                self.base.auth_header(VideoGrants {
-                    room_record: true,
-                    ..Default::default()
-                })?,
+                self.base.auth_header(VideoGrants { room_record: true, ..Default::default() })?,
             )
             .await
             .map_err(Into::into)
@@ -213,10 +204,7 @@ impl EgressClient {
                     },
                     track_id: track_id.to_string(),
                 },
-                self.base.auth_header(VideoGrants {
-                    room_record: true,
-                    ..Default::default()
-                })?,
+                self.base.auth_header(VideoGrants { room_record: true, ..Default::default() })?,
             )
             .await
             .map_err(Into::into)
@@ -235,10 +223,7 @@ impl EgressClient {
                     egress_id: egress_id.to_owned(),
                     layout: layout.to_owned(),
                 },
-                self.base.auth_header(VideoGrants {
-                    room_record: true,
-                    ..Default::default()
-                })?,
+                self.base.auth_header(VideoGrants { room_record: true, ..Default::default() })?,
             )
             .await
             .map_err(Into::into)
@@ -259,10 +244,7 @@ impl EgressClient {
                     add_output_urls,
                     remove_output_urls,
                 },
-                self.base.auth_header(VideoGrants {
-                    room_record: true,
-                    ..Default::default()
-                })?,
+                self.base.auth_header(VideoGrants { room_record: true, ..Default::default() })?,
             )
             .await
             .map_err(Into::into)
@@ -286,15 +268,8 @@ impl EgressClient {
             .request(
                 SVC,
                 "ListEgress",
-                proto::ListEgressRequest {
-                    room_name,
-                    egress_id,
-                    active: options.active,
-                },
-                self.base.auth_header(VideoGrants {
-                    room_record: true,
-                    ..Default::default()
-                })?,
+                proto::ListEgressRequest { room_name, egress_id, active: options.active },
+                self.base.auth_header(VideoGrants { room_record: true, ..Default::default() })?,
             )
             .await?;
 
@@ -306,13 +281,8 @@ impl EgressClient {
             .request(
                 SVC,
                 "StopEgress",
-                proto::StopEgressRequest {
-                    egress_id: egress_id.to_owned(),
-                },
-                self.base.auth_header(VideoGrants {
-                    room_record: true,
-                    ..Default::default()
-                })?,
+                proto::StopEgressRequest { egress_id: egress_id.to_owned() },
+                self.base.auth_header(VideoGrants { room_record: true, ..Default::default() })?,
             )
             .await
             .map_err(Into::into)
@@ -407,41 +377,19 @@ pub mod encoding {
         }
     }
 
-    pub const H264_720P_30: EncodingOptions = EncodingOptions {
-        width: 1280,
-        height: 720,
-        video_bitrate: 3000,
-        ..EncodingOptions::new()
-    };
-    pub const H264_720P_60: EncodingOptions = EncodingOptions {
-        width: 1280,
-        height: 720,
-        framerate: 60,
-        ..EncodingOptions::new()
-    };
+    pub const H264_720P_30: EncodingOptions =
+        EncodingOptions { width: 1280, height: 720, video_bitrate: 3000, ..EncodingOptions::new() };
+    pub const H264_720P_60: EncodingOptions =
+        EncodingOptions { width: 1280, height: 720, framerate: 60, ..EncodingOptions::new() };
     pub const H264_1080P_30: EncodingOptions = EncodingOptions::new();
-    pub const H264_1080P_60: EncodingOptions = EncodingOptions {
-        framerate: 60,
-        video_bitrate: 6000,
-        ..EncodingOptions::new()
-    };
-    pub const PORTRAIT_H264_720P_30: EncodingOptions = EncodingOptions {
-        width: 720,
-        height: 1280,
-        video_bitrate: 3000,
-        ..EncodingOptions::new()
-    };
-    pub const PORTRAIT_H264_720P_60: EncodingOptions = EncodingOptions {
-        width: 720,
-        height: 1280,
-        framerate: 60,
-        ..EncodingOptions::new()
-    };
-    pub const PORTRAIT_H264_1080P_30: EncodingOptions = EncodingOptions {
-        width: 1080,
-        height: 1920,
-        ..EncodingOptions::new()
-    };
+    pub const H264_1080P_60: EncodingOptions =
+        EncodingOptions { framerate: 60, video_bitrate: 6000, ..EncodingOptions::new() };
+    pub const PORTRAIT_H264_720P_30: EncodingOptions =
+        EncodingOptions { width: 720, height: 1280, video_bitrate: 3000, ..EncodingOptions::new() };
+    pub const PORTRAIT_H264_720P_60: EncodingOptions =
+        EncodingOptions { width: 720, height: 1280, framerate: 60, ..EncodingOptions::new() };
+    pub const PORTRAIT_H264_1080P_30: EncodingOptions =
+        EncodingOptions { width: 1080, height: 1920, ..EncodingOptions::new() };
     pub const PORTRAIT_H264_1080P_60: EncodingOptions = EncodingOptions {
         width: 1080,
         height: 1920,

--- a/livekit-api/src/services/ingress.rs
+++ b/livekit-api/src/services/ingress.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{ServiceBase, ServiceResult, LIVEKIT_PACKAGE};
-use crate::services::twirp_client::TwirpClient;
-use crate::{access_token::VideoGrants, get_env_keys};
 use livekit_protocol as proto;
+
+use super::{ServiceBase, ServiceResult, LIVEKIT_PACKAGE};
+use crate::{access_token::VideoGrants, get_env_keys, services::twirp_client::TwirpClient};
 
 #[derive(Default, Clone, Debug)]
 pub struct IngressOptions {
@@ -75,10 +75,7 @@ impl IngressClient {
                     bypass_transcoding: false, // TODO Expose
                     ..Default::default()
                 },
-                self.base.auth_header(VideoGrants {
-                    ingress_admin: true,
-                    ..Default::default()
-                })?,
+                self.base.auth_header(VideoGrants { ingress_admin: true, ..Default::default() })?,
             )
             .await
             .map_err(Into::into)
@@ -103,10 +100,7 @@ impl IngressClient {
                     video: Some(options.video),
                     bypass_transcoding: None, // TODO Expose
                 },
-                self.base.auth_header(VideoGrants {
-                    ingress_admin: true,
-                    ..Default::default()
-                })?,
+                self.base.auth_header(VideoGrants { ingress_admin: true, ..Default::default() })?,
             )
             .await
             .map_err(Into::into)
@@ -131,10 +125,7 @@ impl IngressClient {
                         _ => Default::default(),
                     },
                 },
-                self.base.auth_header(VideoGrants {
-                    ingress_admin: true,
-                    ..Default::default()
-                })?,
+                self.base.auth_header(VideoGrants { ingress_admin: true, ..Default::default() })?,
             )
             .await?;
 
@@ -146,13 +137,8 @@ impl IngressClient {
             .request(
                 SVC,
                 "DeleteIngress",
-                proto::DeleteIngressRequest {
-                    ingress_id: ingress_id.to_owned(),
-                },
-                self.base.auth_header(VideoGrants {
-                    ingress_admin: true,
-                    ..Default::default()
-                })?,
+                proto::DeleteIngressRequest { ingress_id: ingress_id.to_owned() },
+                self.base.auth_header(VideoGrants { ingress_admin: true, ..Default::default() })?,
             )
             .await
             .map_err(Into::into)

--- a/livekit-api/src/services/mod.rs
+++ b/livekit-api/src/services/mod.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::access_token::{AccessToken, AccessTokenError, VideoGrants};
-use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use std::fmt::Debug;
+
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use thiserror::Error;
+
+use crate::access_token::{AccessToken, AccessTokenError, VideoGrants};
 
 pub mod egress;
 pub mod ingress;
@@ -44,18 +46,13 @@ struct ServiceBase {
 
 impl Debug for ServiceBase {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ServiceBase")
-            .field("api_key", &self.api_key)
-            .finish()
+        f.debug_struct("ServiceBase").field("api_key", &self.api_key).finish()
     }
 }
 
 impl ServiceBase {
     pub fn with_api_key(api_key: &str, api_secret: &str) -> Self {
-        Self {
-            api_key: api_key.to_owned(),
-            api_secret: api_secret.to_owned(),
-        }
+        Self { api_key: api_key.to_owned(), api_secret: api_secret.to_owned() }
     }
 
     pub fn auth_header(&self, grants: VideoGrants) -> Result<HeaderMap, AccessTokenError> {
@@ -64,10 +61,7 @@ impl ServiceBase {
             .to_jwt()?;
 
         let mut headers = HeaderMap::new();
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", token)).unwrap(),
-        );
+        headers.insert(AUTHORIZATION, HeaderValue::from_str(&format!("Bearer {}", token)).unwrap());
         Ok(headers)
     }
 }

--- a/livekit-api/src/services/room.rs
+++ b/livekit-api/src/services/room.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{ServiceBase, ServiceResult, LIVEKIT_PACKAGE};
-use crate::services::twirp_client::TwirpClient;
-use crate::{access_token::VideoGrants, get_env_keys};
 use livekit_protocol as proto;
+
+use super::{ServiceBase, ServiceResult, LIVEKIT_PACKAGE};
+use crate::{access_token::VideoGrants, get_env_keys, services::twirp_client::TwirpClient};
 
 const SVC: &str = "RoomService";
 
@@ -81,10 +81,7 @@ impl RoomClient {
                     egress: options.egress,
                     ..Default::default()
                 },
-                self.base.auth_header(VideoGrants {
-                    room_create: true,
-                    ..Default::default()
-                })?,
+                self.base.auth_header(VideoGrants { room_create: true, ..Default::default() })?,
             )
             .await
             .map_err(Into::into)
@@ -97,10 +94,7 @@ impl RoomClient {
                 SVC,
                 "ListRooms",
                 proto::ListRoomsRequest { names },
-                self.base.auth_header(VideoGrants {
-                    room_list: true,
-                    ..Default::default()
-                })?,
+                self.base.auth_header(VideoGrants { room_list: true, ..Default::default() })?,
             )
             .await?;
 
@@ -112,13 +106,8 @@ impl RoomClient {
             .request(
                 SVC,
                 "DeleteRoom",
-                proto::DeleteRoomRequest {
-                    room: room.to_owned(),
-                },
-                self.base.auth_header(VideoGrants {
-                    room_create: true,
-                    ..Default::default()
-                })?,
+                proto::DeleteRoomRequest { room: room.to_owned() },
+                self.base.auth_header(VideoGrants { room_create: true, ..Default::default() })?,
             )
             .await
             .map_err(Into::into)
@@ -156,9 +145,7 @@ impl RoomClient {
             .request(
                 SVC,
                 "ListParticipants",
-                proto::ListParticipantsRequest {
-                    room: room.to_owned(),
-                },
+                proto::ListParticipantsRequest { room: room.to_owned() },
                 self.base.auth_header(VideoGrants {
                     room_admin: true,
                     room: room.to_owned(),

--- a/livekit-api/src/services/twirp_client.rs
+++ b/livekit-api/src/services/twirp_client.rs
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::Display;
+
 use reqwest::{
     header::{HeaderMap, HeaderValue, CONTENT_TYPE},
     StatusCode,
 };
 use serde::Deserialize;
-use std::fmt::Display;
 use thiserror::Error;
 
 pub const DEFAULT_PREFIX: &str = "/twirp";
@@ -95,23 +96,11 @@ impl TwirpClient {
         mut headers: HeaderMap,
     ) -> TwirpResult<R> {
         let mut url = url::Url::parse(&self.host)?;
-        url.set_path(&format!(
-            "{}/{}.{}/{}",
-            self.prefix, self.pkg, service, method
-        ));
+        url.set_path(&format!("{}/{}.{}/{}", self.prefix, self.pkg, service, method));
 
-        headers.insert(
-            CONTENT_TYPE,
-            HeaderValue::from_static("application/protobuf"),
-        );
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/protobuf"));
 
-        let resp = self
-            .client
-            .post(url)
-            .headers(headers)
-            .body(data.encode_to_vec())
-            .send()
-            .await?;
+        let resp = self.client.post(url).headers(headers).body(data.encode_to_vec()).send().await?;
 
         if resp.status() == StatusCode::OK {
             Ok(R::decode(resp.bytes().await?)?)

--- a/livekit-api/src/signal_client/mod.rs
+++ b/livekit-api/src/signal_client/mod.rs
@@ -12,22 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::signal_client::signal_stream::SignalStream;
+use std::{
+    borrow::Cow,
+    fmt::Debug,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
 use livekit_protocol as proto;
 use parking_lot::Mutex;
 use reqwest::StatusCode;
-use std::borrow::Cow;
-use std::fmt::Debug;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use thiserror::Error;
-use tokio::sync::mpsc;
-use tokio::sync::Mutex as AsyncMutex;
-use tokio::sync::RwLock as AsyncRwLock;
-use tokio::task::JoinHandle;
-use tokio::time::{interval, sleep, Instant};
+use tokio::{
+    sync::{mpsc, Mutex as AsyncMutex, RwLock as AsyncRwLock},
+    task::JoinHandle,
+    time::{interval, sleep, Instant},
+};
 use tokio_tungstenite::tungstenite::Error as WsError;
+
+use crate::signal_client::signal_stream::SignalStream;
 
 mod signal_stream;
 
@@ -64,10 +70,7 @@ pub struct SignalOptions {
 
 impl Default for SignalOptions {
     fn default() -> Self {
-        Self {
-            auto_subscribe: true,
-            adaptive_stream: false,
-        }
+        Self { auto_subscribe: true, adaptive_stream: false }
     }
 }
 
@@ -117,15 +120,7 @@ impl SignalClient {
         let (emitter, events) = mpsc::unbounded_channel();
         let signal_task = tokio::spawn(signal_task(inner.clone(), emitter.clone(), stream_events));
 
-        Ok((
-            Self {
-                inner,
-                emitter,
-                handle: Mutex::new(Some(signal_task)),
-            },
-            join_response,
-            events,
-        ))
+        Ok((Self { inner, emitter, handle: Mutex::new(Some(signal_task)) }, join_response, events))
     }
 
     /// Restart the connection to the server
@@ -134,11 +129,8 @@ impl SignalClient {
         self.close().await;
 
         let (reconnect_response, stream_events) = self.inner.restart().await?;
-        let signal_task = tokio::spawn(signal_task(
-            self.inner.clone(),
-            self.emitter.clone(),
-            stream_events,
-        ));
+        let signal_task =
+            tokio::spawn(signal_task(self.inner.clone(), self.emitter.clone(), stream_events));
 
         *self.handle.lock() = Some(signal_task);
         Ok(reconnect_response)
@@ -222,13 +214,7 @@ impl SignalInner {
 
     /// Validate the connection by calling rtc/validate
     async fn validate(mut ws_url: url::Url) -> SignalResult<()> {
-        ws_url
-            .set_scheme(if ws_url.scheme() == "wss" {
-                "https"
-            } else {
-                "http"
-            })
-            .unwrap();
+        ws_url.set_scheme(if ws_url.scheme() == "wss" { "https" } else { "http" }).unwrap();
 
         if let Ok(mut segs) = ws_url.path_segments_mut() {
             segs.extend(&["rtc", "validate"]);
@@ -267,10 +253,7 @@ impl SignalInner {
         let token = self.token.lock().clone();
 
         let mut lk_url = get_livekit_url(&self.url, &token, &self.options).unwrap();
-        lk_url
-            .query_pairs_mut()
-            .append_pair("reconnect", "1")
-            .append_pair("sid", sid);
+        lk_url.query_pairs_mut().append_pair("reconnect", "1").append_pair("sid", sid);
 
         let (new_stream, mut events) = SignalStream::connect(lk_url).await?;
         let reconnect_response = get_reconnect_response(&mut events).await?;
@@ -334,9 +317,7 @@ async fn signal_task(
     emitter: SignalEmitter, // Public emitter
     mut internal_events: mpsc::UnboundedReceiver<Box<proto::signal_response::Message>>,
 ) {
-    let mut ping_interval = interval(Duration::from_secs(
-        inner.join_response.ping_interval as u64,
-    ));
+    let mut ping_interval = interval(Duration::from_secs(inner.join_response.ping_interval as u64));
     let timeout_duration = Duration::from_secs(inner.join_response.ping_timeout as u64);
     let ping_timeout = sleep(timeout_duration);
     tokio::pin!(ping_timeout);
@@ -422,14 +403,8 @@ fn get_livekit_url(url: &str, token: &str, options: &SignalOptions) -> SignalRes
         .append_pair("sdk", "rust")
         .append_pair("access_token", token)
         .append_pair("protocol", PROTOCOL_VERSION.to_string().as_str())
-        .append_pair(
-            "auto_subscribe",
-            if options.auto_subscribe { "1" } else { "0" },
-        )
-        .append_pair(
-            "adaptive_stream",
-            if options.adaptive_stream { "1" } else { "0" },
-        );
+        .append_pair("auto_subscribe", if options.auto_subscribe { "1" } else { "0" })
+        .append_pair("adaptive_stream", if options.adaptive_stream { "1" } else { "0" });
 
     Ok(lk_url)
 }
@@ -449,14 +424,9 @@ macro_rules! get_async_message {
                 Err(WsError::ConnectionClosed)?
             };
 
-            tokio::time::timeout(JOIN_RESPONSE_TIMEOUT, join)
-                .await
-                .map_err(|_| {
-                    SignalError::Timeout(format!(
-                        "failed to receive {}",
-                        std::any::type_name::<$ty>()
-                    ))
-                })?
+            tokio::time::timeout(JOIN_RESPONSE_TIMEOUT, join).await.map_err(|_| {
+                SignalError::Timeout(format!("failed to receive {}", std::any::type_name::<$ty>()))
+            })?
         }
     };
 }

--- a/livekit-api/src/signal_client/signal_stream.rs
+++ b/livekit-api/src/signal_client/signal_stream.rs
@@ -12,16 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{SignalError, SignalResult};
-use futures_util::stream::{SplitSink, SplitStream};
-use futures_util::{SinkExt, StreamExt};
+use futures_util::{
+    stream::{SplitSink, SplitStream},
+    SinkExt, StreamExt,
+};
 use livekit_protocol as proto;
 use prost::Message as ProtoMessage;
-use tokio::net::TcpStream;
-use tokio::sync::{mpsc, oneshot};
-use tokio::task::JoinHandle;
-use tokio_tungstenite::tungstenite::Message;
-use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+use tokio::{
+    net::TcpStream,
+    sync::{mpsc, oneshot},
+    task::JoinHandle,
+};
+use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
+
+use super::{SignalError, SignalResult};
 
 type WebSocket = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
@@ -55,10 +59,7 @@ impl SignalStream {
     /// closed.
     pub async fn connect(
         mut url: url::Url,
-    ) -> SignalResult<(
-        Self,
-        mpsc::UnboundedReceiver<Box<proto::signal_response::Message>>,
-    )> {
+    ) -> SignalResult<(Self, mpsc::UnboundedReceiver<Box<proto::signal_response::Message>>)> {
         {
             // Don't log sensitive info
             let mut url = url.clone();
@@ -96,14 +97,7 @@ impl SignalStream {
         let write_handle = tokio::spawn(Self::write_task(internal_rx, ws_writer));
         let read_handle = tokio::spawn(Self::read_task(internal_tx.clone(), ws_reader, emitter));
 
-        Ok((
-            Self {
-                internal_tx,
-                read_handle,
-                write_handle,
-            },
-            events,
-        ))
+        Ok((Self { internal_tx, read_handle, write_handle }, events))
     }
 
     /// Close the websocket
@@ -118,10 +112,7 @@ impl SignalStream {
     /// It also waits for the message to be sent
     pub async fn send(&self, signal: proto::signal_request::Message) -> SignalResult<()> {
         let (send, recv) = oneshot::channel();
-        let msg = InternalMessage::Signal {
-            signal,
-            response_chn: send,
-        };
+        let msg = InternalMessage::Signal { signal, response_chn: send };
         let _ = self.internal_tx.send(msg).await;
         recv.await.map_err(|_| SignalError::SendError)?
     }
@@ -134,14 +125,8 @@ impl SignalStream {
     ) {
         while let Some(msg) = internal_rx.recv().await {
             match msg {
-                InternalMessage::Signal {
-                    signal,
-                    response_chn,
-                } => {
-                    let data = proto::SignalRequest {
-                        message: Some(signal),
-                    }
-                    .encode_to_vec();
+                InternalMessage::Signal { signal, response_chn } => {
+                    let data = proto::SignalRequest { message: Some(signal) }.encode_to_vec();
 
                     if let Err(err) = ws_writer.send(Message::Binary(data)).await {
                         let _ = response_chn.send(Err(err.into()));
@@ -181,9 +166,7 @@ impl SignalStream {
                     let _ = emitter.send(Box::new(msg));
                 }
                 Ok(Message::Ping(data)) => {
-                    let _ = internal_tx
-                        .send(InternalMessage::Pong { ping_data: data })
-                        .await;
+                    let _ = internal_tx.send(InternalMessage::Pong { ping_data: data }).await;
                     continue;
                 }
                 Ok(Message::Close(close)) => {

--- a/livekit-api/src/webhooks.rs
+++ b/livekit-api/src/webhooks.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::access_token::{AccessTokenError, TokenVerifier};
 use base64::Engine;
 use livekit_protocol as proto;
 use sha2::{Digest, Sha256};
 use thiserror::Error;
+
+use crate::access_token::{AccessTokenError, TokenVerifier};
 
 #[derive(Debug, Error)]
 pub enum WebhookError {

--- a/livekit-ffi/build.rs
+++ b/livekit-ffi/build.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::env;
-use std::path::Path;
+use std::{env, path::Path};
 
 fn main() {
     if env::var("DOCS_RS").is_ok() {

--- a/livekit-ffi/src/cabi.rs
+++ b/livekit-ffi/src/cabi.rs
@@ -1,11 +1,13 @@
+use std::sync::Arc;
+
+use prost::Message;
+use server::FfiDataBuffer;
+
 use crate::{
     proto,
     server::{self, FfiConfig},
     FfiHandleId, FFI_SERVER,
 };
-use prost::Message;
-use server::FfiDataBuffer;
-use std::sync::Arc;
 
 /// # SAFTEY: The "C" callback must be threadsafe and not block
 pub type FfiCallbackFn = unsafe extern "C" fn(*const u8, usize);
@@ -58,10 +60,7 @@ pub unsafe extern "C" fn livekit_ffi_request(
     }
 
     let handle_id = FFI_SERVER.next_id();
-    let ffi_data = FfiDataBuffer {
-        handle: handle_id,
-        data: Arc::new(res),
-    };
+    let ffi_data = FfiDataBuffer { handle: handle_id, data: Arc::new(res) };
 
     FFI_SERVER.store_handle(handle_id, ffi_data);
     handle_id

--- a/livekit-ffi/src/conversion/audio_frame.rs
+++ b/livekit-ffi/src/conversion/audio_frame.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::proto;
-use crate::server::audio_source::FfiAudioSource;
-use crate::server::audio_stream::FfiAudioStream;
-use livekit::webrtc::audio_source::AudioSourceOptions;
-use livekit::webrtc::prelude::*;
+use livekit::webrtc::{audio_source::AudioSourceOptions, prelude::*};
+
+use crate::{
+    proto,
+    server::{audio_source::FfiAudioSource, audio_stream::FfiAudioStream},
+};
 
 impl From<proto::AudioSourceOptions> for AudioSourceOptions {
     fn from(opts: proto::AudioSourceOptions) -> Self {
@@ -41,16 +42,12 @@ impl From<&AudioFrame<'_>> for proto::AudioFrameBufferInfo {
 
 impl From<&FfiAudioSource> for proto::AudioSourceInfo {
     fn from(source: &FfiAudioSource) -> Self {
-        Self {
-            r#type: source.source_type as i32,
-        }
+        Self { r#type: source.source_type as i32 }
     }
 }
 
 impl From<&FfiAudioStream> for proto::AudioStreamInfo {
     fn from(stream: &FfiAudioStream) -> Self {
-        Self {
-            r#type: stream.stream_type as i32,
-        }
+        Self { r#type: stream.stream_type as i32 }
     }
 }

--- a/livekit-ffi/src/conversion/participant.rs
+++ b/livekit-ffi/src/conversion/participant.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::proto;
-use crate::server::room::FfiParticipant;
+use crate::{proto, server::room::FfiParticipant};
 
 impl From<&FfiParticipant> for proto::ParticipantInfo {
     fn from(value: &FfiParticipant) -> Self {

--- a/livekit-ffi/src/conversion/room.rs
+++ b/livekit-ffi/src/conversion/room.rs
@@ -12,16 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::proto;
-use crate::server::room::FfiRoom;
-use livekit::e2ee::key_provider::{KeyProvider, KeyProviderOptions};
-use livekit::e2ee::{E2eeOptions, EncryptionType};
-use livekit::options::{AudioEncoding, TrackPublishOptions, VideoEncoding};
-use livekit::prelude::*;
-use livekit::webrtc::native::frame_cryptor::EncryptionState;
-use livekit::webrtc::prelude::{
-    ContinualGatheringPolicy, IceServer, IceTransportsType, RtcConfiguration,
+use livekit::{
+    e2ee::{
+        key_provider::{KeyProvider, KeyProviderOptions},
+        E2eeOptions, EncryptionType,
+    },
+    options::{AudioEncoding, TrackPublishOptions, VideoEncoding},
+    prelude::*,
+    webrtc::{
+        native::frame_cryptor::EncryptionState,
+        prelude::{ContinualGatheringPolicy, IceServer, IceTransportsType, RtcConfiguration},
+    },
 };
+
+use crate::{proto, server::room::FfiRoom};
 
 impl From<EncryptionState> for proto::EncryptionState {
     fn from(value: EncryptionState) -> Self {
@@ -109,11 +113,7 @@ impl From<proto::ContinualGatheringPolicy> for ContinualGatheringPolicy {
 
 impl From<proto::IceServer> for IceServer {
     fn from(value: proto::IceServer) -> Self {
-        Self {
-            urls: value.urls,
-            username: value.username,
-            password: value.password,
-        }
+        Self { urls: value.urls, username: value.username, password: value.password }
     }
 }
 
@@ -122,11 +122,9 @@ impl From<proto::RtcConfig> for RtcConfiguration {
         let default = RoomOptions::default().rtc_config; // Always use RoomOptions as the default reference
 
         Self {
-            ice_transport_type: value
-                .ice_transport_type
-                .map_or(default.ice_transport_type, |x| {
-                    proto::IceTransportType::try_from(x).unwrap().into()
-                }),
+            ice_transport_type: value.ice_transport_type.map_or(default.ice_transport_type, |x| {
+                proto::IceTransportType::try_from(x).unwrap().into()
+            }),
             continual_gathering_policy: value
                 .continual_gathering_policy
                 .map_or(default.continual_gathering_policy, |x| {
@@ -156,10 +154,8 @@ impl From<proto::RoomOptions> for RoomOptions {
             })
         });
 
-        let rtc_config = value
-            .rtc_config
-            .map(Into::into)
-            .unwrap_or(RoomOptions::default().rtc_config);
+        let rtc_config =
+            value.rtc_config.map(Into::into).unwrap_or(RoomOptions::default().rtc_config);
 
         Self {
             adaptive_stream: value.adaptive_stream,
@@ -206,28 +202,19 @@ impl From<proto::TrackPublishOptions> for TrackPublishOptions {
 
 impl From<proto::VideoEncoding> for VideoEncoding {
     fn from(opts: proto::VideoEncoding) -> Self {
-        Self {
-            max_bitrate: opts.max_bitrate,
-            max_framerate: opts.max_framerate,
-        }
+        Self { max_bitrate: opts.max_bitrate, max_framerate: opts.max_framerate }
     }
 }
 
 impl From<proto::AudioEncoding> for AudioEncoding {
     fn from(opts: proto::AudioEncoding) -> Self {
-        Self {
-            max_bitrate: opts.max_bitrate,
-        }
+        Self { max_bitrate: opts.max_bitrate }
     }
 }
 
 impl From<&FfiRoom> for proto::RoomInfo {
     fn from(value: &FfiRoom) -> Self {
         let room = &value.inner.room;
-        Self {
-            sid: room.sid().into(),
-            name: room.name(),
-            metadata: room.metadata(),
-        }
+        Self { sid: room.sid().into(), name: room.name(), metadata: room.metadata() }
     }
 }

--- a/livekit-ffi/src/conversion/stats.rs
+++ b/livekit-ffi/src/conversion/stats.rs
@@ -1,4 +1,3 @@
-use crate::proto;
 use livekit::webrtc::{
     prelude::DataChannelState,
     stats::{
@@ -7,6 +6,8 @@ use livekit::webrtc::{
         QualityLimitationReason,
     },
 };
+
+use crate::proto;
 
 impl From<DataChannelState> for proto::DataChannelState {
     fn from(value: DataChannelState) -> Self {
@@ -173,10 +174,7 @@ impl From<rtc::RtcStats> for proto::RtcStats {
 
 impl From<rtc::CodecStats> for proto::rtc_stats::Codec {
     fn from(value: rtc::CodecStats) -> Self {
-        Self {
-            rtc: Some(value.rtc.into()),
-            codec: Some(value.codec.into()),
-        }
+        Self { rtc: Some(value.rtc.into()), codec: Some(value.codec.into()) }
     }
 }
 
@@ -237,73 +235,49 @@ impl From<rtc::MediaSourceStats> for proto::rtc_stats::MediaSource {
 
 impl From<rtc::MediaPlayoutStats> for proto::rtc_stats::MediaPlayout {
     fn from(value: rtc::MediaPlayoutStats) -> Self {
-        Self {
-            rtc: Some(value.rtc.into()),
-            audio_playout: Some(value.audio_playout.into()),
-        }
+        Self { rtc: Some(value.rtc.into()), audio_playout: Some(value.audio_playout.into()) }
     }
 }
 
 impl From<rtc::PeerConnectionStats> for proto::rtc_stats::PeerConnection {
     fn from(value: rtc::PeerConnectionStats) -> Self {
-        Self {
-            rtc: Some(value.rtc.into()),
-            pc: Some(value.pc.into()),
-        }
+        Self { rtc: Some(value.rtc.into()), pc: Some(value.pc.into()) }
     }
 }
 
 impl From<rtc::DataChannelStats> for proto::rtc_stats::DataChannel {
     fn from(value: rtc::DataChannelStats) -> Self {
-        Self {
-            rtc: Some(value.rtc.into()),
-            dc: Some(value.dc.into()),
-        }
+        Self { rtc: Some(value.rtc.into()), dc: Some(value.dc.into()) }
     }
 }
 
 impl From<rtc::TransportStats> for proto::rtc_stats::Transport {
     fn from(value: rtc::TransportStats) -> Self {
-        Self {
-            rtc: Some(value.rtc.into()),
-            transport: Some(value.transport.into()),
-        }
+        Self { rtc: Some(value.rtc.into()), transport: Some(value.transport.into()) }
     }
 }
 
 impl From<rtc::CandidatePairStats> for proto::rtc_stats::CandidatePair {
     fn from(value: rtc::CandidatePairStats) -> Self {
-        Self {
-            rtc: Some(value.rtc.into()),
-            candidate_pair: Some(value.candidate_pair.into()),
-        }
+        Self { rtc: Some(value.rtc.into()), candidate_pair: Some(value.candidate_pair.into()) }
     }
 }
 
 impl From<rtc::LocalCandidateStats> for proto::rtc_stats::LocalCandidate {
     fn from(value: rtc::LocalCandidateStats) -> Self {
-        Self {
-            rtc: Some(value.rtc.into()),
-            candidate: Some(value.local_candidate.into()),
-        }
+        Self { rtc: Some(value.rtc.into()), candidate: Some(value.local_candidate.into()) }
     }
 }
 
 impl From<rtc::RemoteCandidateStats> for proto::rtc_stats::RemoteCandidate {
     fn from(value: rtc::RemoteCandidateStats) -> Self {
-        Self {
-            rtc: Some(value.rtc.into()),
-            candidate: Some(value.remote_candidate.into()),
-        }
+        Self { rtc: Some(value.rtc.into()), candidate: Some(value.remote_candidate.into()) }
     }
 }
 
 impl From<rtc::CertificateStats> for proto::rtc_stats::Certificate {
     fn from(value: rtc::CertificateStats) -> Self {
-        Self {
-            rtc: Some(value.rtc.into()),
-            certificate: Some(value.certificate.into()),
-        }
+        Self { rtc: Some(value.rtc.into()), certificate: Some(value.certificate.into()) }
     }
 }
 
@@ -311,10 +285,7 @@ impl From<rtc::CertificateStats> for proto::rtc_stats::Certificate {
 
 impl From<rtc::dictionaries::RtcStats> for proto::RtcStatsData {
     fn from(value: rtc::dictionaries::RtcStats) -> Self {
-        Self {
-            id: value.id,
-            timestamp: value.timestamp,
-        }
+        Self { id: value.id, timestamp: value.timestamp }
     }
 }
 
@@ -414,10 +385,7 @@ impl From<rtc::dictionaries::InboundRtpStreamStats> for proto::InboundRtpStreamS
 
 impl From<rtc::dictionaries::SentRtpStreamStats> for proto::SentRtpStreamStats {
     fn from(value: rtc::dictionaries::SentRtpStreamStats) -> Self {
-        Self {
-            packets_sent: value.packets_sent,
-            bytes_sent: value.bytes_sent,
-        }
+        Self { packets_sent: value.packets_sent, bytes_sent: value.bytes_sent }
     }
 }
 
@@ -487,10 +455,7 @@ impl From<rtc::dictionaries::RemoteOutboundRtpStreamStats> for proto::RemoteOutb
 
 impl From<rtc::dictionaries::MediaSourceStats> for proto::MediaSourceStats {
     fn from(value: rtc::dictionaries::MediaSourceStats) -> Self {
-        Self {
-            track_identifier: value.track_identifier,
-            kind: value.kind,
-        }
+        Self { track_identifier: value.track_identifier, kind: value.kind }
     }
 }
 
@@ -567,12 +532,8 @@ impl From<rtc::dictionaries::TransportStats> for proto::TransportStats {
             bytes_received: value.bytes_received,
             ice_role: proto::IceRole::from(value.ice_role) as i32,
             ice_local_username_fragment: value.ice_local_username_fragment,
-            dtls_state: value
-                .dtls_state
-                .map(|v| proto::DtlsTransportState::from(v) as i32),
-            ice_state: value
-                .ice_state
-                .map(|v| proto::IceTransportState::from(v) as i32),
+            dtls_state: value.dtls_state.map(|v| proto::DtlsTransportState::from(v) as i32),
+            ice_state: value.ice_state.map(|v| proto::IceTransportState::from(v) as i32),
             selected_candidate_pair_id: value.selected_candidate_pair_id,
             local_certificate_id: value.local_certificate_id,
             remote_certificate_id: value.remote_certificate_id,
@@ -591,9 +552,7 @@ impl From<rtc::dictionaries::CandidatePairStats> for proto::CandidatePairStats {
             transport_id: value.transport_id,
             local_candidate_id: value.local_candidate_id,
             remote_candidate_id: value.remote_candidate_id,
-            state: value
-                .state
-                .map(|v| proto::IceCandidatePairState::from(v) as i32),
+            state: value.state.map(|v| proto::IceCandidatePairState::from(v) as i32),
             nominated: value.nominated,
             packets_sent: value.packets_sent,
             packets_received: value.packets_received,
@@ -623,9 +582,7 @@ impl From<rtc::dictionaries::IceCandidateStats> for proto::IceCandidateStats {
             address: value.address,
             port: value.port,
             protocol: value.protocol,
-            candidate_type: value
-                .candidate_type
-                .map(|v| proto::IceCandidateType::from(v) as i32),
+            candidate_type: value.candidate_type.map(|v| proto::IceCandidateType::from(v) as i32),
             priority: value.priority,
             url: value.url,
             relay_protocol: value
@@ -635,9 +592,7 @@ impl From<rtc::dictionaries::IceCandidateStats> for proto::IceCandidateStats {
             related_address: value.related_address,
             related_port: value.related_port,
             username_fragment: value.username_fragment,
-            tcp_type: value
-                .tcp_type
-                .map(|v| proto::IceTcpCandidateType::from(v) as i32),
+            tcp_type: value.tcp_type.map(|v| proto::IceTcpCandidateType::from(v) as i32),
         }
     }
 }

--- a/livekit-ffi/src/conversion/track.rs
+++ b/livekit-ffi/src/conversion/track.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use livekit::prelude::*;
+
 use crate::{
     proto,
     server::room::{FfiPublication, FfiTrack},
 };
-use livekit::prelude::*;
 
 impl From<&FfiPublication> for proto::TrackPublicationInfo {
     fn from(value: &FfiPublication) -> Self {

--- a/livekit-ffi/src/conversion/video_frame.rs
+++ b/livekit-ffi/src/conversion/video_frame.rs
@@ -12,20 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::proto;
-use crate::server::video_source::FfiVideoSource;
-use crate::server::video_stream::FfiVideoStream;
-use livekit::options::{VideoCodec, VideoResolution};
-use livekit::webrtc::prelude::*;
-use livekit::webrtc::video_frame;
-use livekit::webrtc::video_source::VideoResolution as VideoSourceResolution;
+use livekit::{
+    options::{VideoCodec, VideoResolution},
+    webrtc::{prelude::*, video_frame, video_source::VideoResolution as VideoSourceResolution},
+};
+
+use crate::{
+    proto,
+    server::{video_source::FfiVideoSource, video_stream::FfiVideoStream},
+};
 
 impl From<proto::VideoSourceResolution> for VideoSourceResolution {
     fn from(res: proto::VideoSourceResolution) -> Self {
-        Self {
-            width: res.width,
-            height: res.height,
-        }
+        Self { width: res.width, height: res.height }
     }
 }
 
@@ -43,17 +42,13 @@ impl proto::VideoFrameInfo {
 
 impl From<&FfiVideoSource> for proto::VideoSourceInfo {
     fn from(source: &FfiVideoSource) -> Self {
-        Self {
-            r#type: source.source_type as i32,
-        }
+        Self { r#type: source.source_type as i32 }
     }
 }
 
 impl From<&FfiVideoStream> for proto::VideoStreamInfo {
     fn from(stream: &FfiVideoStream) -> Self {
-        Self {
-            r#type: stream.stream_type as i32,
-        }
+        Self { r#type: stream.stream_type as i32 }
     }
 }
 

--- a/livekit-ffi/src/lib.rs
+++ b/livekit-ffi/src/lib.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::{borrow::Cow, sync::Arc};
+
 use lazy_static::lazy_static;
 use livekit::prelude::*;
 use prost::Message;
 use server::FfiDataBuffer;
-use std::{borrow::Cow, sync::Arc};
 use thiserror::Error;
 
 mod conversion;

--- a/livekit-ffi/src/lib.rs
+++ b/livekit-ffi/src/lib.rs
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{borrow::Cow, sync::Arc};
+use std::borrow::Cow;
 
 use lazy_static::lazy_static;
 use livekit::prelude::*;
-use prost::Message;
-use server::FfiDataBuffer;
 use thiserror::Error;
 
 mod conversion;

--- a/livekit-ffi/src/server/audio_source.rs
+++ b/livekit-ffi/src/server/audio_source.rs
@@ -14,9 +14,10 @@
 
 use std::{borrow::Cow, slice};
 
+use livekit::webrtc::prelude::*;
+
 use super::FfiHandle;
 use crate::{proto, server, FfiError, FfiHandleId, FfiResult};
-use livekit::webrtc::prelude::*;
 
 pub struct FfiAudioSource {
     pub handle_id: FfiHandleId,
@@ -46,19 +47,11 @@ impl FfiAudioSource {
                 );
                 RtcAudioSource::Native(audio_source)
             }
-            _ => {
-                return Err(FfiError::InvalidRequest(
-                    "unsupported audio source type".into(),
-                ))
-            }
+            _ => return Err(FfiError::InvalidRequest("unsupported audio source type".into())),
         };
 
         let handle_id = server.next_id();
-        let source = Self {
-            handle_id,
-            source_type,
-            source: source_inner,
-        };
+        let source = Self { handle_id, source_type, source: source_inner };
 
         let info = proto::AudioSourceInfo::from(&source);
         server.store_handle(source.handle_id, source);

--- a/livekit-ffi/src/server/logger.rs
+++ b/livekit-ffi/src/server/logger.rs
@@ -1,10 +1,13 @@
-use crate::proto;
-use crate::FFI_SERVER;
+use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
+
 use env_logger;
 use log::{self, Log};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
+
+use crate::{proto, FFI_SERVER};
 
 pub const FLUSH_INTERVAL: Duration = Duration::from_secs(1);
 pub const BATCH_SIZE: usize = 32;

--- a/livekit-ffi/src/server/room.rs
+++ b/livekit-ffi/src/server/room.rs
@@ -217,7 +217,7 @@ impl RoomInner {
             server.async_runtime.spawn(async move {
                 let cb = proto::PublishDataCallback {
                     async_id,
-                    error: Some(format!("failed to send data, room closed: {}", err).into()),
+                    error: Some(format!("failed to send data, room closed: {}", err)),
                 };
 
                 let _ = server.send_event(proto::ffi_event::Message::PublishData(cb)).await;

--- a/livekit-ffi/src/server/room.rs
+++ b/livekit-ffi/src/server/room.rs
@@ -12,19 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::server::{FfiHandle, FfiServer};
-use crate::{proto, FfiError, FfiHandleId, FfiResult};
+use std::{collections::HashSet, slice, sync::Arc, time::Duration};
+
 use livekit::prelude::*;
 use parking_lot::Mutex;
-use std::collections::HashSet;
-use std::slice;
-use std::sync::Arc;
-use std::time::Duration;
-use tokio::sync::{broadcast, mpsc};
-use tokio::sync::{oneshot, Mutex as AsyncMutex};
-use tokio::task::JoinHandle;
+use tokio::{
+    sync::{broadcast, mpsc, oneshot, Mutex as AsyncMutex},
+    task::JoinHandle,
+};
 
 use super::FfiDataBuffer;
+use crate::{
+    proto,
+    server::{FfiHandle, FfiServer},
+    FfiError, FfiHandleId, FfiResult,
+};
 
 #[derive(Clone)]
 pub struct FfiParticipant {
@@ -97,9 +99,8 @@ impl FfiRoom {
                 Ok((room, mut events)) => {
                     // Successfully connected to the room
                     // Forward the initial state for the FfiClient
-                    let Some(RoomEvent::Connected {
-                        participants_with_tracks,
-                    }) = events.recv().await
+                    let Some(RoomEvent::Connected { participants_with_tracks }) =
+                        events.recv().await
                     else {
                         unreachable!("Connected event should always be the first event");
                     };
@@ -120,14 +121,14 @@ impl FfiRoom {
                         build_initial_states(server, &inner, participants_with_tracks);
 
                     // Send callback
-                    let ffi_room = Self {
-                        inner: inner.clone(),
-                        handle: Default::default(),
-                    };
+                    let ffi_room = Self { inner: inner.clone(), handle: Default::default() };
                     server.store_handle(ffi_room.inner.handle_id, ffi_room.clone());
 
-                    // Keep the lock until the handle is "Some" (So it is OK for the client to request a disconnect quickly after connecting)
-                    // (When requesting a disconnect, the handle will still be locked and the disconnect will wait for the lock to be released and gracefully close the room)
+                    // Keep the lock until the handle is "Some" (So it is OK for the client to
+                    // request a disconnect quickly after connecting)
+                    // (When requesting a disconnect, the handle will still be locked and the
+                    // disconnect will wait for the lock to be released and gracefully close the
+                    // room)
                     let mut handle = ffi_room.handle.lock().await;
                     let room_info = proto::RoomInfo::from(&ffi_room);
 
@@ -154,11 +155,7 @@ impl FfiRoom {
                     let data_handle =
                         tokio::spawn(data_task(server, inner.clone(), data_rx, close_rx)); // Publish data
 
-                    *handle = Some(Handle {
-                        event_handle,
-                        data_handle,
-                        close_tx,
-                    });
+                    *handle = Some(Handle { event_handle, data_handle, close_tx });
                 }
                 Err(e) => {
                     // Failed to connect to the room, send an error message to the FfiClient
@@ -223,9 +220,7 @@ impl RoomInner {
                     error: Some(format!("failed to send data, room closed: {}", err).into()),
                 };
 
-                let _ = server
-                    .send_event(proto::ffi_event::Message::PublishData(cb))
-                    .await;
+                let _ = server.send_event(proto::ffi_event::Message::PublishData(cb)).await;
             });
         }
 
@@ -244,9 +239,7 @@ impl RoomInner {
         let inner = self.clone();
         server.async_runtime.spawn(async move {
             let publish_res = async {
-                let ffi_track = server
-                    .retrieve_handle::<FfiTrack>(publish.track_handle)?
-                    .clone();
+                let ffi_track = server.retrieve_handle::<FfiTrack>(publish.track_handle)?.clone();
 
                 let track = LocalTrack::try_from(ffi_track.track.clone())
                     .map_err(|_| FfiError::InvalidRequest("track is not a LocalTrack".into()))?;
@@ -285,10 +278,7 @@ impl RoomInner {
                         ))
                         .await;
 
-                    inner
-                        .pending_published_tracks
-                        .lock()
-                        .insert(publication.sid());
+                    inner.pending_published_tracks.lock().insert(publication.sid());
                 }
                 Err(err) => {
                     // Failed to publish the track
@@ -310,7 +300,8 @@ impl RoomInner {
 
     /// Unpublish a track and make sure to sync the async callback
     /// with the LocalTrackUnpublished event.
-    /// Contrary to publish_track, the LocalTrackUnpublished event must be sent *before* the async callback.
+    /// Contrary to publish_track, the LocalTrackUnpublished event must be sent *before* the async
+    /// callback.
     pub fn unpublish_track(
         self: &Arc<Self>,
         server: &'static FfiServer,
@@ -379,11 +370,7 @@ impl RoomInner {
         let async_id = server.next_id();
         let inner = self.clone();
         server.async_runtime.spawn(async move {
-            let _ = inner
-                .room
-                .local_participant()
-                .update_name(update_local_name.name)
-                .await;
+            let _ = inner.room.local_participant().update_name(update_local_name.name).await;
 
             let _ = server
                 .send_event(proto::ffi_event::Message::UpdateLocalName(
@@ -437,9 +424,7 @@ async fn room_task(
     mut events: mpsc::UnboundedReceiver<livekit::RoomEvent>,
     mut close_rx: broadcast::Receiver<()>,
 ) {
-    let present_state = Arc::new(Mutex::new(ActualState {
-        reconnecting: false,
-    }));
+    let present_state = Arc::new(Mutex::new(ActualState { reconnecting: false }));
 
     loop {
         tokio::select! {
@@ -511,24 +496,19 @@ async fn forward_event(
         }
         RoomEvent::ParticipantDisconnected(participant) => {
             let _ = send_event(proto::room_event::Message::ParticipantDisconnected(
-                proto::ParticipantDisconnected {
-                    participant_sid: participant.sid().into(),
-                },
+                proto::ParticipantDisconnected { participant_sid: participant.sid().into() },
             ))
             .await;
         }
-        RoomEvent::LocalTrackPublished {
-            publication,
-            track: _,
-            participant: _,
-        } => {
+        RoomEvent::LocalTrackPublished { publication, track: _, participant: _ } => {
             let sid = publication.sid();
             // If we're currently reconnecting, users can't publish tracks, if we receive this
             // event it means the RoomEngine is republishing tracks to finish the reconnection
             // process. (So we're not waiting for any PublishCallback)
             if !present_state.lock().reconnecting {
                 // Make sure to send the event *after* the async callback of the PublishTrackRequest
-                // Wait for the PublishTrack callback to be sent (waiting time is really short, so it is fine to not spawn a new task)
+                // Wait for the PublishTrack callback to be sent (waiting time is really short, so
+                // it is fine to not spawn a new task)
                 loop {
                     if inner.pending_published_tracks.lock().remove(&sid) {
                         break;
@@ -545,32 +525,19 @@ async fn forward_event(
             server.store_handle(ffi_publication.handle, ffi_publication);
 
             let _ = send_event(proto::room_event::Message::LocalTrackPublished(
-                proto::LocalTrackPublished {
-                    track_sid: sid.to_string(),
-                },
+                proto::LocalTrackPublished { track_sid: sid.to_string() },
             ))
             .await;
         }
-        RoomEvent::LocalTrackUnpublished {
-            publication,
-            participant: _,
-        } => {
+        RoomEvent::LocalTrackUnpublished { publication, participant: _ } => {
             let _ = send_event(proto::room_event::Message::LocalTrackUnpublished(
-                proto::LocalTrackUnpublished {
-                    publication_sid: publication.sid().into(),
-                },
+                proto::LocalTrackUnpublished { publication_sid: publication.sid().into() },
             ))
             .await;
 
-            inner
-                .pending_unpublished_tracks
-                .lock()
-                .insert(publication.sid());
+            inner.pending_unpublished_tracks.lock().insert(publication.sid());
         }
-        RoomEvent::TrackPublished {
-            publication,
-            participant,
-        } => {
+        RoomEvent::TrackPublished { publication, participant } => {
             let handle_id = server.next_id();
             let ffi_publication = FfiPublication {
                 handle: handle_id,
@@ -580,59 +547,41 @@ async fn forward_event(
             let publication_info = proto::TrackPublicationInfo::from(&ffi_publication);
             server.store_handle(ffi_publication.handle, ffi_publication);
 
-            let _ = send_event(proto::room_event::Message::TrackPublished(
-                proto::TrackPublished {
-                    participant_sid: participant.sid().to_string(),
-                    publication: Some(proto::OwnedTrackPublication {
-                        handle: Some(proto::FfiOwnedHandle { id: handle_id }),
-                        info: Some(publication_info),
-                    }),
-                },
-            ))
+            let _ = send_event(proto::room_event::Message::TrackPublished(proto::TrackPublished {
+                participant_sid: participant.sid().to_string(),
+                publication: Some(proto::OwnedTrackPublication {
+                    handle: Some(proto::FfiOwnedHandle { id: handle_id }),
+                    info: Some(publication_info),
+                }),
+            }))
             .await;
         }
-        RoomEvent::TrackUnpublished {
-            publication,
-            participant,
-        } => {
-            let _ = send_event(proto::room_event::Message::TrackUnpublished(
-                proto::TrackUnpublished {
+        RoomEvent::TrackUnpublished { publication, participant } => {
+            let _ =
+                send_event(proto::room_event::Message::TrackUnpublished(proto::TrackUnpublished {
                     participant_sid: participant.sid().to_string(),
                     publication_sid: publication.sid().into(),
-                },
-            ))
-            .await;
+                }))
+                .await;
         }
-        RoomEvent::TrackSubscribed {
-            track,
-            publication: _,
-            participant,
-        } => {
+        RoomEvent::TrackSubscribed { track, publication: _, participant } => {
             let handle_id = server.next_id();
-            let ffi_track = FfiTrack {
-                handle: handle_id,
-                track: track.into(),
-            };
+            let ffi_track = FfiTrack { handle: handle_id, track: track.into() };
 
             let track_info = proto::TrackInfo::from(&ffi_track);
             server.store_handle(ffi_track.handle, ffi_track);
 
-            let _ = send_event(proto::room_event::Message::TrackSubscribed(
-                proto::TrackSubscribed {
+            let _ =
+                send_event(proto::room_event::Message::TrackSubscribed(proto::TrackSubscribed {
                     participant_sid: participant.sid().to_string(),
                     track: Some(proto::OwnedTrack {
                         handle: Some(proto::FfiOwnedHandle { id: handle_id }),
                         info: Some(track_info),
                     }),
-                },
-            ))
-            .await;
+                }))
+                .await;
         }
-        RoomEvent::TrackUnsubscribed {
-            track,
-            publication: _,
-            participant,
-        } => {
+        RoomEvent::TrackUnsubscribed { track, publication: _, participant } => {
             let _ = send_event(proto::room_event::Message::TrackUnsubscribed(
                 proto::TrackUnsubscribed {
                     participant_sid: participant.sid().to_string(),
@@ -641,11 +590,7 @@ async fn forward_event(
             ))
             .await;
         }
-        RoomEvent::TrackSubscriptionFailed {
-            participant,
-            error,
-            track_sid,
-        } => {
+        RoomEvent::TrackSubscriptionFailed { participant, error, track_sid } => {
             let _ = send_event(proto::room_event::Message::TrackSubscriptionFailed(
                 proto::TrackSubscriptionFailed {
                     participant_sid: participant.sid().to_string(),
@@ -655,42 +600,27 @@ async fn forward_event(
             ))
             .await;
         }
-        RoomEvent::TrackMuted {
-            participant,
-            publication,
-        } => {
+        RoomEvent::TrackMuted { participant, publication } => {
             let _ = send_event(proto::room_event::Message::TrackMuted(proto::TrackMuted {
                 participant_sid: participant.sid().to_string(),
                 track_sid: publication.sid().into(),
             }))
             .await;
         }
-        RoomEvent::TrackUnmuted {
-            participant,
-            publication,
-        } => {
-            let _ = send_event(proto::room_event::Message::TrackUnmuted(
-                proto::TrackUnmuted {
-                    participant_sid: participant.sid().to_string(),
-                    track_sid: publication.sid().into(),
-                },
-            ))
+        RoomEvent::TrackUnmuted { participant, publication } => {
+            let _ = send_event(proto::room_event::Message::TrackUnmuted(proto::TrackUnmuted {
+                participant_sid: participant.sid().to_string(),
+                track_sid: publication.sid().into(),
+            }))
             .await;
         }
-        RoomEvent::RoomMetadataChanged {
-            old_metadata: _,
-            metadata,
-        } => {
+        RoomEvent::RoomMetadataChanged { old_metadata: _, metadata } => {
             let _ = send_event(proto::room_event::Message::RoomMetadataChanged(
                 proto::RoomMetadataChanged { metadata },
             ))
             .await;
         }
-        RoomEvent::ParticipantMetadataChanged {
-            participant,
-            old_metadata: _,
-            metadata,
-        } => {
+        RoomEvent::ParticipantMetadataChanged { participant, old_metadata: _, metadata } => {
             let _ = send_event(proto::room_event::Message::ParticipantMetadataChanged(
                 proto::ParticipantMetadataChanged {
                     participant_sid: participant.sid().to_string(),
@@ -699,11 +629,7 @@ async fn forward_event(
             ))
             .await;
         }
-        RoomEvent::ParticipantNameChanged {
-            participant,
-            old_name: _,
-            name,
-        } => {
+        RoomEvent::ParticipantNameChanged { participant, old_name: _, name } => {
             let _ = send_event(proto::room_event::Message::ParticipantNameChanged(
                 proto::ParticipantNameChanged {
                     participant_sid: participant.sid().to_string(),
@@ -713,20 +639,14 @@ async fn forward_event(
             .await;
         }
         RoomEvent::ActiveSpeakersChanged { speakers } => {
-            let participant_sids = speakers
-                .iter()
-                .map(|p| p.sid().to_string())
-                .collect::<Vec<_>>();
+            let participant_sids = speakers.iter().map(|p| p.sid().to_string()).collect::<Vec<_>>();
 
             let _ = send_event(proto::room_event::Message::ActiveSpeakersChanged(
                 proto::ActiveSpeakersChanged { participant_sids },
             ))
             .await;
         }
-        RoomEvent::ConnectionQualityChanged {
-            quality,
-            participant,
-        } => {
+        RoomEvent::ConnectionQualityChanged { quality, participant } => {
             let _ = send_event(proto::room_event::Message::ConnectionQualityChanged(
                 proto::ConnectionQualityChanged {
                     participant_sid: participant.sid().to_string(),
@@ -735,43 +655,28 @@ async fn forward_event(
             ))
             .await;
         }
-        RoomEvent::DataReceived {
-            payload,
-            kind,
-            participant,
-            topic,
-        } => {
+        RoomEvent::DataReceived { payload, kind, participant, topic } => {
             let handle_id = server.next_id();
             let buffer_info = proto::BufferInfo {
                 data_ptr: payload.as_ptr() as u64,
                 data_len: payload.len() as u64,
             };
 
-            server.store_handle(
-                handle_id,
-                FfiDataBuffer {
-                    handle: handle_id,
-                    data: payload,
-                },
-            );
-            let _ = send_event(proto::room_event::Message::DataReceived(
-                proto::DataReceived {
-                    data: Some(proto::OwnedBuffer {
-                        handle: Some(proto::FfiOwnedHandle { id: handle_id }),
-                        data: Some(buffer_info),
-                    }),
-                    participant_sid: participant.map(|p| p.sid().to_string()),
-                    kind: proto::DataPacketKind::from(kind).into(),
-                    topic,
-                },
-            ))
+            server.store_handle(handle_id, FfiDataBuffer { handle: handle_id, data: payload });
+            let _ = send_event(proto::room_event::Message::DataReceived(proto::DataReceived {
+                data: Some(proto::OwnedBuffer {
+                    handle: Some(proto::FfiOwnedHandle { id: handle_id }),
+                    data: Some(buffer_info),
+                }),
+                participant_sid: participant.map(|p| p.sid().to_string()),
+                kind: proto::DataPacketKind::from(kind).into(),
+                topic,
+            }))
             .await;
         }
         RoomEvent::ConnectionStateChanged(state) => {
             let _ = send_event(proto::room_event::Message::ConnectionStateChanged(
-                proto::ConnectionStateChanged {
-                    state: proto::ConnectionState::from(state).into(),
-                },
+                proto::ConnectionStateChanged { state: proto::ConnectionState::from(state).into() },
             ))
             .await;
         }
@@ -779,33 +684,26 @@ async fn forward_event(
             // Ignore here, we're already sent the event on connect (see above)
         }
         RoomEvent::Disconnected { reason: _ } => {
-            let _ = send_event(proto::room_event::Message::Disconnected(
-                proto::Disconnected {},
-            ))
-            .await;
+            let _ =
+                send_event(proto::room_event::Message::Disconnected(proto::Disconnected {})).await;
         }
         RoomEvent::Reconnecting => {
             present_state.lock().reconnecting = true;
-            let _ = send_event(proto::room_event::Message::Reconnecting(
-                proto::Reconnecting {},
-            ))
-            .await;
+            let _ =
+                send_event(proto::room_event::Message::Reconnecting(proto::Reconnecting {})).await;
         }
         RoomEvent::Reconnected => {
             present_state.lock().reconnecting = false;
-            let _ = send_event(proto::room_event::Message::Reconnected(
-                proto::Reconnected {},
-            ))
-            .await;
+            let _ =
+                send_event(proto::room_event::Message::Reconnected(proto::Reconnected {})).await;
         }
         RoomEvent::E2eeStateChanged { participant, state } => {
-            let _ = send_event(proto::room_event::Message::E2eeStateChanged(
-                proto::E2eeStateChanged {
+            let _ =
+                send_event(proto::room_event::Message::E2eeStateChanged(proto::E2eeStateChanged {
                     participant_sid: participant.sid().to_string(),
                     state: proto::EncryptionState::from(state).into(),
-                },
-            ))
-            .await;
+                }))
+                .await;
         }
         _ => {
             log::warn!("unhandled room event: {:?}", event);
@@ -817,10 +715,7 @@ fn build_initial_states(
     server: &'static FfiServer,
     inner: &Arc<RoomInner>,
     participants_with_tracks: Vec<(RemoteParticipant, Vec<RemoteTrackPublication>)>,
-) -> (
-    proto::OwnedParticipant,
-    Vec<proto::connect_callback::ParticipantWithTracks>,
-) {
+) -> (proto::OwnedParticipant, Vec<proto::connect_callback::ParticipantWithTracks>) {
     let local_participant = inner.room.local_participant(); // Is it too late to get the local participant info here?
     let handle_id = server.next_id();
     let local_participant = FfiParticipant {

--- a/livekit-protocol/src/debouncer.rs
+++ b/livekit-protocol/src/debouncer.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use futures_util::Future;
 use std::time::Duration;
+
+use futures_util::Future;
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
 
@@ -35,10 +36,7 @@ where
     let (tx, rx) = mpsc::unbounded_channel();
     let (cancel_tx, cancel_rx) = oneshot::channel();
     tokio::spawn(debounce_task(duration, future, rx, cancel_rx));
-    Debouncer {
-        tx,
-        cancel_tx: Some(cancel_tx),
-    }
+    Debouncer { tx, cancel_tx: Some(cancel_tx) }
 }
 
 async fn debounce_task<F>(

--- a/livekit-protocol/src/observer.rs
+++ b/livekit-protocol/src/observer.rs
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use futures_util::sink::Sink;
-use futures_util::task::{Context, Poll};
+use std::{pin::Pin, sync::Arc};
+
+use futures_util::{
+    sink::Sink,
+    task::{Context, Poll},
+};
 use parking_lot::Mutex;
-use std::pin::Pin;
-use std::sync::Arc;
 use tokio::sync::mpsc;
 
 #[derive(Clone, Debug)]
@@ -32,9 +34,7 @@ where
     T: Clone,
 {
     fn default() -> Self {
-        Self {
-            senders: Default::default(),
-        }
+        Self { senders: Default::default() }
     }
 }
 
@@ -49,9 +49,7 @@ where
     }
 
     pub fn dispatch(&self, msg: &T) {
-        self.senders
-            .lock()
-            .retain(|sender| sender.send(msg.clone()).is_ok());
+        self.senders.lock().retain(|sender| sender.send(msg.clone()).is_ok());
     }
 
     pub fn clear(&self) {

--- a/livekit/src/prelude.rs
+++ b/livekit/src/prelude.rs
@@ -12,18 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use crate::participant::{ConnectionQuality, LocalParticipant, Participant, RemoteParticipant};
-
 pub use crate::{
+    id::*,
+    participant::{ConnectionQuality, LocalParticipant, Participant, RemoteParticipant},
+    publication::{LocalTrackPublication, RemoteTrackPublication, TrackPublication},
+    track::{
+        AudioTrack, LocalAudioTrack, LocalTrack, LocalVideoTrack, RemoteAudioTrack, RemoteTrack,
+        RemoteVideoTrack, StreamState, Track, TrackDimension, TrackKind, TrackSource, VideoTrack,
+    },
     ConnectionState, DataPacket, DataPacketKind, Room, RoomError, RoomEvent, RoomOptions,
     RoomResult,
 };
-
-pub use crate::publication::{LocalTrackPublication, RemoteTrackPublication, TrackPublication};
-
-pub use crate::track::{
-    AudioTrack, LocalAudioTrack, LocalTrack, LocalVideoTrack, RemoteAudioTrack, RemoteTrack,
-    RemoteVideoTrack, StreamState, Track, TrackDimension, TrackKind, TrackSource, VideoTrack,
-};
-
-pub use crate::id::*;

--- a/livekit/src/proto.rs
+++ b/livekit/src/proto.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{e2ee::EncryptionType, participant, track, DataPacketKind};
 use livekit_protocol::*;
+
+use crate::{e2ee::EncryptionType, participant, track, DataPacketKind};
 
 // Conversions
 impl From<ConnectionQuality> for participant::ConnectionQuality {

--- a/livekit/src/room/e2ee/manager.rs
+++ b/livekit/src/room/e2ee/manager.rs
@@ -12,18 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::key_provider::KeyProvider;
-use super::EncryptionType;
-use crate::e2ee::E2eeOptions;
-use crate::id::{ParticipantIdentity, TrackSid};
-use crate::participant::{LocalParticipant, RemoteParticipant};
-use crate::prelude::{LocalTrack, LocalTrackPublication, RemoteTrack, RemoteTrackPublication};
-use crate::rtc_engine::lk_runtime::LkRuntime;
-use libwebrtc::native::frame_cryptor::{EncryptionAlgorithm, EncryptionState, FrameCryptor};
-use libwebrtc::{rtp_receiver::RtpReceiver, rtp_sender::RtpSender};
+use std::{collections::HashMap, sync::Arc};
+
+use libwebrtc::{
+    native::frame_cryptor::{EncryptionAlgorithm, EncryptionState, FrameCryptor},
+    rtp_receiver::RtpReceiver,
+    rtp_sender::RtpSender,
+};
 use parking_lot::Mutex;
-use std::collections::HashMap;
-use std::sync::Arc;
+
+use super::{key_provider::KeyProvider, EncryptionType};
+use crate::{
+    e2ee::E2eeOptions,
+    id::{ParticipantIdentity, TrackSid},
+    participant::{LocalParticipant, RemoteParticipant},
+    prelude::{LocalTrack, LocalTrackPublication, RemoteTrack, RemoteTrackPublication},
+    rtc_engine::lk_runtime::LkRuntime,
+};
 
 type StateChangedHandler = Box<dyn Fn(ParticipantIdentity, EncryptionState) + Send>;
 
@@ -40,7 +45,8 @@ pub struct E2eeManager {
 }
 
 impl E2eeManager {
-    /// E2eeOptions is an optional parameter. We may support to reconfigure e2ee after connect in the future.
+    /// E2eeOptions is an optional parameter. We may support to reconfigure e2ee after connect in
+    /// the future.
     pub(crate) fn new(options: Option<E2eeOptions>) -> Self {
         Self {
             inner: Arc::new(Mutex::new(ManagerInner {
@@ -94,9 +100,7 @@ impl E2eeManager {
         self.setup_cryptor(&frame_cryptor);
 
         let mut inner = self.inner.lock();
-        inner
-            .frame_cryptors
-            .insert((identity, publication.sid()), frame_cryptor.clone());
+        inner.frame_cryptors.insert((identity, publication.sid()), frame_cryptor.clone());
     }
 
     /// Called by the room
@@ -120,9 +124,7 @@ impl E2eeManager {
         self.setup_cryptor(&frame_cryptor);
 
         let mut inner = self.inner.lock();
-        inner
-            .frame_cryptors
-            .insert((identity, publication.sid()), frame_cryptor.clone());
+        inner.frame_cryptors.insert((identity, publication.sid()), frame_cryptor.clone());
     }
 
     fn setup_cryptor(&self, frame_cryptor: &FrameCryptor) {
@@ -179,11 +181,7 @@ impl E2eeManager {
 
     pub fn encryption_type(&self) -> EncryptionType {
         let inner = self.inner.lock();
-        inner
-            .options
-            .as_ref()
-            .map(|opts| opts.encryption_type)
-            .unwrap_or(EncryptionType::None)
+        inner.options.as_ref().map(|opts| opts.encryption_type).unwrap_or(EncryptionType::None)
     }
 
     fn setup_rtp_sender(
@@ -228,8 +226,6 @@ impl E2eeManager {
         log::debug!("removing frame cryptor for {}", participant_identity);
 
         let mut inner = self.inner.lock();
-        inner
-            .frame_cryptors
-            .remove(&(participant_identity, track_sid));
+        inner.frame_cryptors.remove(&(participant_identity, track_sid));
     }
 }

--- a/livekit/src/room/e2ee/manager.rs
+++ b/livekit/src/room/e2ee/manager.rs
@@ -131,7 +131,7 @@ impl E2eeManager {
         let state_changed = self.state_changed.clone();
         frame_cryptor.on_state_change(Some(Box::new(move |participant_identity, state| {
             if let Some(state_changed) = state_changed.lock().as_ref() {
-                state_changed(participant_identity.try_into().unwrap(), state);
+                state_changed(participant_identity.into(), state);
             }
         })));
     }

--- a/livekit/src/room/options.rs
+++ b/livekit/src/room/options.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::prelude::*;
 use libwebrtc::prelude::*;
 use livekit_protocol as proto;
+
+use crate::prelude::*;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum VideoCodec {
@@ -68,9 +69,7 @@ pub struct AudioPreset {
 
 impl AudioPreset {
     pub const fn new(max_bitrate: u64) -> Self {
-        Self {
-            encoding: AudioEncoding { max_bitrate },
-        }
+        Self { encoding: AudioEncoding { max_bitrate } }
     }
 }
 
@@ -103,14 +102,7 @@ impl Default for TrackPublishOptions {
 
 impl VideoPreset {
     pub const fn new(width: u32, height: u32, max_bitrate: u64, max_framerate: f64) -> Self {
-        Self {
-            width,
-            height,
-            encoding: VideoEncoding {
-                max_bitrate,
-                max_framerate,
-            },
-        }
+        Self { width, height, encoding: VideoEncoding { max_bitrate, max_framerate } }
     }
 
     pub fn resolution(&self) -> VideoResolution {
@@ -316,14 +308,8 @@ pub mod audio {
     pub const MUSIC_HIGH_QUALITY: AudioPreset = AudioPreset::new(64_000);
     pub const MUSIC_HIGH_QUALITY_STEREO: AudioPreset = AudioPreset::new(96_000);
 
-    pub const PRESETS: &[AudioPreset] = &[
-        TELEPHONE,
-        SPEECH,
-        MUSIC,
-        MUSIC_STEREO,
-        MUSIC_HIGH_QUALITY,
-        MUSIC_HIGH_QUALITY_STEREO,
-    ];
+    pub const PRESETS: &[AudioPreset] =
+        &[TELEPHONE, SPEECH, MUSIC, MUSIC_STEREO, MUSIC_HIGH_QUALITY, MUSIC_HIGH_QUALITY_STEREO];
 }
 
 pub mod video {

--- a/livekit/src/room/participant/local_participant.rs
+++ b/livekit/src/room/participant/local_participant.rs
@@ -25,7 +25,7 @@ use crate::{
     options::{compute_video_encodings, video_layers_from_encodings, TrackPublishOptions},
     prelude::*,
     rtc_engine::RtcEngine,
-    DataPacket, DataPacketKind,
+    DataPacket,
 };
 
 type LocalTrackPublishedHandler = Box<dyn Fn(LocalParticipant, LocalTrackPublication) + Send>;
@@ -272,7 +272,7 @@ impl LocalParticipant {
 
     pub async fn publish_data(&self, packet: DataPacket) -> RoomResult<()> {
         let data = proto::DataPacket {
-            kind: DataPacketKind::from(packet.kind) as i32,
+            kind: packet.kind as i32,
             value: Some(proto::data_packet::Value::User(proto::UserPacket {
                 payload: packet.payload,
                 topic: packet.topic,

--- a/livekit/src/room/participant/mod.rs
+++ b/livekit/src/room/participant/mod.rs
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::prelude::*;
-use crate::rtc_engine::RtcEngine;
+use std::{collections::HashMap, fmt::Debug, sync::Arc};
+
 use livekit_protocol as proto;
 use livekit_protocol::enum_dispatch;
 use parking_lot::{Mutex, RwLock};
-use std::collections::HashMap;
-use std::fmt::Debug;
-use std::sync::Arc;
+
+use crate::{prelude::*, rtc_engine::RtcEngine};
 
 mod local_participant;
 mod remote_participant;

--- a/livekit/src/room/publication/local.rs
+++ b/livekit/src/room/publication/local.rs
@@ -12,15 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::TrackPublicationInner;
-use crate::e2ee::EncryptionType;
-use crate::options::TrackPublishOptions;
-use crate::prelude::*;
+use std::{fmt::Debug, sync::Arc};
 
 use livekit_protocol as proto;
 use parking_lot::Mutex;
-use std::fmt::Debug;
-use std::sync::Arc;
+
+use super::TrackPublicationInner;
+use crate::{e2ee::EncryptionType, options::TrackPublishOptions, prelude::*};
 
 #[derive(Default)]
 struct LocalInfo {
@@ -117,12 +115,7 @@ impl LocalTrackPublication {
     }
 
     pub fn track(&self) -> Option<LocalTrack> {
-        self.inner
-            .info
-            .read()
-            .track
-            .clone()
-            .map(|track| track.try_into().unwrap())
+        self.inner.info.read().track.clone().map(|track| track.try_into().unwrap())
     }
 
     pub fn mime_type(&self) -> String {

--- a/livekit/src/room/publication/mod.rs
+++ b/livekit/src/room/publication/mod.rs
@@ -117,7 +117,7 @@ pub(super) fn new_inner(
     let info = PublicationInfo {
         track,
         proto_info: info.clone(),
-        source: info.source().try_into().unwrap(),
+        source: info.source().into(),
         kind: info.r#type().try_into().unwrap(),
         encryption_type: info.encryption().into(),
         name: info.name,

--- a/livekit/src/room/publication/mod.rs
+++ b/livekit/src/room/publication/mod.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::track::TrackDimension;
-use crate::track::Track;
-use crate::{e2ee::EncryptionType, prelude::*};
+use std::sync::Arc;
+
 use livekit_protocol as proto;
 use livekit_protocol::enum_dispatch;
 use parking_lot::{Mutex, RwLock};
-use std::sync::Arc;
+
+use super::track::TrackDimension;
+use crate::{e2ee::EncryptionType, prelude::*, track::Track};
 
 mod local;
 mod remote;
@@ -127,10 +128,7 @@ pub(super) fn new_inner(
         muted: info.muted,
     };
 
-    Arc::new(TrackPublicationInner {
-        info: RwLock::new(info),
-        events: Default::default(),
-    })
+    Arc::new(TrackPublicationInner { info: RwLock::new(info), events: Default::default() })
 }
 
 pub(super) fn update_info(

--- a/livekit/src/room/track/audio_track.rs
+++ b/livekit/src/room/track/audio_track.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::track_dispatch;
-use crate::prelude::*;
 use libwebrtc::prelude::*;
 use livekit_protocol as proto;
 use livekit_protocol::enum_dispatch;
+
+use super::track_dispatch;
+use crate::prelude::*;
 
 #[derive(Clone, Debug)]
 pub enum AudioTrack {

--- a/livekit/src/room/track/local_audio_track.rs
+++ b/livekit/src/room/track/local_audio_track.rs
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::TrackInner;
-use crate::prelude::*;
-use crate::rtc_engine::lk_runtime::LkRuntime;
 use core::panic;
-use libwebrtc::prelude::*;
-use libwebrtc::stats::RtcStats;
+use std::{fmt::Debug, sync::Arc};
+
+use libwebrtc::{prelude::*, stats::RtcStats};
 use livekit_protocol as proto;
-use std::fmt::Debug;
-use std::sync::Arc;
+
+use super::TrackInner;
+use crate::{prelude::*, rtc_engine::lk_runtime::LkRuntime};
 
 #[derive(Clone)]
 pub struct LocalAudioTrack {

--- a/livekit/src/room/track/local_track.rs
+++ b/livekit/src/room/track/local_track.rs
@@ -14,12 +14,12 @@
 
 use std::sync::Arc;
 
-use super::{track_dispatch, TrackInner};
-use crate::prelude::*;
-use libwebrtc::prelude::*;
-use libwebrtc::stats::RtcStats;
+use libwebrtc::{prelude::*, stats::RtcStats};
 use livekit_protocol as proto;
 use livekit_protocol::enum_dispatch;
+
+use super::{track_dispatch, TrackInner};
+use crate::prelude::*;
 
 #[derive(Clone, Debug)]
 pub enum LocalTrack {

--- a/livekit/src/room/track/local_video_track.rs
+++ b/livekit/src/room/track/local_video_track.rs
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::TrackInner;
-use crate::prelude::*;
-use crate::rtc_engine::lk_runtime::LkRuntime;
-use libwebrtc::prelude::*;
-use libwebrtc::stats::RtcStats;
+use std::{fmt::Debug, sync::Arc};
+
+use libwebrtc::{prelude::*, stats::RtcStats};
 use livekit_protocol as proto;
-use std::fmt::Debug;
-use std::sync::Arc;
+
+use super::TrackInner;
+use crate::{prelude::*, rtc_engine::lk_runtime::LkRuntime};
 
 #[derive(Clone)]
 pub struct LocalVideoTrack {

--- a/livekit/src/room/track/mod.rs
+++ b/livekit/src/room/track/mod.rs
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::prelude::*;
-use libwebrtc::prelude::*;
-use libwebrtc::stats::RtcStats;
+use std::{fmt::Debug, sync::Arc};
+
+use libwebrtc::{prelude::*, stats::RtcStats};
 use livekit_protocol as proto;
 use livekit_protocol::enum_dispatch;
 use parking_lot::{Mutex, RwLock};
-use std::fmt::Debug;
-use std::sync::Arc;
 use thiserror::Error;
+
+use crate::prelude::*;
 
 mod audio_track;
 mod local_audio_track;

--- a/livekit/src/room/track/remote_audio_track.rs
+++ b/livekit/src/room/track/remote_audio_track.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::{fmt::Debug, sync::Arc};
+
+use libwebrtc::{prelude::*, stats::RtcStats};
+use livekit_protocol as proto;
+
 use super::{remote_track, TrackInner};
 use crate::prelude::*;
-use libwebrtc::prelude::*;
-use libwebrtc::stats::RtcStats;
-use livekit_protocol as proto;
-use std::fmt::Debug;
-use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct RemoteAudioTrack {

--- a/livekit/src/room/track/remote_track.rs
+++ b/livekit/src/room/track/remote_track.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::track_dispatch;
-use super::TrackInner;
-use crate::prelude::*;
-use libwebrtc::prelude::*;
-use libwebrtc::stats::RtcStats;
+use std::sync::Arc;
+
+use libwebrtc::{prelude::*, stats::RtcStats};
 use livekit_protocol as proto;
 use livekit_protocol::enum_dispatch;
-use std::sync::Arc;
+
+use super::{track_dispatch, TrackInner};
+use crate::prelude::*;
 
 #[derive(Clone, Debug)]
 pub enum RemoteTrack {

--- a/livekit/src/room/track/remote_video_track.rs
+++ b/livekit/src/room/track/remote_video_track.rs
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::remote_track;
-use super::TrackInner;
-use crate::prelude::*;
-use libwebrtc::prelude::*;
-use libwebrtc::stats::RtcStats;
+use std::{fmt::Debug, sync::Arc};
+
+use libwebrtc::{prelude::*, stats::RtcStats};
 use livekit_protocol as proto;
-use std::fmt::Debug;
-use std::sync::Arc;
+
+use super::{remote_track, TrackInner};
+use crate::prelude::*;
 
 #[derive(Clone)]
 pub struct RemoteVideoTrack {

--- a/livekit/src/room/track/video_track.rs
+++ b/livekit/src/room/track/video_track.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::track_dispatch;
-use crate::prelude::*;
 use libwebrtc::prelude::*;
 use livekit_protocol as proto;
 use livekit_protocol::enum_dispatch;
+
+use super::track_dispatch;
+use crate::prelude::*;
 
 #[derive(Clone, Debug)]
 pub enum VideoTrack {

--- a/livekit/src/rtc_engine/lk_runtime.rs
+++ b/livekit/src/rtc_engine/lk_runtime.rs
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::{
+    fmt::{Debug, Formatter},
+    sync::{Arc, Weak},
+};
+
 use lazy_static::lazy_static;
 use libwebrtc::prelude::*;
 use parking_lot::Mutex;
-use std::fmt::{Debug, Formatter};
-use std::sync::{Arc, Weak};
 
 lazy_static! {
     static ref LK_RUNTIME: Mutex<Weak<LkRuntime>> = Mutex::new(Weak::new());
@@ -39,9 +42,7 @@ impl LkRuntime {
             lk_runtime
         } else {
             log::debug!("LkRuntime::new()");
-            let new_runtime = Arc::new(Self {
-                pc_factory: PeerConnectionFactory::default(),
-            });
+            let new_runtime = Arc::new(Self { pc_factory: PeerConnectionFactory::default() });
             *lk_runtime_ref = Arc::downgrade(&new_runtime);
             new_runtime
         }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,10 @@
+comment_width = 100
+doc_comment_code_block_width = 100
+format_code_in_doc_comments = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+max_width = 100
+use_small_heuristics = "Max"
+wrap_comments = true
+# Workaround for https://github.com/rust-lang/rust.vim/issues/464
+edition = "2021"

--- a/webrtc-sys/build.rs
+++ b/webrtc-sys/build.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::env;
-use std::path;
-use std::process::Command;
+use std::{env, path, process::Command};
 
 fn main() {
     if env::var("DOCS_RS").is_ok() {
@@ -93,10 +91,7 @@ fn main() {
         webrtc_include.join("sdk/objc/base"),
     ]);
 
-    println!(
-        "cargo:rustc-link-search=native={}",
-        webrtc_lib.to_str().unwrap()
-    );
+    println!("cargo:rustc-link-search=native={}", webrtc_lib.to_str().unwrap());
 
     for (key, value) in webrtc_sys_build::webrtc_defines() {
         let value = value.as_deref();
@@ -157,10 +152,7 @@ fn main() {
 
             configure_darwin_sysroot(&mut builder);
 
-            builder
-                .file("src/objc_video_factory.mm")
-                .flag("-stdlib=libc++")
-                .flag("-std=c++20");
+            builder.file("src/objc_video_factory.mm").flag("-stdlib=libc++").flag("-std=c++20");
         }
         "ios" => {
             println!("cargo:rustc-link-lib=framework=CoreFoundation");
@@ -192,10 +184,7 @@ fn main() {
 
             configure_android_sysroot(&mut builder);
 
-            builder
-                .file("src/android.cpp")
-                .flag("-std=c++20")
-                .cpp_link_stdlib("c++_static");
+            builder.file("src/android.cpp").flag("-std=c++20").cpp_link_stdlib("c++_static");
         }
         _ => {
             panic!("Unsupported target, {}", target_os);
@@ -239,18 +228,12 @@ fn configure_darwin_sysroot(builder: &mut cc::Build) {
     println!("cargo:rustc-link-lib={}", clang_rt);
     println!("cargo:rustc-link-arg=-ObjC");
 
-    let sysroot = Command::new("xcrun")
-        .args(["--sdk", sdk, "--show-sdk-path"])
-        .output()
-        .unwrap();
+    let sysroot = Command::new("xcrun").args(["--sdk", sdk, "--show-sdk-path"]).output().unwrap();
 
     let sysroot = String::from_utf8_lossy(&sysroot.stdout);
     let sysroot = sysroot.trim();
 
-    let search_dirs = Command::new("clang")
-        .arg("--print-search-dirs")
-        .output()
-        .unwrap();
+    let search_dirs = Command::new("clang").arg("--print-search-dirs").output().unwrap();
 
     let search_dirs = String::from_utf8_lossy(&search_dirs.stdout);
     for line in search_dirs.lines() {

--- a/webrtc-sys/build/src/lib.rs
+++ b/webrtc-sys/build/src/lib.rs
@@ -83,8 +83,8 @@ pub fn custom_dir() -> Option<path::PathBuf> {
 }
 
 /// Location of the downloaded webrtc binaries
-/// The reason why we don't use OUT_DIR is because we sometimes need to share the same binaries across multiple crates
-/// without dependencies constraints
+/// The reason why we don't use OUT_DIR is because we sometimes need to share the same binaries
+/// across multiple crates without dependencies constraints
 /// This also has the benefit of not re-downloading the binaries for each crate
 pub fn prebuilt_dir() -> path::PathBuf {
     let target_dir = scratch::path(SCRATH_PATH);
@@ -119,9 +119,7 @@ pub fn webrtc_defines() -> Vec<(String, Option<String>)> {
     let webrtc_gni = fs::File::open(webrtc_dir().join("webrtc.ninja")).unwrap();
 
     let mut defines_line = String::default();
-    io::BufReader::new(webrtc_gni)
-        .read_line(&mut defines_line)
-        .unwrap();
+    io::BufReader::new(webrtc_gni).read_line(&mut defines_line).unwrap();
 
     let mut vec = Vec::default();
     for cap in defines_re.captures_iter(&defines_line) {
@@ -157,10 +155,8 @@ pub fn configure_jni_symbols() -> Result<(), Box<dyn Error>> {
 
     let jni_regex = Regex::new(r"(Java_org_webrtc.*)").unwrap();
     let content = String::from_utf8_lossy(&readelf_output.stdout);
-    let jni_symbols: Vec<&str> = jni_regex
-        .captures_iter(&content)
-        .map(|cap| cap.get(1).unwrap().as_str())
-        .collect();
+    let jni_symbols: Vec<&str> =
+        jni_regex.captures_iter(&content).map(|cap| cap.get(1).unwrap().as_str()).collect();
 
     if jni_symbols.is_empty() {
         return Err("No JNI symbols found".into()); // Shouldn't happen
@@ -178,10 +174,7 @@ pub fn configure_jni_symbols() -> Result<(), Box<dyn Error>> {
     let jni_symbols = jni_symbols.join("; ");
     write!(vs_file, "JNI_WEBRTC {{\n\tglobal: {}; \n}};", jni_symbols).unwrap();
 
-    println!(
-        "cargo:rustc-link-arg=-Wl,--version-script={}",
-        vs_path.display()
-    );
+    println!("cargo:rustc-link-arg=-Wl,--version-script={}", vs_path.display());
 
     Ok(())
 }
@@ -203,11 +196,7 @@ pub fn download_webrtc() -> Result<(), Box<dyn Error>> {
 
     let tmp_path = env::var("OUT_DIR").unwrap() + "/webrtc.zip";
     let tmp_path = path::Path::new(&tmp_path);
-    let mut file = fs::File::options()
-        .write(true)
-        .read(true)
-        .create(true)
-        .open(tmp_path)?;
+    let mut file = fs::File::options().write(true).read(true).create(true).open(tmp_path)?;
     resp.copy_to(&mut file)?;
 
     let mut archive = zip::ZipArchive::new(file)?;

--- a/webrtc-sys/src/audio_track.rs
+++ b/webrtc-sys/src/audio_track.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::impl_thread_safety;
 use std::sync::Arc;
+
+use crate::impl_thread_safety;
 
 #[cxx::bridge(namespace = "livekit")]
 pub mod ffi {
@@ -88,7 +89,6 @@ impl AudioSinkWrapper {
     }
 
     fn on_data(&self, data: &[i16], sample_rate: i32, nb_channels: usize, nb_frames: usize) {
-        self.observer
-            .on_data(data, sample_rate, nb_channels, nb_frames);
+        self.observer.on_data(data, sample_rate, nb_channels, nb_frames);
     }
 }

--- a/webrtc-sys/src/data_channel.rs
+++ b/webrtc-sys/src/data_channel.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::impl_thread_safety;
 use std::sync::Arc;
+
+use crate::impl_thread_safety;
 
 #[cxx::bridge(namespace = "livekit")]
 pub mod ffi {

--- a/webrtc-sys/src/frame_cryptor.rs
+++ b/webrtc-sys/src/frame_cryptor.rs
@@ -161,7 +161,6 @@ impl RtcFrameCryptorObserverWrapper {
         participant_id: String,
         state: FrameCryptionState,
     ) {
-        self.observer
-            .on_frame_cryption_state_change(participant_id, state);
+        self.observer.on_frame_cryption_state_change(participant_id, state);
     }
 }

--- a/webrtc-sys/src/jsep.rs
+++ b/webrtc-sys/src/jsep.rs
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::{
+    error::Error,
+    fmt::{Display, Formatter},
+};
+
 use crate::impl_thread_safety;
-use std::error::Error;
-use std::fmt::{Display, Formatter};
 
 #[cxx::bridge(namespace = "livekit")]
 pub mod ffi {
@@ -74,11 +77,7 @@ impl Error for ffi::SdpParseError {}
 
 impl Display for ffi::SdpParseError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "SdpParseError occurred {}: {}",
-            self.line, self.description
-        )
+        write!(f, "SdpParseError occurred {}: {}", self.line, self.description)
     }
 }
 

--- a/webrtc-sys/src/lib.rs
+++ b/webrtc-sys/src/lib.rs
@@ -18,6 +18,7 @@ pub mod audio_resampler;
 pub mod audio_track;
 pub mod candidate;
 pub mod data_channel;
+pub mod frame_cryptor;
 pub mod helper;
 pub mod jsep;
 pub mod media_stream;
@@ -34,7 +35,6 @@ pub mod video_frame_buffer;
 pub mod video_track;
 pub mod webrtc;
 pub mod yuv_helper;
-pub mod frame_cryptor;
 
 pub const MEDIA_TYPE_VIDEO: &str = "video";
 pub const MEDIA_TYPE_AUDIO: &str = "audio";

--- a/webrtc-sys/src/peer_connection.rs
+++ b/webrtc-sys/src/peer_connection.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::impl_thread_safety;
 use std::any::Any;
+
+use crate::impl_thread_safety;
 
 #[cxx::bridge(namespace = "livekit")]
 pub mod ffi {

--- a/webrtc-sys/src/peer_connection_factory.rs
+++ b/webrtc-sys/src/peer_connection_factory.rs
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::candidate::ffi::Candidate;
-use crate::data_channel::ffi::DataChannel;
-use crate::impl_thread_safety;
-use crate::jsep::ffi::IceCandidate;
-use crate::media_stream::ffi::MediaStream;
-use crate::rtp_receiver::ffi::RtpReceiver;
-use crate::rtp_transceiver::ffi::RtpTransceiver;
-use cxx::SharedPtr;
 use std::sync::Arc;
+
+use cxx::SharedPtr;
+
+use crate::{
+    candidate::ffi::Candidate, data_channel::ffi::DataChannel, impl_thread_safety,
+    jsep::ffi::IceCandidate, media_stream::ffi::MediaStream, rtp_receiver::ffi::RtpReceiver,
+    rtp_transceiver::ffi::RtpTransceiver,
+};
 
 #[cxx::bridge(namespace = "livekit")]
 pub mod ffi {
@@ -251,8 +251,7 @@ impl PeerConnectionObserverWrapper {
     }
 
     fn on_standardized_ice_connection_change(&self, new_state: ffi::IceConnectionState) {
-        self.observer
-            .on_standardized_ice_connection_change(new_state);
+        self.observer.on_standardized_ice_connection_change(new_state);
     }
 
     fn on_connection_change(&self, new_state: ffi::PeerConnectionState) {
@@ -275,13 +274,11 @@ impl PeerConnectionObserverWrapper {
         error_code: i32,
         error_text: String,
     ) {
-        self.observer
-            .on_ice_candidate_error(address, port, url, error_code, error_text);
+        self.observer.on_ice_candidate_error(address, port, url, error_code, error_text);
     }
 
     fn on_ice_candidates_removed(&self, candidates: Vec<ffi::CandidatePtr>) {
-        self.observer
-            .on_ice_candidates_removed(candidates.into_iter().map(|v| v.ptr).collect());
+        self.observer.on_ice_candidates_removed(candidates.into_iter().map(|v| v.ptr).collect());
     }
 
     fn on_ice_connection_receiving_change(&self, receiving: bool) {
@@ -293,8 +290,7 @@ impl PeerConnectionObserverWrapper {
     }
 
     fn on_add_track(&self, receiver: SharedPtr<RtpReceiver>, streams: Vec<ffi::MediaStreamPtr>) {
-        self.observer
-            .on_add_track(receiver, streams.into_iter().map(|v| v.ptr).collect());
+        self.observer.on_add_track(receiver, streams.into_iter().map(|v| v.ptr).collect());
     }
 
     fn on_track(&self, transceiver: SharedPtr<RtpTransceiver>) {

--- a/webrtc-sys/src/rtc_error.rs
+++ b/webrtc-sys/src/rtc_error.rs
@@ -117,7 +117,7 @@ mod tests {
 
         assert_eq!(error.error_type, RtcErrorType::InternalError);
         assert_eq!(error.error_detail, RtcErrorDetailType::DataChannelFailure);
-        assert_eq!(error.has_sctp_cause_code, true);
+        assert!(error.has_sctp_cause_code);
         assert_eq!(error.sctp_cause_code, 24);
         assert_eq!(error.message, "this is not a test, I repeat, this is not a test");
     }
@@ -129,7 +129,7 @@ mod tests {
 
         assert_eq!(error.error_type, RtcErrorType::InvalidModification);
         assert_eq!(error.error_detail, RtcErrorDetailType::None);
-        assert_eq!(error.has_sctp_cause_code, false);
+        assert!(!error.has_sctp_cause_code);
         assert_eq!(error.sctp_cause_code, 0);
         assert_eq!(error.message, "exception is thrown!");
     }

--- a/webrtc-sys/src/rtc_error.rs
+++ b/webrtc-sys/src/rtc_error.rs
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::error::Error;
-use std::fmt::{Display, Formatter};
+use std::{
+    error::Error,
+    fmt::{Display, Formatter},
+};
 
-// cxx doesn't support custom Exception type, so we serialize RtcError inside the cxx::Exception "what" string
+// cxx doesn't support custom Exception type, so we serialize RtcError inside the cxx::Exception
+// "what" string
 
 #[cxx::bridge(namespace = "livekit")]
 pub mod ffi {
@@ -89,11 +92,7 @@ impl Error for ffi::RtcError {}
 
 impl Display for ffi::RtcError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "RtcError occurred {:?}: {}",
-            self.error_type, self.message
-        )
+        write!(f, "RtcError occurred {:?}: {}", self.error_type, self.message)
     }
 }
 
@@ -120,10 +119,7 @@ mod tests {
         assert_eq!(error.error_detail, RtcErrorDetailType::DataChannelFailure);
         assert_eq!(error.has_sctp_cause_code, true);
         assert_eq!(error.sctp_cause_code, 24);
-        assert_eq!(
-            error.message,
-            "this is not a test, I repeat, this is not a test"
-        );
+        assert_eq!(error.message, "this is not a test, I repeat, this is not a test");
     }
 
     #[test]

--- a/webrtc-sys/src/rtp_receiver.rs
+++ b/webrtc-sys/src/rtp_receiver.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::impl_thread_safety;
 use std::any::Any;
+
+use crate::impl_thread_safety;
 
 #[cxx::bridge(namespace = "livekit")]
 pub mod ffi {

--- a/webrtc-sys/src/rtp_sender.rs
+++ b/webrtc-sys/src/rtp_sender.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::impl_thread_safety;
 use std::any::Any;
+
+use crate::impl_thread_safety;
 
 #[cxx::bridge(namespace = "livekit")]
 pub mod ffi {

--- a/webrtc-sys/src/video_track.rs
+++ b/webrtc-sys/src/video_track.rs
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::impl_thread_safety;
-use crate::video_frame::ffi::VideoFrame;
-use cxx::UniquePtr;
 use std::sync::Arc;
+
+use cxx::UniquePtr;
+
+use crate::{impl_thread_safety, video_frame::ffi::VideoFrame};
 
 #[cxx::bridge(namespace = "livekit")]
 pub mod ffi {


### PR DESCRIPTION
So that contributions from multiple people are more consistent w.r.t. code style and formatting 🙂 

Note, that this one does not include all of the `cargo clippy` fixes since there are quite a few of them that require manual intervention. I did not want to make them part of this PR (since unlike the rest of the changes these would not be automated, hence would require a more rigorous review of whether the user-written code changes anything).

Also, `cargo check` still produces 3 warnings that I did not fix as they would need some minor changes:
- `RemoteTrackPublication::on_subscription_status_changed` and `RemoteTrackPublication::on_permission_status_changed` are `pub(crate)` and never used within a crate. I was not sure if I'm allowed to remove them (since we don't use them) or if I need to make them `pub` (that would require making the rest of the things `pub` as well, for consistency).
- `RtcSession::publisher()` is `pub`, but never used (not sure why it complains about it given that it is `pub`, perhaps it's never exported or something).

Also I added a tiny simple job to check the formatting so that we can keep it consistent.