### PR TITLE
Correct issue that prevented publish_track from respecting the user defined video_encoding parameters

### DIFF
--- a/livekit/src/room/options.rs
+++ b/livekit/src/room/options.rs
@@ -125,7 +125,13 @@ pub fn compute_video_encodings(
     let screenshare = options.source == TrackSource::Screenshare;
     let video_encoding = options.video_encoding.clone();
 
-    let encoding = compute_appropriate_encoding(screenshare, width, height, options.video_codec, video_encoding);
+    let encoding = compute_appropriate_encoding(
+        screenshare,
+        width,
+        height,
+        options.video_codec,
+        video_encoding
+    );
 
     let initial_preset = VideoPreset {
         width,
@@ -190,7 +196,7 @@ pub fn compute_appropriate_encoding(
 
     if override_encoding.is_some() {
         let override_enc = override_encoding.unwrap();
-        
+
         if override_enc.max_bitrate > 0 {
             encoding.max_bitrate = override_enc.max_bitrate;
         }


### PR DESCRIPTION
Hello everyone!

When publishing a track, with the following code

```
let bitrate = 30_000_000;
let framerate: f64 = 60.0;

local_participant
    .publish_track(
        LocalTrack::Video(track.clone()),
        TrackPublishOptions {
            source: TrackSource::Camera,
            video_codec: VideoCodec::VP9,
            video_encoding: Some(VideoEncoding {
                max_bitrate: bitrate,
                max_framerate: framerate,
            }),
            dtx: false,
            red: false,
            simulcast: false,
            ..Default::default()
        },
    )
    .await
    .unwrap();
```

We determined that tracks were always getting limited to 30fps and approx 4mbps. After digging into the `publish_track` method it was determined that the user defined `video_encoding` parameters were getting thrown out in favor of the defaults.

This PR modifies the `compute_appropriate_encoding` to properly take into account the user defined encoding settings. After making this change we were able to reliably push 60fps @ 30mbps using VP8/VP9/AV1 and are no longer running into a cap.
