### PR TITLE
Increase default audio bitrates

### DIFF
--- a/livekit/src/room/options.rs
+++ b/livekit/src/room/options.rs
@@ -307,11 +307,11 @@ pub mod audio {
     use super::AudioPreset;
 
     pub const TELEPHONE: AudioPreset = AudioPreset::new(12_000);
-    pub const SPEECH: AudioPreset = AudioPreset::new(20_000);
-    pub const MUSIC: AudioPreset = AudioPreset::new(32_000);
-    pub const MUSIC_STEREO: AudioPreset = AudioPreset::new(48_000);
-    pub const MUSIC_HIGH_QUALITY: AudioPreset = AudioPreset::new(64_000);
-    pub const MUSIC_HIGH_QUALITY_STEREO: AudioPreset = AudioPreset::new(96_000);
+    pub const SPEECH: AudioPreset = AudioPreset::new(24_000);
+    pub const MUSIC: AudioPreset = AudioPreset::new(48_000);
+    pub const MUSIC_STEREO: AudioPreset = AudioPreset::new(64_000);
+    pub const MUSIC_HIGH_QUALITY: AudioPreset = AudioPreset::new(96_000);
+    pub const MUSIC_HIGH_QUALITY_STEREO: AudioPreset = AudioPreset::new(128_000);
 
     pub const PRESETS: &[AudioPreset] =
         &[TELEPHONE, SPEECH, MUSIC, MUSIC_STEREO, MUSIC_HIGH_QUALITY, MUSIC_HIGH_QUALITY_STEREO];

--- a/livekit/src/room/participant/local_participant.rs
+++ b/livekit/src/room/participant/local_participant.rs
@@ -210,7 +210,7 @@ impl LocalParticipant {
             LocalTrack::Audio(_audio_track) => {
                 // Setup audio encoding
                 let audio_encoding =
-                    options.audio_encoding.as_ref().unwrap_or(&options::audio::SPEECH.encoding);
+                    options.audio_encoding.as_ref().unwrap_or(&options::audio::MUSIC.encoding);
 
                 encodings.push(RtpEncodingParameters {
                     max_bitrate: Some(audio_encoding.max_bitrate),


### PR DESCRIPTION
Users prefer FullBand audio by default. In most cases this gives a clear boost in both voice and audio quality.