### PR TITLE
Fix broken examples.

### DIFF
--- a/examples/api/Cargo.toml
+++ b/examples/api/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 tokio = { version = "1", features = ["full", "parking_lot"] }
-livekit-api = { path = "../../livekit-api", version = "0.3.2", features = ["native-tls"] }
+livekit-api = { path = "../../livekit-api", features = ["native-tls"] }
 futures = "0.3"
 

--- a/examples/basic_room/Cargo.toml
+++ b/examples/basic_room/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 [dependencies]
 tokio = { version = "1", features = ["full"] }
 env_logger = "0.10"
-livekit = { path = "../../livekit", version = "0.3.2", features = ["native-tls"]}
-livekit-api = { path = "../../livekit-api", version = "0.3.2"}
+livekit = { path = "../../livekit", features = ["native-tls"]}
+livekit-api = { path = "../../livekit-api"}
 log = "0.4"

--- a/examples/basic_room/src/main.rs
+++ b/examples/basic_room/src/main.rs
@@ -27,12 +27,12 @@ async fn main() {
     let (room, mut rx) = Room::connect(&url, &token, RoomOptions::default())
         .await
         .unwrap();
-    log::info!("Connected to room: {} - {}", room.name(), room.sid());
+    log::info!("Connected to room: {} - {}", room.name(), String::from(room.sid().await));
 
     room.local_participant()
         .publish_data(DataPacket {
             payload: "Hello world".to_owned().into_bytes(),
-            kind: DataPacketKind::Reliable,
+            reliable: true,
             ..Default::default()
         })
         .await

--- a/examples/basic_room_async/Cargo.toml
+++ b/examples/basic_room_async/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 futures = "0.3.0"
 async-std = "1"
 env_logger = "0.10"
-livekit = { path = "../../livekit", version = "0.3.0", default-features = false, features = ["native-tls", "async"]}
-livekit-api = { path = "../../livekit-api", version = "0.3.0"}
+livekit = { path = "../../livekit", default-features = false, features = ["native-tls", "async"]}
+livekit-api = { path = "../../livekit-api" }
 log = "0.4"
 
 [workspace]

--- a/examples/basic_room_dispatcher/Cargo.toml
+++ b/examples/basic_room_dispatcher/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 futures = "0.3.0"
 smol = "2.0.0"
 env_logger = "0.10"
-livekit = { path = "../../livekit", version = "0.3.0", default-features = false, features = ["native-tls", "dispatcher"]}
-livekit-api = { path = "../../livekit-api", version = "0.3.0"}
+livekit = { path = "../../livekit", default-features = false, features = ["native-tls", "dispatcher"]}
+livekit-api = { path = "../../livekit-api" }
 log = "0.4"
 
 [workspace]

--- a/examples/mobile/Cargo.toml
+++ b/examples/mobile/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 lazy_static = "1.4.0"
-livekit = { path = "../../livekit", version = "0.3.2", features = ["rustls-tls-webpki-roots"] }
+livekit = { path = "../../livekit", features = ["rustls-tls-webpki-roots"] }
 log = "0.4.19"
 tokio = { version = "1", features = ["full"] }
 
@@ -14,7 +14,7 @@ jni = "0.21.1"
 android_logger = "0.13.1"
 
 [build-dependencies]
-webrtc-sys-build = { path = "../../webrtc-sys/build", version = "0.3.2" }
+webrtc-sys-build = { path = "../../webrtc-sys/build" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -32,7 +32,7 @@ pub fn livekit_connect(url: String, token: String) {
         }
 
         let (room, mut events) = res.unwrap();
-        log::info!("Connected to room {}", room.sid());
+        log::info!("Connected to room {}", String::from(room.sid().await));
 
         while let Some(event) = events.recv().await {
             log::info!("Received event {:?}", event);

--- a/examples/play_from_disk/Cargo.toml
+++ b/examples/play_from_disk/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
-livekit = { path = "../../livekit", version = "0.3.2" }
+livekit = { path = "../../livekit" }
 thiserror = "1.0.47"
 log = "0.4.20"
 env_logger = "0.10.0"

--- a/examples/save_to_disk/Cargo.toml
+++ b/examples/save_to_disk/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
-livekit = { path = "../../livekit", version = "0.3.2" }
+livekit = { path = "../../livekit" }
 bytes = "1.4.0"
 tokio-util = "0.7.8"
 futures = "0.3.28"

--- a/examples/save_to_disk/src/main.rs
+++ b/examples/save_to_disk/src/main.rs
@@ -92,7 +92,8 @@ async fn main() {
     let (room, mut rx) = Room::connect(&url, &token, RoomOptions::default())
         .await
         .unwrap();
-    println!("Connected to room: {} - {}", room.name(), room.sid());
+    let sid = room.sid().await;
+    println!("Connected to room: {} - {}", room.name(), String::from(sid));
 
     while let Some(msg) = rx.recv().await {
         #[allow(clippy::single_match)]

--- a/examples/save_to_disk/src/main.rs
+++ b/examples/save_to_disk/src/main.rs
@@ -92,8 +92,7 @@ async fn main() {
     let (room, mut rx) = Room::connect(&url, &token, RoomOptions::default())
         .await
         .unwrap();
-    let sid = room.sid().await;
-    println!("Connected to room: {} - {}", room.name(), String::from(sid));
+    println!("Connected to room: {} - {}", room.name(), String::from(room.sid().await));
 
     while let Some(msg) = rx.recv().await {
         #[allow(clippy::single_match)]

--- a/examples/webhooks/Cargo.toml
+++ b/examples/webhooks/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-livekit-api = { version = "0.3.2", path = "../../livekit-api" }
+livekit-api = { path = "../../livekit-api" }
 hyper = { version = "0.14", features = ["full"] }
 tokio = { version = "1", features = ["full"] }

--- a/examples/wgpu_room/Cargo.toml
+++ b/examples/wgpu_room/Cargo.toml
@@ -9,7 +9,7 @@ tracing = ["console-subscriber", "tokio/tracing"]
 
 [dependencies]
 tokio = { version = "1", features = ["full", "parking_lot"] }
-livekit = { path = "../../livekit", version = "0.3.2", features = ["native-tls"] }
+livekit = { path = "../../livekit", features = ["native-tls"] }
 futures = "0.3"
 winit = "0.28"
 parking_lot = { version = "0.12.1", features = ["deadlock_detection"] }

--- a/examples/wgpu_room/src/app.rs
+++ b/examples/wgpu_room/src/app.rs
@@ -238,7 +238,7 @@ impl LkApp {
 
         if let Some(room) = room.as_ref() {
             ui.label(format!("Name: {}", room.name()));
-            //ui.label(format!("Sid: {}", String::from(sid)));
+            //ui.label(format!("Sid: {}", String::from(room.sid().await)));
             ui.label(format!("ConnectionState: {:?}", room.connection_state()));
             ui.label(format!(
                 "ParticipantCount: {:?}",

--- a/examples/wgpu_room/src/service.rs
+++ b/examples/wgpu_room/src/service.rs
@@ -202,7 +202,7 @@ async fn service_task(inner: Arc<ServiceInner>, mut cmd_rx: mpsc::UnboundedRecei
             }
             AsyncCmd::LogStats => {
                 if let Some(state) = running_state.as_ref() {
-                    for (_, publication) in state.room.local_participant().tracks() {
+                    for (_, publication) in state.room.local_participant().track_publications() {
                         if let Some(track) = publication.track() {
                             log::info!(
                                 "track stats: LOCAL {:?} {:?}",
@@ -212,8 +212,8 @@ async fn service_task(inner: Arc<ServiceInner>, mut cmd_rx: mpsc::UnboundedRecei
                         }
                     }
 
-                    for (_, participant) in state.room.participants() {
-                        for (_, publication) in participant.tracks() {
+                    for (_, participant) in state.room.remote_participants() {
+                        for (_, publication) in participant.track_publications() {
                             if let Some(track) = publication.track() {
                                 log::info!(
                                     "track stats: {:?} {:?} {:?}",

--- a/examples/wgpu_room/src/sine_track.rs
+++ b/examples/wgpu_room/src/sine_track.rs
@@ -46,6 +46,7 @@ impl SineTrack {
                 AudioSourceOptions::default(),
                 params.sample_rate,
                 params.num_channels,
+                None,
             ),
             params,
             room,


### PR DESCRIPTION
changes:
Since the examples use directories as dependencies, they should always correspond to the livekit api version, so the version field is removed from all examples' Cargo.toml

close https://github.com/livekit/rust-sdks/issues/380

Just tested, basic_room and wgpu_room are working again.