### PR TITLE
actually bump livekit to 0.5.2

### DIFF
--- a/livekit/Cargo.toml
+++ b/livekit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "livekit"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust Client SDK for LiveKit"


### PR DESCRIPTION
tagging this commit `v0.5.2` when merged for CI and crates.io