### PR TITLE
Add publish_dtmf

### DIFF
--- a/livekit-ffi/protocol/ffi.proto
+++ b/livekit-ffi/protocol/ffi.proto
@@ -68,6 +68,7 @@ message FfiRequest {
     SetLocalAttributesRequest set_local_attributes = 11;
     GetSessionStatsRequest get_session_stats = 12;
     PublishTranscriptionRequest publish_transcription = 13;
+    PublishSipDtmfRequest publish_sip_dtmf = 14;
 
     // Track
     CreateVideoTrackRequest create_video_track = 15;
@@ -107,6 +108,7 @@ message FfiResponse {
     SetLocalAttributesResponse set_local_attributes = 11;
     GetSessionStatsResponse get_session_stats = 12;
     PublishTranscriptionResponse publish_transcription = 13;
+    PublishSipDtmfResponse publish_sip_dtmf = 14;
 
     // Track
     CreateVideoTrackResponse create_video_track = 15;

--- a/livekit-ffi/protocol/ffi.proto
+++ b/livekit-ffi/protocol/ffi.proto
@@ -150,6 +150,7 @@ message FfiEvent {
     LogBatch logs = 16;
     GetSessionStatsCallback get_session_stats = 17;
     Panic panic = 18;
+    PublishSipDtmfCallback publish_sip_dtmf = 19;
   }
 }
 

--- a/livekit-ffi/protocol/room.proto
+++ b/livekit-ffi/protocol/room.proto
@@ -116,6 +116,21 @@ message PublishTranscriptionCallback {
   optional string error = 2;
 }
 
+// Publish Sip DTMF messages to other participants
+message PublishSipDtmfRequest {
+  uint64 local_participant_handle = 1;
+  uint32 code = 2;
+  string digit = 3;
+  repeated string destination_identities = 4;
+}
+message PublishSipDtmfResponse {
+  uint64 async_id = 1;
+}
+message PublishSipDtmfCallback {
+  uint64 async_id = 1;
+  optional string error = 2;
+}
+
 // Change the local participant's metadata
 message UpdateLocalMetadataRequest {
   uint64 local_participant_handle = 1;

--- a/livekit-ffi/src/livekit.proto.rs
+++ b/livekit-ffi/src/livekit.proto.rs
@@ -3046,7 +3046,7 @@ impl AudioSourceType {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FfiRequest {
-    #[prost(oneof="ffi_request::Message", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 18, 19, 20, 21, 23, 24, 25, 26, 27, 28")]
+    #[prost(oneof="ffi_request::Message", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 23, 24, 25, 26, 27, 28")]
     pub message: ::core::option::Option<ffi_request::Message>,
 }
 /// Nested message and enum types in `FfiRequest`.
@@ -3079,6 +3079,8 @@ pub mod ffi_request {
         GetSessionStats(super::GetSessionStatsRequest),
         #[prost(message, tag="13")]
         PublishTranscription(super::PublishTranscriptionRequest),
+        #[prost(message, tag="14")]
+        PublishSipDtmf(super::PublishSipDtmfRequest),
         /// Track
         #[prost(message, tag="15")]
         CreateVideoTrack(super::CreateVideoTrackRequest),
@@ -3114,7 +3116,7 @@ pub mod ffi_request {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FfiResponse {
-    #[prost(oneof="ffi_response::Message", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27")]
+    #[prost(oneof="ffi_response::Message", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27")]
     pub message: ::core::option::Option<ffi_response::Message>,
 }
 /// Nested message and enum types in `FfiResponse`.
@@ -3147,6 +3149,8 @@ pub mod ffi_response {
         GetSessionStats(super::GetSessionStatsResponse),
         #[prost(message, tag="13")]
         PublishTranscription(super::PublishTranscriptionResponse),
+        #[prost(message, tag="14")]
+        PublishSipDtmf(super::PublishSipDtmfResponse),
         /// Track
         #[prost(message, tag="15")]
         CreateVideoTrack(super::CreateVideoTrackResponse),

--- a/livekit-ffi/src/livekit.proto.rs
+++ b/livekit-ffi/src/livekit.proto.rs
@@ -2070,6 +2070,33 @@ pub struct PublishTranscriptionCallback {
     #[prost(string, optional, tag="2")]
     pub error: ::core::option::Option<::prost::alloc::string::String>,
 }
+/// Publish Sip DTMF messages to other participants
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PublishSipDtmfRequest {
+    #[prost(uint64, tag="1")]
+    pub local_participant_handle: u64,
+    #[prost(uint32, tag="2")]
+    pub code: u32,
+    #[prost(string, tag="3")]
+    pub digit: ::prost::alloc::string::String,
+    #[prost(string, repeated, tag="4")]
+    pub destination_identities: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PublishSipDtmfResponse {
+    #[prost(uint64, tag="1")]
+    pub async_id: u64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PublishSipDtmfCallback {
+    #[prost(uint64, tag="1")]
+    pub async_id: u64,
+    #[prost(string, optional, tag="2")]
+    pub error: ::core::option::Option<::prost::alloc::string::String>,
+}
 /// Change the local participant's metadata
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -3112,7 +3139,7 @@ pub mod ffi_response {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FfiEvent {
-    #[prost(oneof="ffi_event::Message", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18")]
+    #[prost(oneof="ffi_event::Message", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19")]
     pub message: ::core::option::Option<ffi_event::Message>,
 }
 /// Nested message and enum types in `FfiEvent`.
@@ -3156,6 +3183,8 @@ pub mod ffi_event {
         GetSessionStats(super::GetSessionStatsCallback),
         #[prost(message, tag="18")]
         Panic(super::Panic),
+        #[prost(message, tag="19")]
+        PublishSipDtmf(super::PublishSipDtmfCallback),
     }
 }
 /// Stop all rooms synchronously (Do we need async here?).

--- a/livekit-ffi/src/server/requests.rs
+++ b/livekit-ffi/src/server/requests.rs
@@ -122,6 +122,18 @@ fn on_publish_transcription(
     ffi_participant.room.publish_transcription(server, publish)
 }
 
+/// Publish sip dtmf messages to the room
+fn on_publish_sip_dtmf(
+    server: &'static FfiServer,
+    publish: proto::PublishSipDtmfRequest,
+) -> FfiResult<proto::PublishSipDtmfResponse> {
+    // Push the data to an async queue (avoid blocking and keep the order)
+    let ffi_participant =
+        server.retrieve_handle::<FfiParticipant>(publish.local_participant_handle)?;
+
+    ffi_participant.room.publish_sip_dtmf(server, publish)
+}
+
 /// Change the desired subscription state of a publication
 fn on_set_subscribed(
     server: &'static FfiServer,

--- a/livekit-ffi/src/server/requests.rs
+++ b/livekit-ffi/src/server/requests.rs
@@ -604,6 +604,9 @@ pub fn handle_request(
                 server, publish,
             )?)
         }
+        proto::ffi_request::Message::PublishSipDtmf(publish) => {
+            proto::ffi_response::Message::PublishSipDtmf(on_publish_sip_dtmf(server, publish)?)
+        }
         proto::ffi_request::Message::SetSubscribed(subscribed) => {
             proto::ffi_response::Message::SetSubscribed(on_set_subscribed(server, subscribed)?)
         }

--- a/livekit/src/prelude.rs
+++ b/livekit/src/prelude.rs
@@ -21,5 +21,5 @@ pub use crate::{
         RemoteVideoTrack, StreamState, Track, TrackDimension, TrackKind, TrackSource, VideoTrack,
     },
     ConnectionState, DataPacket, DataPacketKind, Room, RoomError, RoomEvent, RoomOptions,
-    RoomResult, Transcription, TranscriptionSegment,
+    RoomResult, SipDTMF, Transcription, TranscriptionSegment,
 };

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -211,6 +211,13 @@ pub struct TranscriptionSegment {
     pub language: String,
 }
 
+#[derive(Default, Debug, Clone)]
+pub struct SipDTMF {
+    pub code: u32,
+    pub digit: String,
+    pub destination_identities: Vec<ParticipantIdentity>,
+}
+
 #[derive(Debug, Clone)]
 pub struct RoomOptions {
     pub auto_subscribe: bool,

--- a/livekit/src/room/participant/local_participant.rs
+++ b/livekit/src/room/participant/local_participant.rs
@@ -25,7 +25,7 @@ use crate::{
     options::{compute_video_encodings, video_layers_from_encodings, TrackPublishOptions},
     prelude::*,
     rtc_engine::RtcEngine,
-    DataPacket, Transcription, TranscriptionSegment,
+    DataPacket, SipDTMF, Transcription, TranscriptionSegment,
 };
 
 type LocalTrackPublishedHandler = Box<dyn Fn(LocalParticipant, LocalTrackPublication) + Send>;
@@ -338,6 +338,24 @@ impl LocalParticipant {
             value: Some(proto::data_packet::Value::Transcription(transcription_packet)),
             ..Default::default()
         };
+        self.inner
+            .rtc_engine
+            .publish_data(&data, DataPacketKind::Reliable)
+            .await
+            .map_err(Into::into)
+    }
+
+    pub async fn publish_dtmf(&self, dtmf: SipDTMF) -> RoomResult<()> {
+        let destination_identities: Vec<String> =
+            dtmf.destination_identities.into_iter().map(Into::into).collect();
+        let dtmf_message = proto::SipDtmf { code: dtmf.code, digit: dtmf.digit };
+
+        let data = proto::DataPacket {
+            value: Some(proto::data_packet::Value::SipDtmf(dtmf_message)),
+            destination_identities: destination_identities.clone(),
+            ..Default::default()
+        };
+
         self.inner
             .rtc_engine
             .publish_data(&data, DataPacketKind::Reliable)


### PR DESCRIPTION
implementation naming varies between `publish_dtmf` and `publish_sip_dtmf`. 
The intention was to use `publish_dtmf` on exposed APIs and `publish_sip_dtmf` for sdk-internal messaging.

Not sure anymore if that distinction makes any sense though.