### PR TITLE
Fix hardcoded kBytesPerSample

### DIFF
--- a/webrtc-sys/src/audio_device.cpp
+++ b/webrtc-sys/src/audio_device.cpp
@@ -16,9 +16,9 @@
 
 #include "livekit/audio_device.h"
 
-const int kBytesPerSample = 2;
 const int kSampleRate = 48000;
 const int kChannels = 2;
+const int kBytesPerSample = kChannels * sizeof(int16_t);
 const int kSamplesPer10Ms = kSampleRate / 100;
 
 namespace livekit {


### PR DESCRIPTION
Hardcoded:
```
kBytesPerSample = 2;
kChannels = 2;
```

Does not follow webrtc assert in `AudioTransportImpl::NeedMorePlayData`:
```
RTC_DCHECK_EQ(sizeof(int16_t) * nChannels, nBytesPerSample);
```

so the fix follows the same convention as we have in webrtc ` AudioDeviceBuffer::RequestPlayoutData`:
```
  const size_t bytes_per_frame = play_channels_ * sizeof(int16_t);
```