### PR TITLE
Upgrade macOS runners to `macos-13`.

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -40,13 +40,13 @@ jobs:
           - os: windows-2019
             target: aarch64-pc-windows-msvc
             #extraargs: --exclude livekit-api --exclude livekit-ffi # waiting for v0.17 of ring
-          - os: macos-11
+          - os: macos-13
             target: x86_64-apple-darwin
-          - os: macos-11
+          - os: macos-13
             target: aarch64-apple-darwin
-          - os: macos-11
+          - os: macos-13
             target: aarch64-apple-ios
-          - os: macos-11
+          - os: macos-13
             target: aarch64-apple-ios-sim
           - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu

--- a/.github/workflows/ffi-builds.yml
+++ b/.github/workflows/ffi-builds.yml
@@ -40,25 +40,25 @@ jobs:
             buildargs: --no-default-features --features "native-tls" # ring 0.16 is incompatible with win aarch64
             target: aarch64-pc-windows-msvc
             name: ffi-windows-arm64
-          - os: macos-11
+          - os: macos-13
             platform: macos
             dylib: liblivekit_ffi.dylib
             target: x86_64-apple-darwin
             macosx_deployment_target: "10.15"
             name: ffi-macos-x86_64
-          - os: macos-11
+          - os: macos-13
             platform: macos
             dylib: liblivekit_ffi.dylib
             target: aarch64-apple-darwin
             macosx_deployment_target: "11.0" # aarch64 requires 11
             name: ffi-macos-arm64
-          - os: macos-11
+          - os: macos-13
             platform: ios
             dylib: liblivekit_ffi.a
             target: aarch64-apple-ios
             iphoneos_deployment_target: "13.0"
             name: ffi-ios-arm64
-          - os: macos-11
+          - os: macos-13
             platform: ios
             dylib: liblivekit_ffi.a
             target: aarch64-apple-ios-sim

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
           # Platform supports is limited for tests (no aarch64)
           - os: windows-2019
             target: x86_64-pc-windows-msvc
-          - os: macos-11
+          - os: macos-13
             target: x86_64-apple-darwin
           - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu

--- a/.github/workflows/webrtc-builds.yml
+++ b/.github/workflows/webrtc-builds.yml
@@ -36,12 +36,12 @@ jobs:
             arch: arm64
 
           - name: mac
-            os: macos-11
+            os: macos-13
             cmd: ./build_macos.sh
             arch: x64
 
           - name: mac
-            os: macos-11
+            os: macos-13
             cmd: ./build_macos.sh
             arch: arm64
 
@@ -72,13 +72,13 @@ jobs:
 
           - name: ios
             out: ios-device-arm64
-            os: macos-11
+            os: macos-13
             cmd: ./build_ios.sh
             arch: arm64
 
           - name: ios
             out: ios-simulator-arm64
-            os: macos-11
+            os: macos-13
             cmd: ./build_ios.sh
             arch: arm64
             buildargs: --environment simulator 
@@ -118,7 +118,7 @@ jobs:
           sudo apt install -y ninja-build pkg-config openjdk-11-jdk
 
       - name: Install macos dependencies
-        if: ${{ matrix.target.os == 'macos-11' }}
+        if: ${{ matrix.target.os == 'macos-13' }}
         run: brew install ninja
 
       - name: Install windows dependencies


### PR DESCRIPTION


# macOS 11 deprecation and removal
In January 2024, GitHub announced the [deprecation of macOS 11](https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/) and the removal of the runner image by June 2024. The macOS 11 runner image will be removed on 6/28/2024. We recommend updating workflows to use macos-14, macos-13, macos-12, or macos-latest. Reminder emails will be sent to those who have used the macOS 11 runner image in the past 30 days. Jobs using macOS 11 will temporarily fail during scheduled time periods to raise awareness of the upcoming removal.

https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/#macos-11-deprecation-and-removal