### PR TITLE
Fix attribute diff logic

### DIFF
--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -1156,6 +1156,15 @@ impl RoomSession {
             }
         });
 
+        participant.on_attributes_changed({
+            let dispatcher = self.dispatcher.clone();
+            move |participant, changed_attributes| {
+                let event =
+                    RoomEvent::ParticipantAttributesChanged { participant, changed_attributes };
+                dispatcher.dispatch(&event);
+            }
+        });
+
         let mut participants = self.remote_participants.write();
         participants.insert(identity, participant.clone());
         participant

--- a/livekit/src/room/participant/mod.rs
+++ b/livekit/src/room/participant/mod.rs
@@ -152,11 +152,13 @@ pub(super) fn update_info(
         }
     }
 
-    if new_info.attributes.len() != 0 {
-        let changed_attributes = utils::calculate_changed_attributes(
-            info.attributes.clone(),
+    let old_attributes = std::mem::replace(&mut info.attributes, new_info.attributes.clone());
+    // print new attributes
+    let changed_attributes = utils::calculate_changed_attributes(
+            old_attributes,
             new_info.attributes.clone(),
-        );
+    );
+    if changed_attributes.len() != 0  {
         if let Some(cb) = inner.events.attributes_changed.lock().as_ref() {
             cb(participant.clone(), changed_attributes);
         }

--- a/livekit/src/room/participant/mod.rs
+++ b/livekit/src/room/participant/mod.rs
@@ -153,7 +153,6 @@ pub(super) fn update_info(
     }
 
     let old_attributes = std::mem::replace(&mut info.attributes, new_info.attributes.clone());
-    // print new attributes
     let changed_attributes = utils::calculate_changed_attributes(
             old_attributes,
             new_info.attributes.clone(),


### PR DESCRIPTION
Attribute diff logic didn't exactly match the behavior of client-sdk-js

Tested manually against python-sdk