### PR TITLE
Remove unexpected close error message

### DIFF
--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -1024,9 +1024,8 @@ impl RoomSession {
             self.dispatcher.dispatch(&RoomEvent::Disconnected { reason });
         }
 
+        log::info!("disconnected from room with reason: {:?}", reason);
         if reason != DisconnectReason::ClientInitiated {
-            log::error!("unexpectedly disconnected from room: {:?}", reason);
-
             livekit_runtime::spawn({
                 let inner = self.clone();
                 async move {


### PR DESCRIPTION
This is confusing to be logged at the Rust layer.