### PR TITLE
Add APIs for converting between native VideoFrameBuffers and their underlying `CVPixelBuffer` on macOS

### DIFF
--- a/libwebrtc/src/native/video_frame.rs
+++ b/libwebrtc/src/native/video_frame.rs
@@ -148,6 +148,17 @@ macro_rules! impl_to_argb {
 
 #[allow(unused_unsafe)]
 impl NativeBuffer {
+    #[cfg(target_os = "macos")]
+    pub unsafe fn from_cv_pixel_buffer(
+        cv_pixel_buffer: *mut std::ffi::c_void,
+    ) -> vf::native::NativeBuffer {
+        vf::native::NativeBuffer {
+            handle: NativeBuffer {
+                sys_handle: vfb_sys::ffi::new_native_buffer(cv_pixel_buffer as *mut _),
+            },
+        }
+    }
+
     pub fn sys_handle(&self) -> &vfb_sys::ffi::VideoFrameBuffer {
         &self.sys_handle
     }

--- a/libwebrtc/src/native/video_frame.rs
+++ b/libwebrtc/src/native/video_frame.rs
@@ -154,8 +154,17 @@ impl NativeBuffer {
     ) -> vf::native::NativeBuffer {
         vf::native::NativeBuffer {
             handle: NativeBuffer {
-                sys_handle: vfb_sys::ffi::new_native_buffer(cv_pixel_buffer as *mut _),
+                sys_handle: vfb_sys::ffi::new_native_buffer_from_platform_image_buffer(
+                    cv_pixel_buffer as *mut _,
+                ),
             },
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    pub fn get_cv_pixel_buffer(&self) -> *mut std::ffi::c_void {
+        unsafe {
+            vfb_sys::ffi::native_buffer_to_platform_image_buffer(&self.sys_handle) as *mut _
         }
     }
 

--- a/libwebrtc/src/native/video_frame.rs
+++ b/libwebrtc/src/native/video_frame.rs
@@ -163,9 +163,7 @@ impl NativeBuffer {
 
     #[cfg(target_os = "macos")]
     pub fn get_cv_pixel_buffer(&self) -> *mut std::ffi::c_void {
-        unsafe {
-            vfb_sys::ffi::native_buffer_to_platform_image_buffer(&self.sys_handle) as *mut _
-        }
+        unsafe { vfb_sys::ffi::native_buffer_to_platform_image_buffer(&self.sys_handle) as *mut _ }
     }
 
     pub fn sys_handle(&self) -> &vfb_sys::ffi::VideoFrameBuffer {

--- a/libwebrtc/src/native/video_source.rs
+++ b/libwebrtc/src/native/video_source.rs
@@ -18,6 +18,7 @@ use std::{
 };
 
 use cxx::SharedPtr;
+use livekit_runtime::interval;
 use parking_lot::Mutex;
 use webrtc_sys::{video_frame as vf_sys, video_frame::ffi::VideoRotation, video_track as vt_sys};
 
@@ -61,7 +62,7 @@ impl NativeVideoSource {
             let source = source.clone();
             let i420 = I420Buffer::new(resolution.width, resolution.height);
             async move {
-                let mut interval = tokio::time::interval(Duration::from_millis(100)); // 10 fps
+                let mut interval = interval(Duration::from_millis(100)); // 10 fps
 
                 loop {
                     interval.tick().await;

--- a/libwebrtc/src/video_frame.rs
+++ b/libwebrtc/src/video_frame.rs
@@ -449,6 +449,12 @@ pub mod native {
 
     new_buffer_type!(NativeBuffer, Native, as_native);
 
+    impl NativeBuffer {
+        pub unsafe fn from_cv_pixel_buffer(cv_pixel_buffer: *mut std::ffi::c_void) -> NativeBuffer {
+            vf_imp::NativeBuffer::from_cv_pixel_buffer(cv_pixel_buffer)
+        }
+    }
+
     pub trait VideoFrameBufferExt: VideoBuffer {
         fn to_i420(&self) -> I420Buffer;
         fn to_argb(

--- a/libwebrtc/src/video_frame.rs
+++ b/libwebrtc/src/video_frame.rs
@@ -450,8 +450,23 @@ pub mod native {
     new_buffer_type!(NativeBuffer, Native, as_native);
 
     impl NativeBuffer {
-        pub unsafe fn from_cv_pixel_buffer(cv_pixel_buffer: *mut std::ffi::c_void) -> NativeBuffer {
+        /// Creates a `NativeBuffer` from a `CVPixelBufferRef` pointer.
+        ///
+        /// This function does not bump the reference count of the pixel buffer.
+        ///
+        /// Safety: The given pointer must be a valid `CVPixelBufferRef`.
+        #[cfg(target_os = "macos")]
+        pub unsafe fn from_cv_pixel_buffer(cv_pixel_buffer: *mut std::ffi::c_void) -> Self {
             vf_imp::NativeBuffer::from_cv_pixel_buffer(cv_pixel_buffer)
+        }
+
+        /// Returns the `CVPixelBufferRef` that backs this buffer, or `null` if
+        /// this buffer is not currently backed by a `CVPixelBufferRef`.
+        ///
+        /// This function does not bump the reference count of the pixel buffer.
+        #[cfg(target_os = "macos")]
+        pub fn get_cv_pixel_buffer(&self) -> *mut std::ffi::c_void {
+            self.handle.get_cv_pixel_buffer()
         }
     }
 

--- a/webrtc-sys/build.rs
+++ b/webrtc-sys/build.rs
@@ -152,7 +152,11 @@ fn main() {
 
             configure_darwin_sysroot(&mut builder);
 
-            builder.file("src/objc_video_factory.mm").flag("-stdlib=libc++").flag("-std=c++20");
+            builder
+                .file("src/objc_video_factory.mm")
+                .file("src/objc_video_frame_buffer.mm")
+                .flag("-stdlib=libc++")
+                .flag("-std=c++20");
         }
         "ios" => {
             println!("cargo:rustc-link-lib=framework=CoreFoundation");

--- a/webrtc-sys/include/livekit/video_frame_buffer.h
+++ b/webrtc-sys/include/livekit/video_frame_buffer.h
@@ -39,6 +39,14 @@ class I444Buffer;
 class I010Buffer;
 class NV12Buffer;
 }  // namespace livekit
+
+#ifdef __APPLE__
+#include <CoreVideo/CoreVideo.h>
+namespace livekit {
+typedef __CVBuffer PlatformNativeBuffer;
+}  // namespace livekit
+#endif
+
 #include "webrtc-sys/src/video_frame_buffer.rs.h"
 
 namespace livekit {
@@ -179,6 +187,7 @@ std::unique_ptr<I422Buffer> new_i422_buffer(int width, int height, int stride_y,
 std::unique_ptr<I444Buffer> new_i444_buffer(int width, int height, int stride_y, int stride_u, int stride_v);
 std::unique_ptr<I010Buffer> new_i010_buffer(int width, int height, int stride_y, int stride_u, int stride_v);
 std::unique_ptr<NV12Buffer> new_nv12_buffer(int width, int height, int stride_y, int stride_uv);
+std::unique_ptr<VideoFrameBuffer> new_native_buffer(PlatformNativeBuffer *buffer);
 
 static const VideoFrameBuffer* yuv_to_vfb(const PlanarYuvBuffer* yuv) {
   return yuv;

--- a/webrtc-sys/include/livekit/video_frame_buffer.h
+++ b/webrtc-sys/include/livekit/video_frame_buffer.h
@@ -45,6 +45,10 @@ class NV12Buffer;
 namespace livekit {
 typedef __CVBuffer PlatformImageBuffer;
 }  // namespace livekit
+#else
+namespace livekit {
+typedef void PlatformImageBuffer;
+}  // namespace livekit
 #endif
 
 #include "webrtc-sys/src/video_frame_buffer.rs.h"

--- a/webrtc-sys/include/livekit/video_frame_buffer.h
+++ b/webrtc-sys/include/livekit/video_frame_buffer.h
@@ -43,7 +43,7 @@ class NV12Buffer;
 #ifdef __APPLE__
 #include <CoreVideo/CoreVideo.h>
 namespace livekit {
-typedef __CVBuffer PlatformNativeBuffer;
+typedef __CVBuffer PlatformImageBuffer;
 }  // namespace livekit
 #endif
 
@@ -187,7 +187,9 @@ std::unique_ptr<I422Buffer> new_i422_buffer(int width, int height, int stride_y,
 std::unique_ptr<I444Buffer> new_i444_buffer(int width, int height, int stride_y, int stride_u, int stride_v);
 std::unique_ptr<I010Buffer> new_i010_buffer(int width, int height, int stride_y, int stride_u, int stride_v);
 std::unique_ptr<NV12Buffer> new_nv12_buffer(int width, int height, int stride_y, int stride_uv);
-std::unique_ptr<VideoFrameBuffer> new_native_buffer(PlatformNativeBuffer *buffer);
+
+std::unique_ptr<VideoFrameBuffer> new_native_buffer_from_platform_image_buffer(PlatformImageBuffer *buffer);
+PlatformImageBuffer* native_buffer_to_platform_image_buffer(const std::unique_ptr<VideoFrameBuffer> &);
 
 static const VideoFrameBuffer* yuv_to_vfb(const PlanarYuvBuffer* yuv) {
   return yuv;

--- a/webrtc-sys/src/objc_video_frame_buffer.mm
+++ b/webrtc-sys/src/objc_video_frame_buffer.mm
@@ -28,6 +28,7 @@ std::unique_ptr<VideoFrameBuffer> new_native_buffer(
     RTCCVPixelBuffer *buffer = [[RTCCVPixelBuffer alloc] initWithPixelBuffer:pixelBuffer];
     rtc::scoped_refptr<webrtc::VideoFrameBuffer> frame_buffer = webrtc::ObjCToNativeVideoFrameBuffer(buffer);
     [buffer release];
+    [pixelBuffer release];
     return std::make_unique<VideoFrameBuffer>(frame_buffer);
 }
 

--- a/webrtc-sys/src/objc_video_frame_buffer.mm
+++ b/webrtc-sys/src/objc_video_frame_buffer.mm
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "livekit/video_frame_buffer.h"
+
+#import <CoreVideo/CoreVideo.h>
+#import <sdk/objc/components/video_frame_buffer/RTCCVPixelBuffer.h>
+#include "sdk/objc/native/api/video_frame_buffer.h"
+
+namespace livekit {
+
+std::unique_ptr<VideoFrameBuffer> new_native_buffer(
+    CVPixelBufferRef pixelBuffer
+) {
+    RTCCVPixelBuffer *buffer = [[RTCCVPixelBuffer alloc] initWithPixelBuffer:pixelBuffer];
+    rtc::scoped_refptr<webrtc::VideoFrameBuffer> frame_buffer = webrtc::ObjCToNativeVideoFrameBuffer(buffer);
+    [buffer release];
+    return std::make_unique<VideoFrameBuffer>(frame_buffer);
+}
+
+}  // namespace livekit

--- a/webrtc-sys/src/video_frame_buffer.cpp
+++ b/webrtc-sys/src/video_frame_buffer.cpp
@@ -280,7 +280,7 @@ std::unique_ptr<VideoFrameBuffer> new_native_buffer_from_platform_image_buffer(
 PlatformImageBuffer* native_buffer_to_platform_image_buffer(
     const std::unique_ptr<VideoFrameBuffer> &buffer
 ) {
-  return nullptr
+  return nullptr;
 }
 
 #endif

--- a/webrtc-sys/src/video_frame_buffer.cpp
+++ b/webrtc-sys/src/video_frame_buffer.cpp
@@ -271,7 +271,15 @@ std::unique_ptr<NV12Buffer> new_nv12_buffer(int width,
 
 #ifndef __APPLE__
 
-std::unique_ptr<VideoFrameBuffer> new_native_buffer(PlatformNativeBuffer *platform_buffer) {
+std::unique_ptr<VideoFrameBuffer> new_native_buffer_from_platform_image_buffer(
+    PlatformImageBuffer *buffer
+) {
+  return nullptr;
+}
+
+PlatformImageBuffer* native_buffer_to_platform_image_buffer(
+    const std::unique_ptr<VideoFrameBuffer> &buffer
+) {
   return nullptr
 }
 

--- a/webrtc-sys/src/video_frame_buffer.cpp
+++ b/webrtc-sys/src/video_frame_buffer.cpp
@@ -269,4 +269,12 @@ std::unique_ptr<NV12Buffer> new_nv12_buffer(int width,
       webrtc::NV12Buffer::Create(width, height, stride_y, stride_uv));
 }
 
+#ifndef __APPLE__
+
+std::unique_ptr<VideoFrameBuffer> new_native_buffer(PlatformNativeBuffer *platform_buffer) {
+  return nullptr
+}
+
+#endif
+
 }  // namespace livekit

--- a/webrtc-sys/src/video_frame_buffer.rs
+++ b/webrtc-sys/src/video_frame_buffer.rs
@@ -43,7 +43,7 @@ pub mod ffi {
         type I444Buffer;
         type I010Buffer;
         type NV12Buffer;
-        type PlatformNativeBuffer;
+        type PlatformImageBuffer;
 
         fn buffer_type(self: &VideoFrameBuffer) -> VideoFrameBufferType;
         fn width(self: &VideoFrameBuffer) -> u32;
@@ -127,9 +127,12 @@ pub mod ffi {
             stride_uv: i32,
         ) -> UniquePtr<NV12Buffer>;
 
-        unsafe fn new_native_buffer(
-            platform_native_buffer: *mut PlatformNativeBuffer,
+        unsafe fn new_native_buffer_from_platform_image_buffer(
+            platform_native_buffer: *mut PlatformImageBuffer,
         ) -> UniquePtr<VideoFrameBuffer>;
+        unsafe fn native_buffer_to_platform_image_buffer(
+            buffer: &UniquePtr<VideoFrameBuffer>,
+        ) -> *mut PlatformImageBuffer;
 
         unsafe fn yuv_to_vfb(yuv: *const PlanarYuvBuffer) -> *const VideoFrameBuffer;
         unsafe fn biyuv_to_vfb(yuv: *const BiplanarYuvBuffer) -> *const VideoFrameBuffer;

--- a/webrtc-sys/src/video_frame_buffer.rs
+++ b/webrtc-sys/src/video_frame_buffer.rs
@@ -43,6 +43,7 @@ pub mod ffi {
         type I444Buffer;
         type I010Buffer;
         type NV12Buffer;
+        type PlatformNativeBuffer;
 
         fn buffer_type(self: &VideoFrameBuffer) -> VideoFrameBufferType;
         fn width(self: &VideoFrameBuffer) -> u32;
@@ -125,6 +126,10 @@ pub mod ffi {
             stride_y: i32,
             stride_uv: i32,
         ) -> UniquePtr<NV12Buffer>;
+
+        unsafe fn new_native_buffer(
+            platform_native_buffer: *mut PlatformNativeBuffer,
+        ) -> UniquePtr<VideoFrameBuffer>;
 
         unsafe fn yuv_to_vfb(yuv: *const PlanarYuvBuffer) -> *const VideoFrameBuffer;
         unsafe fn biyuv_to_vfb(yuv: *const BiplanarYuvBuffer) -> *const VideoFrameBuffer;


### PR DESCRIPTION
Depends on https://github.com/livekit/rust-sdks/pull/354 (this branch contains that change as well).

### Background

In the [Zed editor](https://github.com/zed-industries/zed), we're switching over from using the LiveKit [Swift SDK](https://github.com/livekit/client-sdk-swift) to this crate.  The main motivation is that we want our LiveKit-based screen-sharing and audio features to work on Linux (and someday Windows), not just macOS.

In order to implement screen sharing efficiently (as it was before, when using the Swift  SDK), we want to pass video frames directly from the `ScreenCaptureKit` framework to this crate's `NativeVideoSource::capture_frame` method, without copying them into intermediate buffers. Similarly, when playing remote video tracks, we want to take decoded video frames directly from the `NativeVideoStream` and use them as GPU textures without performing an extra copy.

### Change

To support both of these use cases, we have added two new macOS-specific APIs to the `video_frame::NativeBuffer` type: `from_cv_pixel_buffer`, and `get_cv_pixel_buffer`. I think it makes sense to have this functionality, since AFAICT, the purpose of the `Native` variant of `VideoFrameBuffer` is to adapt a platform-specific video frame representation into the WebRTC's logic.

### Details

* We haven't attempted to make the APIs type safe. This would drag in a dependency on the macOS `CoreMedia` framework, so we decided to leave the interface in terms of `*mut c_void`.
* The `get_cv_pixel_buffer` **can** return `NULL` if the native buffer is not actually backed by a `CVPixelBuffer`. Rather than implicitly perform some potentially expensive conversion implicitly, we decided to leave that to the caller. The only point of these method is to enable a fast path in which we minimize conversions.

Let me know if there is a different solution to this problem that you'd prefer. Thanks!