### PR TITLE
Avoid tokio-stream dependency when using a runtime other than tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,7 +1505,6 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-stream",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -1639,6 +1638,7 @@ dependencies = [
  "async-task",
  "futures",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/libwebrtc/Cargo.toml
+++ b/libwebrtc/Cargo.toml
@@ -23,7 +23,6 @@ livekit-runtime = { path = "../livekit-runtime", version = "0.3.0" }
 lazy_static = "1.4"
 parking_lot = { version = "0.12" }
 tokio = { version = "1", default-features = false, features = ["sync", "macros"] }
-tokio-stream = "0.1.14"
 cxx = "1.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/libwebrtc/src/audio_stream.rs
+++ b/libwebrtc/src/audio_stream.rs
@@ -22,7 +22,7 @@ pub mod native {
         task::{Context, Poll},
     };
 
-    use tokio_stream::Stream;
+    use livekit_runtime::Stream;
 
     use super::stream_imp;
     use crate::{audio_frame::AudioFrame, audio_track::RtcAudioTrack};

--- a/libwebrtc/src/native/audio_stream.rs
+++ b/libwebrtc/src/native/audio_stream.rs
@@ -19,8 +19,8 @@ use std::{
 };
 
 use cxx::SharedPtr;
+use livekit_runtime::Stream;
 use tokio::sync::mpsc;
-use tokio_stream::Stream;
 use webrtc_sys::audio_track as sys_at;
 
 use crate::{audio_frame::AudioFrame, audio_track::RtcAudioTrack};

--- a/libwebrtc/src/native/peer_connection_factory.rs
+++ b/libwebrtc/src/native/peer_connection_factory.rs
@@ -107,8 +107,8 @@ impl PeerConnectionFactory {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_peer_connection_factory() {
+    #[tokio::test]
+    async fn test_peer_connection_factory() {
         let _ = env_logger::builder().is_test(true).try_init();
 
         let factory = PeerConnectionFactory::default();

--- a/libwebrtc/src/native/video_stream.rs
+++ b/libwebrtc/src/native/video_stream.rs
@@ -19,8 +19,8 @@ use std::{
 };
 
 use cxx::{SharedPtr, UniquePtr};
+use livekit_runtime::Stream;
 use tokio::sync::mpsc;
-use tokio_stream::Stream;
 use webrtc_sys::video_track as sys_vt;
 
 use super::video_frame::new_video_frame_buffer;

--- a/libwebrtc/src/video_stream.rs
+++ b/libwebrtc/src/video_stream.rs
@@ -25,10 +25,9 @@ pub mod native {
         task::{Context, Poll},
     };
 
-    use tokio_stream::Stream;
-
     use super::stream_imp;
     use crate::{video_frame::BoxVideoFrame, video_track::RtcVideoTrack};
+    use livekit_runtime::Stream;
 
     pub struct NativeVideoStream {
         pub(crate) handle: stream_imp::NativeVideoStream,

--- a/livekit-runtime/Cargo.toml
+++ b/livekit-runtime/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 repository = "https://github.com/livekit/rust-sdks"
 
 [features]
-tokio = ["dep:tokio"]
+tokio = ["dep:tokio", "dep:tokio-stream"]
 async = [
     "dep:async-std",
     "dep:futures",
@@ -21,6 +21,7 @@ tokio = { version = "1", default-features = false, optional = true, features = [
     "rt",
     "rt-multi-thread",
 ] }
+tokio-stream = { version = "0.1.14", optional = true }
 
 # dispatcher and async-std
 async-std = { version = "1", optional = true }

--- a/livekit-runtime/src/async_std.rs
+++ b/livekit-runtime/src/async_std.rs
@@ -1,10 +1,11 @@
+use futures::{Future, FutureExt, StreamExt};
 use std::time::Duration;
-pub type JoinHandle<T> = async_std::task::JoinHandle<T>;
-// async_std::future::timeout uses async_io under the hood
+
 pub use async_std::future::timeout;
 pub use async_std::net::TcpStream;
 pub use async_std::task::spawn;
-use futures::{Future, FutureExt, StreamExt};
+pub use async_std::task::JoinHandle;
+pub use futures::Stream;
 pub use std::time::Instant;
 
 /// This is semantically equivalent to Tokio's MissedTickBehavior:

--- a/livekit-runtime/src/dispatcher.rs
+++ b/livekit-runtime/src/dispatcher.rs
@@ -3,6 +3,7 @@ use std::{sync::OnceLock, task::Poll, time::Duration};
 
 pub use async_std::net::TcpStream;
 pub use async_task::Runnable;
+pub use futures::Stream;
 pub use std::time::Instant;
 
 /// This is semantically equivalent to Tokio's MissedTickBehavior:

--- a/livekit-runtime/src/tokio.rs
+++ b/livekit-runtime/src/tokio.rs
@@ -7,6 +7,7 @@ pub use tokio::time::sleep;
 pub use tokio::time::timeout;
 pub use tokio::time::Instant;
 pub use tokio::time::MissedTickBehavior;
+pub use tokio_stream::Stream;
 
 pub type JoinHandle<T> = TokioJoinHandle<T>;
 pub type Interval = tokio::time::Interval;


### PR DESCRIPTION
This is a follow-up to https://github.com/livekit/rust-sdks/pull/310

When building the main `livekit` crate the `async` or `dispatcher` features  (as opposed to the default `tokio` feature), we already have a dependency on the `futures` crate, which provides the `Stream` trait, so we don't need a dependency on `tokio-stream`.

As a drive-by, I fixed a test that was failing in CI due to a  missing `tokio` runtime, by applying the `tokio::test` macro to that test (which sets up a tokio runtime automatically).