### PR TITLE
Add enable_queue for AudioSourceOptions.

### DIFF
--- a/libwebrtc/src/audio_source.rs
+++ b/libwebrtc/src/audio_source.rs
@@ -21,7 +21,7 @@ pub struct AudioSourceOptions {
     pub echo_cancellation: bool,
     pub noise_suppression: bool,
     pub auto_gain_control: bool,
-    pub disable_silent_frames: bool,
+    pub enable_queue: bool,
 }
 
 #[non_exhaustive]

--- a/libwebrtc/src/audio_source.rs
+++ b/libwebrtc/src/audio_source.rs
@@ -21,6 +21,7 @@ pub struct AudioSourceOptions {
     pub echo_cancellation: bool,
     pub noise_suppression: bool,
     pub auto_gain_control: bool,
+    pub disable_silent_frames: bool,
 }
 
 #[non_exhaustive]

--- a/libwebrtc/src/native/audio_source.rs
+++ b/libwebrtc/src/native/audio_source.rs
@@ -95,17 +95,16 @@ impl NativeAudioSource {
                                             num_channels,
                                             blank_data.len() / num_channels as usize,
                                         );
+
+                                        interval.tick().await;
                                     }
-                                    
-                                    interval.tick().await;
+                                    continue;
                                 }
                                 TryRecvError::Disconnected => {
                                     // channel disconnected, break out of loop
                                     break;
                                 }
                             }
-
-                            break;
                         }
                     }
                 }

--- a/livekit-ffi/protocol/audio_frame.proto
+++ b/livekit-ffi/protocol/audio_frame.proto
@@ -124,7 +124,7 @@ message AudioSourceOptions {
   bool echo_cancellation = 1;
   bool noise_suppression = 2;
   bool auto_gain_control = 3;
-  bool disable_silent_frames = 4;
+  bool enable_queue = 4;
 }
 
 enum AudioSourceType {

--- a/livekit-ffi/protocol/audio_frame.proto
+++ b/livekit-ffi/protocol/audio_frame.proto
@@ -124,6 +124,7 @@ message AudioSourceOptions {
   bool echo_cancellation = 1;
   bool noise_suppression = 2;
   bool auto_gain_control = 3;
+  bool disable_silent_frames = 4;
 }
 
 enum AudioSourceType {

--- a/livekit-ffi/src/conversion/audio_frame.rs
+++ b/livekit-ffi/src/conversion/audio_frame.rs
@@ -25,6 +25,7 @@ impl From<proto::AudioSourceOptions> for AudioSourceOptions {
             echo_cancellation: opts.echo_cancellation,
             auto_gain_control: opts.auto_gain_control,
             noise_suppression: opts.noise_suppression,
+            disable_silent_frames: opts.disable_silent_frames,
         }
     }
 }

--- a/livekit-ffi/src/conversion/audio_frame.rs
+++ b/livekit-ffi/src/conversion/audio_frame.rs
@@ -25,7 +25,7 @@ impl From<proto::AudioSourceOptions> for AudioSourceOptions {
             echo_cancellation: opts.echo_cancellation,
             auto_gain_control: opts.auto_gain_control,
             noise_suppression: opts.noise_suppression,
-            disable_silent_frames: opts.disable_silent_frames,
+            enable_queue: opts.enable_queue,
         }
     }
 }

--- a/livekit-ffi/src/livekit.proto.rs
+++ b/livekit-ffi/src/livekit.proto.rs
@@ -2861,7 +2861,7 @@ pub struct AudioSourceOptions {
     #[prost(bool, tag="3")]
     pub auto_gain_control: bool,
     #[prost(bool, tag="4")]
-    pub disable_silent_frames: bool,
+    pub enable_queue: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/livekit-ffi/src/livekit.proto.rs
+++ b/livekit-ffi/src/livekit.proto.rs
@@ -2860,6 +2860,8 @@ pub struct AudioSourceOptions {
     pub noise_suppression: bool,
     #[prost(bool, tag="3")]
     pub auto_gain_control: bool,
+    #[prost(bool, tag="4")]
+    pub disable_silent_frames: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/webrtc-sys/src/audio_track.rs
+++ b/webrtc-sys/src/audio_track.rs
@@ -23,6 +23,7 @@ pub mod ffi {
         pub echo_cancellation: bool,
         pub noise_suppression: bool,
         pub auto_gain_control: bool,
+        pub disable_silent_frames: bool,
     }
 
     extern "C++" {

--- a/webrtc-sys/src/audio_track.rs
+++ b/webrtc-sys/src/audio_track.rs
@@ -23,7 +23,7 @@ pub mod ffi {
         pub echo_cancellation: bool,
         pub noise_suppression: bool,
         pub auto_gain_control: bool,
-        pub disable_silent_frames: bool,
+        pub enable_queue: bool,
     }
 
     extern "C++" {


### PR DESCRIPTION
This parameter is used to avoid queues and silence frames causing latency accumulation, and is typically used when connecting to Audio Capture devices or other real-time sources.