### PR TITLE
API for pre-encoded audio tracks

### DIFF
--- a/examples/play_from_disk/Cargo.lock
+++ b/examples/play_from_disk/Cargo.lock
@@ -756,7 +756,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libwebrtc"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "cxx",
  "jni",
@@ -794,7 +794,7 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "livekit"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "livekit-api"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "futures-util",
  "http",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "livekit-protocol"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "futures-util",
  "livekit-runtime",
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "webrtc-sys"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "cc",
  "cxx",
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "webrtc-sys-build"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "fs2",
  "regex",

--- a/examples/play_from_disk/src/main.rs
+++ b/examples/play_from_disk/src/main.rs
@@ -131,7 +131,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
         header.num_channels as u32,
     );
 
-    let track = LocalAudioTrack::create_audio_track("file", RtcAudioSource::Native(source.clone()));
+    let native_source = RtcAudioSource::Native(source.clone());
+    // ...just to show an API and emphasis the source is *not* pre-encoded,
+    // otherwise set pre_encoded = true
+    native_source.set_audio_options(AudioSourceOptions{
+        pre_encoded: false,
+        ..Default::default()
+    });
+
+    let track = LocalAudioTrack::create_audio_track("file", native_source);
 
     room.local_participant()
         .publish_track(

--- a/examples/save_to_disk/Cargo.toml
+++ b/examples/save_to_disk/Cargo.toml
@@ -11,3 +11,5 @@ livekit = { path = "../../livekit", version = "0.3.2" }
 bytes = "1.4.0"
 tokio-util = "0.7.8"
 futures = "0.3.28"
+
+[workspace]

--- a/libwebrtc/src/audio_source.rs
+++ b/libwebrtc/src/audio_source.rs
@@ -21,6 +21,7 @@ pub struct AudioSourceOptions {
     pub echo_cancellation: bool,
     pub noise_suppression: bool,
     pub auto_gain_control: bool,
+    pub pre_encoded: bool,
 }
 
 #[non_exhaustive]
@@ -33,10 +34,10 @@ pub enum RtcAudioSource {
 impl RtcAudioSource {
     enum_dispatch!(
         [Native];
-        fn set_audio_options(self: &Self, options: AudioSourceOptions) -> ();
-        fn audio_options(self: &Self) -> AudioSourceOptions;
-        fn sample_rate(self: &Self) -> u32;
-        fn num_channels(self: &Self) -> u32;
+        pub fn set_audio_options(self: &Self, options: AudioSourceOptions) -> ();
+        pub fn audio_options(self: &Self) -> AudioSourceOptions;
+        pub fn sample_rate(self: &Self) -> u32;
+        pub fn num_channels(self: &Self) -> u32;
     );
 }
 

--- a/libwebrtc/src/native/audio_source.rs
+++ b/libwebrtc/src/native/audio_source.rs
@@ -177,6 +177,7 @@ impl From<sys_at::ffi::AudioSourceOptions> for AudioSourceOptions {
             echo_cancellation: options.echo_cancellation,
             noise_suppression: options.noise_suppression,
             auto_gain_control: options.auto_gain_control,
+            pre_encoded: options.pre_encoded,
         }
     }
 }
@@ -187,6 +188,7 @@ impl From<AudioSourceOptions> for sys_at::ffi::AudioSourceOptions {
             echo_cancellation: options.echo_cancellation,
             noise_suppression: options.noise_suppression,
             auto_gain_control: options.auto_gain_control,
+            pre_encoded: options.pre_encoded,
         }
     }
 }

--- a/livekit-ffi/protocol/audio_frame.proto
+++ b/livekit-ffi/protocol/audio_frame.proto
@@ -36,9 +36,9 @@ message NewAudioSourceRequest {
 }
 message NewAudioSourceResponse { OwnedAudioSource source = 1; }
 
-// Push a frame to an AudioSource 
+// Push a frame to an AudioSource
 // The data provided must be available as long as the client receive the callback.
-message CaptureAudioFrameRequest { 
+message CaptureAudioFrameRequest {
   uint64 source_handle = 1;
   AudioFrameBufferInfo buffer = 2;
 }
@@ -104,7 +104,7 @@ message OwnedAudioStream {
 
 message AudioStreamEvent {
   uint64 stream_handle = 1;
-  oneof message { 
+  oneof message {
     AudioFrameReceived frame_received = 2;
     AudioStreamEOS eos = 3;
   }
@@ -124,6 +124,7 @@ message AudioSourceOptions {
   bool echo_cancellation = 1;
   bool noise_suppression = 2;
   bool auto_gain_control = 3;
+  bool pre_encoded = 4;
 }
 
 enum AudioSourceType {

--- a/livekit-ffi/src/conversion/audio_frame.rs
+++ b/livekit-ffi/src/conversion/audio_frame.rs
@@ -25,6 +25,7 @@ impl From<proto::AudioSourceOptions> for AudioSourceOptions {
             echo_cancellation: opts.echo_cancellation,
             auto_gain_control: opts.auto_gain_control,
             noise_suppression: opts.noise_suppression,
+            pre_encoded: opts.pre_encoded,
         }
     }
 }

--- a/livekit-ffi/src/livekit.proto.rs
+++ b/livekit-ffi/src/livekit.proto.rs
@@ -303,11 +303,11 @@ impl EncryptionState {
 /// # Safety
 /// The foreign language is responsable for disposing handles
 /// Forgetting to dispose the handle may lead to memory leaks
-/// 
+///
 /// Dropping a handle doesn't necessarily mean that the object is destroyed if it is still used
 /// on the FfiServer (Atomic reference counting)
-/// 
-/// When refering to a handle without owning it, we just use a uint32 without this message. 
+///
+/// When refering to a handle without owning it, we just use a uint32 without this message.
 /// (the variable name is suffixed with "_handle")
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1549,7 +1549,7 @@ pub struct NewVideoSourceRequest {
     #[prost(enumeration="VideoSourceType", tag="1")]
     pub r#type: i32,
     /// Used to determine which encodings to use + simulcast layers
-    /// Most of the time it corresponds to the source resolution 
+    /// Most of the time it corresponds to the source resolution
     #[prost(message, optional, tag="2")]
     pub resolution: ::core::option::Option<VideoSourceResolution>,
 }
@@ -2716,7 +2716,7 @@ pub struct NewAudioSourceResponse {
     #[prost(message, optional, tag="1")]
     pub source: ::core::option::Option<OwnedAudioSource>,
 }
-/// Push a frame to an AudioSource 
+/// Push a frame to an AudioSource
 /// The data provided must be available as long as the client receive the callback.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2851,6 +2851,8 @@ pub struct AudioSourceOptions {
     pub noise_suppression: bool,
     #[prost(bool, tag="3")]
     pub auto_gain_control: bool,
+    #[prost(bool, tag="4")]
+    pub pre_encoded: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2955,7 +2957,7 @@ impl AudioSourceType {
 //    that it receives from the server.
 //
 // Therefore, the ffi client is easier to implement if there is less handles to manage.
-// 
+//
 // - We are mainly using FfiHandle on info messages (e.g: RoomInfo, TrackInfo, etc...)
 //    For this reason, info are only sent once, at creation (We're not using them for updates, we can infer them from
 //    events on the client implementation).

--- a/livekit-protocol/Cargo.toml
+++ b/livekit-protocol/Cargo.toml
@@ -7,8 +7,8 @@ description = "Livekit protocol and utilities for the Rust SDK"
 repository = "https://github.com/livekit/rust-sdks"
 
 [dependencies]
-livekit-runtime = { path = "../livekit-runtime", version = "0.3.0" }
-tokio = { version = "1", default-features = false, features = [ "sync", "macros" ] }
+livekit-runtime = { path = "../livekit-runtime", version = "0.3.0", features = [ "tokio" ] }
+tokio = { version = "1", default-features = false, features = [ "sync", "macros", "time", "net" ] }
 futures-util = { version = "0.3", features = ["sink"] }
 parking_lot = "0.12"
 prost = "0.12"

--- a/webrtc-sys/src/audio_device.cpp
+++ b/webrtc-sys/src/audio_device.cpp
@@ -16,9 +16,9 @@
 
 #include "livekit/audio_device.h"
 
-const int kBytesPerSample = 2;
 const int kSampleRate = 48000;
 const int kChannels = 2;
+const int kBytesPerSample = kChannels * sizeof(int16_t);
 const int kSamplesPer10Ms = kSampleRate / 100;
 
 namespace livekit {

--- a/webrtc-sys/src/audio_track.cpp
+++ b/webrtc-sys/src/audio_track.cpp
@@ -39,6 +39,7 @@ inline cricket::AudioOptions to_native_audio_options(
   rtc_options.echo_cancellation = options.echo_cancellation;
   rtc_options.noise_suppression = options.noise_suppression;
   rtc_options.auto_gain_control = options.auto_gain_control;
+  rtc_options.pre_encoded = options.pre_encoded;
   return rtc_options;
 }
 
@@ -48,6 +49,7 @@ inline AudioSourceOptions to_rust_audio_options(
   options.echo_cancellation = rtc_options.echo_cancellation.value_or(false);
   options.noise_suppression = rtc_options.noise_suppression.value_or(false);
   options.auto_gain_control = rtc_options.auto_gain_control.value_or(false);
+  options.pre_encoded = rtc_options.pre_encoded.value_or(false);
   return options;
 }
 

--- a/webrtc-sys/src/audio_track.rs
+++ b/webrtc-sys/src/audio_track.rs
@@ -23,6 +23,7 @@ pub mod ffi {
         pub echo_cancellation: bool,
         pub noise_suppression: bool,
         pub auto_gain_control: bool,
+        pub pre_encoded: bool,
     }
 
     extern "C++" {


### PR DESCRIPTION
This PR contains small changes in API - exports `pre_encoded` option for `AudioOptions`, so we can propagate this information down to encoders (webrtc C++ library).

Note: This PR can be merged iff we merge similar API changes in webrtc (https://github.com/webrtc-sdk/webrtc/pull/120)