### PR TITLE
livekit: send mute events to SFU

### DIFF
--- a/livekit/src/room/participant/mod.rs
+++ b/livekit/src/room/participant/mod.rs
@@ -248,8 +248,19 @@ pub(super) fn add_publication(
     publication.on_muted({
         let events = inner.events.clone();
         let participant = participant.clone();
+        let rtc_engine = inner.rtc_engine.clone();
         move |publication| {
             if let Some(cb) = events.track_muted.lock().as_ref() {
+                let rtc_engine = rtc_engine.clone();
+                let publication_cloned = publication.clone();
+                livekit_runtime::spawn(async move {
+                    let _ = rtc_engine
+                        .mute_track(proto::MuteTrackRequest {
+                            sid: publication_cloned.sid().to_string(),
+                            muted: true,
+                        })
+                        .await;
+                });
                 cb(participant.clone(), publication);
             }
         }
@@ -258,8 +269,19 @@ pub(super) fn add_publication(
     publication.on_unmuted({
         let events = inner.events.clone();
         let participant = participant.clone();
+        let rtc_engine = inner.rtc_engine.clone();
         move |publication| {
             if let Some(cb) = events.track_unmuted.lock().as_ref() {
+                let rtc_engine = rtc_engine.clone();
+                let publication_cloned = publication.clone();
+                livekit_runtime::spawn(async move {
+                    let _ = rtc_engine
+                        .mute_track(proto::MuteTrackRequest {
+                            sid: publication_cloned.sid().to_string(),
+                            muted: false,
+                        })
+                        .await;
+                });
                 cb(participant.clone(), publication);
             }
         }

--- a/livekit/src/room/participant/mod.rs
+++ b/livekit/src/room/participant/mod.rs
@@ -251,16 +251,18 @@ pub(super) fn add_publication(
         let rtc_engine = inner.rtc_engine.clone();
         move |publication| {
             if let Some(cb) = events.track_muted.lock().as_ref() {
-                let rtc_engine = rtc_engine.clone();
-                let publication_cloned = publication.clone();
-                livekit_runtime::spawn(async move {
-                    let _ = rtc_engine
-                        .mute_track(proto::MuteTrackRequest {
-                            sid: publication_cloned.sid().to_string(),
-                            muted: true,
-                        })
-                        .await;
-                });
+                if !publication.is_remote() {
+                    let rtc_engine = rtc_engine.clone();
+                    let publication_cloned = publication.clone();
+                    livekit_runtime::spawn(async move {
+                        let _ = rtc_engine
+                            .mute_track(proto::MuteTrackRequest {
+                                sid: publication_cloned.sid().to_string(),
+                                muted: true,
+                            })
+                            .await;
+                    });
+                }
                 cb(participant.clone(), publication);
             }
         }
@@ -272,16 +274,18 @@ pub(super) fn add_publication(
         let rtc_engine = inner.rtc_engine.clone();
         move |publication| {
             if let Some(cb) = events.track_unmuted.lock().as_ref() {
-                let rtc_engine = rtc_engine.clone();
-                let publication_cloned = publication.clone();
-                livekit_runtime::spawn(async move {
-                    let _ = rtc_engine
-                        .mute_track(proto::MuteTrackRequest {
-                            sid: publication_cloned.sid().to_string(),
-                            muted: false,
-                        })
-                        .await;
-                });
+                if !publication.is_remote() {
+                    let rtc_engine = rtc_engine.clone();
+                    let publication_cloned = publication.clone();
+                    livekit_runtime::spawn(async move {
+                        let _ = rtc_engine
+                            .mute_track(proto::MuteTrackRequest {
+                                sid: publication_cloned.sid().to_string(),
+                                muted: false,
+                            })
+                            .await;
+                    });
+                }
                 cb(participant.clone(), publication);
             }
         }

--- a/livekit/src/room/participant/mod.rs
+++ b/livekit/src/room/participant/mod.rs
@@ -255,12 +255,15 @@ pub(super) fn add_publication(
                     let rtc_engine = rtc_engine.clone();
                     let publication_cloned = publication.clone();
                     livekit_runtime::spawn(async move {
-                        rtc_engine
+                        let engine_request = rtc_engine
                             .mute_track(proto::MuteTrackRequest {
                                 sid: publication_cloned.sid().to_string(),
                                 muted: true,
                             })
-                            .await
+                            .await;
+                        if let Err(e) = engine_request {
+                            log::error!("could not mute track: {e:?}");
+                        }
                     });
                 }
                 cb(participant.clone(), publication);
@@ -278,12 +281,15 @@ pub(super) fn add_publication(
                     let rtc_engine = rtc_engine.clone();
                     let publication_cloned = publication.clone();
                     livekit_runtime::spawn(async move {
-                        rtc_engine
+                        let engine_request = rtc_engine
                             .mute_track(proto::MuteTrackRequest {
                                 sid: publication_cloned.sid().to_string(),
                                 muted: false,
                             })
-                            .await
+                            .await;
+                        if let Err(e) = engine_request {
+                            log::error!("could not unmute track: {e:?}");
+                        }
                     });
                 }
                 cb(participant.clone(), publication);

--- a/livekit/src/room/participant/mod.rs
+++ b/livekit/src/room/participant/mod.rs
@@ -255,12 +255,12 @@ pub(super) fn add_publication(
                     let rtc_engine = rtc_engine.clone();
                     let publication_cloned = publication.clone();
                     livekit_runtime::spawn(async move {
-                        let _ = rtc_engine
+                        rtc_engine
                             .mute_track(proto::MuteTrackRequest {
                                 sid: publication_cloned.sid().to_string(),
                                 muted: true,
                             })
-                            .await;
+                            .await
                     });
                 }
                 cb(participant.clone(), publication);
@@ -278,12 +278,12 @@ pub(super) fn add_publication(
                     let rtc_engine = rtc_engine.clone();
                     let publication_cloned = publication.clone();
                     livekit_runtime::spawn(async move {
-                        let _ = rtc_engine
+                        rtc_engine
                             .mute_track(proto::MuteTrackRequest {
                                 sid: publication_cloned.sid().to_string(),
                                 muted: false,
                             })
-                            .await;
+                            .await
                     });
                 }
                 cb(participant.clone(), publication);

--- a/livekit/src/room/publication/local.rs
+++ b/livekit/src/room/publication/local.rs
@@ -82,11 +82,19 @@ impl LocalTrackPublication {
         if let Some(track) = self.track() {
             track.mute();
         }
+
+        if let Some(mute_update_needed) = self.inner.events.muted.lock().as_ref() {
+            mute_update_needed(TrackPublication::Local(self.clone()))
+        }
     }
 
     pub fn unmute(&self) {
         if let Some(track) = self.track() {
             track.unmute();
+        }
+
+        if let Some(unmute_update_needed) = self.inner.events.unmuted.lock().as_ref() {
+            unmute_update_needed(TrackPublication::Local(self.clone()))
         }
     }
 

--- a/livekit/src/room/track/local_audio_track.rs
+++ b/livekit/src/room/track/local_audio_track.rs
@@ -124,11 +124,11 @@ impl LocalAudioTrack {
     }
 
     pub(crate) fn on_muted(&self, f: impl Fn(Track) + Send + 'static) {
-        *self.inner.events.muted.lock() = Some(Box::new(f));
+        self.inner.events.lock().muted.replace(Box::new(f));
     }
 
     pub(crate) fn on_unmuted(&self, f: impl Fn(Track) + Send + 'static) {
-        *self.inner.events.unmuted.lock() = Some(Box::new(f));
+        self.inner.events.lock().unmuted.replace(Box::new(f));
     }
 
     pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {

--- a/livekit/src/room/track/local_video_track.rs
+++ b/livekit/src/room/track/local_video_track.rs
@@ -124,11 +124,11 @@ impl LocalVideoTrack {
     }
 
     pub(crate) fn on_muted(&self, f: impl Fn(Track) + Send + 'static) {
-        *self.inner.events.muted.lock() = Some(Box::new(f));
+        self.inner.events.lock().muted.replace(Box::new(f));
     }
 
     pub(crate) fn on_unmuted(&self, f: impl Fn(Track) + Send + 'static) {
-        *self.inner.events.unmuted.lock() = Some(Box::new(f));
+        self.inner.events.lock().unmuted.replace(Box::new(f));
     }
 
     pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {

--- a/livekit/src/room/track/mod.rs
+++ b/livekit/src/room/track/mod.rs
@@ -131,8 +131,8 @@ type UnmutedHandler = Box<dyn Fn(Track) + Send>;
 #[derive(Default)]
 struct TrackEvents {
     // These mute handlers are only called for local tracks
-    pub muted: Mutex<Option<MutedHandler>>,
-    pub unmuted: Mutex<Option<UnmutedHandler>>,
+    pub muted: Option<MutedHandler>,
+    pub unmuted: Option<UnmutedHandler>,
 }
 
 #[derive(Debug)]
@@ -149,7 +149,7 @@ struct TrackInfo {
 pub(super) struct TrackInner {
     info: RwLock<TrackInfo>,
     rtc_track: MediaStreamTrack,
-    events: TrackEvents,
+    events: Mutex<TrackEvents>,
 }
 
 pub(super) fn new_inner(
@@ -190,10 +190,10 @@ pub(super) fn set_muted(inner: &Arc<TrackInner>, track: &Track, muted: bool) {
     inner.info.write().muted = muted;
 
     if muted {
-        if let Some(on_mute) = inner.events.muted.lock().as_ref() {
+        if let Some(on_mute) = inner.events.lock().muted.as_ref() {
             on_mute(track.clone());
         }
-    } else if let Some(on_unmute) = inner.events.unmuted.lock().as_ref() {
+    } else if let Some(on_unmute) = inner.events.lock().muted.as_ref() {
         on_unmute(track.clone());
     }
 }

--- a/livekit/src/room/track/remote_audio_track.rs
+++ b/livekit/src/room/track/remote_audio_track.rs
@@ -95,11 +95,11 @@ impl RemoteAudioTrack {
     }
 
     pub(crate) fn on_muted(&self, f: impl Fn(Track) + Send + 'static) {
-        *self.inner.events.muted.lock() = Some(Box::new(f));
+        self.inner.events.lock().muted.replace(Box::new(f));
     }
 
     pub(crate) fn on_unmuted(&self, f: impl Fn(Track) + Send + 'static) {
-        *self.inner.events.unmuted.lock() = Some(Box::new(f));
+        self.inner.events.lock().unmuted.replace(Box::new(f));
     }
 
     #[allow(dead_code)]

--- a/livekit/src/room/track/remote_video_track.rs
+++ b/livekit/src/room/track/remote_video_track.rs
@@ -95,11 +95,11 @@ impl RemoteVideoTrack {
     }
 
     pub(crate) fn on_muted(&self, f: impl Fn(Track) + Send + 'static) {
-        *self.inner.events.muted.lock() = Some(Box::new(f));
+        self.inner.events.lock().muted.replace(Box::new(f));
     }
 
     pub(crate) fn on_unmuted(&self, f: impl Fn(Track) + Send + 'static) {
-        *self.inner.events.unmuted.lock() = Some(Box::new(f));
+        self.inner.events.lock().unmuted.replace(Box::new(f));
     }
 
     pub(crate) fn transceiver(&self) -> Option<RtpTransceiver> {

--- a/livekit/src/rtc_engine/mod.rs
+++ b/livekit/src/rtc_engine/mod.rs
@@ -226,6 +226,14 @@ impl RtcEngine {
                                      // happen on bad timing and it is safe to ignore)
     }
 
+    pub async fn mute_track(&self, req: proto::MuteTrackRequest) -> EngineResult<()> {
+        let (session, _r_lock) = {
+            let (handle, _r_lock) = self.inner.wait_reconnection().await?;
+            (handle.session.clone(), _r_lock)
+        };
+        session.mute_track(req).await
+    }
+
     pub async fn create_sender(
         &self,
         track: LocalTrack,

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -256,6 +256,10 @@ impl RtcSession {
         self.inner.add_track(req).await
     }
 
+    pub async fn mute_track(&self, req: proto::MuteTrackRequest) -> EngineResult<()> {
+        self.inner.mute_track(req).await
+    }
+
     pub async fn create_sender(
         &self,
         track: LocalTrack,
@@ -646,6 +650,12 @@ impl SessionInner {
         }
 
         self.publisher_pc.peer_connection().remove_track(sender)?;
+
+        Ok(())
+    }
+
+    async fn mute_track(&self, req: proto::MuteTrackRequest) -> EngineResult<()> {
+        self.signal_client.send(proto::signal_request::Message::Mute(req)).await;
 
         Ok(())
     }


### PR DESCRIPTION
fixes #358 (`ActiveSpeakersChanged` always got sent for me, this fixes the `Muted` issues)

tested with Zed's example, with rust-sdks on commit `ffi-v0.6.1~3` because some APIs changed since they made the example.