### PR TITLE
livekit: wait for disconnect before callback

### DIFF
--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -566,7 +566,7 @@ impl RoomSession {
             EngineEvent::SignalRestarted { join_response, tx } => {
                 self.handle_signal_restarted(join_response, tx)
             }
-            EngineEvent::Disconnected { reason } => self.handle_disconnected(reason),
+            EngineEvent::Disconnected { reason, tx } => self.handle_disconnected(reason, tx),
             EngineEvent::Data { payload, topic, kind, participant_sid, participant_identity } => {
                 self.handle_data(payload, topic, kind, participant_sid, participant_identity);
             }
@@ -960,7 +960,7 @@ impl RoomSession {
         let _ = tx.send(());
     }
 
-    fn handle_disconnected(self: &Arc<Self>, reason: DisconnectReason) {
+    fn handle_disconnected(self: &Arc<Self>, reason: DisconnectReason, tx: oneshot::Sender<()>) {
         if self.update_connection_state(ConnectionState::Disconnected) {
             self.dispatcher.dispatch(&RoomEvent::Disconnected { reason });
         }
@@ -975,6 +975,8 @@ impl RoomSession {
                 }
             });
         }
+
+        let _ = tx.send(());
     }
 
     fn handle_data(

--- a/livekit/src/rtc_engine/mod.rs
+++ b/livekit/src/rtc_engine/mod.rs
@@ -129,6 +129,7 @@ pub enum EngineEvent {
     },
     Disconnected {
         reason: DisconnectReason,
+        tx: oneshot::Sender<()>,
     },
 }
 
@@ -439,10 +440,12 @@ impl EngineInner {
         };
 
         if let Some((engine_task, close_tx)) = engine_task {
+            let (tx, rx) = oneshot::channel();
             session.close().await;
             let _ = close_tx.send(());
             let _ = engine_task.await;
-            let _ = self.engine_tx.send(EngineEvent::Disconnected { reason });
+            let _ = self.engine_tx.send(EngineEvent::Disconnected { reason, tx });
+            let _ = rx.await;
         }
     }
 


### PR DESCRIPTION
should fix a race condition where in node-sdks `await room.disconnect()` doesn't wait for the room status update to change.

draft because it doesn't yet work: patched node-sdks still fails approximately one in fifty times, but i don't know if this is because it runs an old rust-sdks that i backported this to or if this is a bug in this patch.

<details>
<summary>node-sdks diff</summary>

```diff
diff --git a/packages/livekit-rtc/src/room.ts b/packages/livekit-rtc/src/room.ts
index 143774f..f9bebeb 100644
--- a/packages/livekit-rtc/src/room.ts
+++ b/packages/livekit-rtc/src/room.ts
@@ -16,6 +16,7 @@ import type {
   ConnectResponse,
   ConnectionQuality,
   DataPacketKind,
+  DisconnectCallback,
   DisconnectResponse,
   IceServer,
   RoomInfo,
@@ -148,7 +149,7 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
       return;
     }

-    FfiClient.instance.request<DisconnectResponse>({
+    const res = FfiClient.instance.request<DisconnectResponse>({
       message: {
         case: 'disconnect',
         value: {
@@ -157,6 +158,10 @@ export class Room extends (EventEmitter as new () => TypedEmitter<RoomCallbacks>
       },
     });

+    await FfiClient.instance.waitFor<DisconnectCallback>((ev: FfiEvent) => {
+      return ev.message.case == 'disconnect' && ev.message.value.asyncId == res.asyncId;
+    });
+
     FfiClient.instance.removeAllListeners();
     this.removeAllListeners();
   }
```

</details>