### PR TITLE
send silence frames on the AudioSource when the queue is empty

### DIFF
--- a/webrtc-sys/include/livekit/audio_track.h
+++ b/webrtc-sys/include/livekit/audio_track.h
@@ -104,6 +104,8 @@ class AudioTrackSource {
                    int buffer_size_ms,
                    webrtc::TaskQueueFactory* task_queue_factory);
 
+    ~InternalSource() override;
+
     SourceState state() const override;
     bool remote() const override;
 
@@ -133,6 +135,9 @@ class AudioTrackSource {
 
     const SourceContext* capture_userdata_ RTC_GUARDED_BY(mutex_);
     void (*on_complete_)(const SourceContext*) RTC_GUARDED_BY(mutex_);
+
+    int missed_frames_ RTC_GUARDED_BY(mutex_) = 0;
+    int16_t* silence_buffer_ = nullptr;
 
     int sample_rate_;
     int num_channels_;

--- a/webrtc-sys/src/audio_track.cpp
+++ b/webrtc-sys/src/audio_track.cpp
@@ -139,7 +139,8 @@ AudioTrackSource::InternalSource::InternalSource(
   if (!queue_size_ms)
     return;  // no audio queue
 
-  // start sending silence after missing frames since 100ms
+  // start sending silence when there is nothing on the queue for 10 frames
+  // (100ms)
   const int silence_frames_threshold = 10;
   int samples10ms = sample_rate / 100 * num_channels;
 

--- a/webrtc-sys/src/audio_track.cpp
+++ b/webrtc-sys/src/audio_track.cpp
@@ -139,8 +139,8 @@ AudioTrackSource::InternalSource::InternalSource(
   if (!queue_size_ms)
     return;  // no audio queue
 
-  // start sending silence after missing frames since 80ms
-  const int silence_frames_threshold = 8;
+  // start sending silence after missing frames since 100ms
+  const int silence_frames_threshold = 10;
   int samples10ms = sample_rate / 100 * num_channels;
 
   silence_buffer_ = new int16_t[samples10ms]();

--- a/webrtc-sys/src/audio_track.cpp
+++ b/webrtc-sys/src/audio_track.cpp
@@ -139,11 +139,15 @@ AudioTrackSource::InternalSource::InternalSource(
   if (!queue_size_ms)
     return;  // no audio queue
 
+  // start sending silence after missing frames since 80ms
+  const int silence_frames_threshold = 8;
   int samples10ms = sample_rate / 100 * num_channels;
+
+  silence_buffer_ = new int16_t[samples10ms]();
   queue_size_samples_ = queue_size_ms / 10 * samples10ms;
   notify_threshold_samples_ = queue_size_samples_;  // TODO: this is currently
                                                     // using x2 the queue size
-  buffer_.resize(queue_size_samples_ + notify_threshold_samples_);
+  buffer_.reserve(queue_size_samples_ + notify_threshold_samples_);
 
   audio_queue_ =
       std::make_unique<rtc::TaskQueue>(task_queue_factory->CreateTaskQueue(
@@ -160,6 +164,13 @@ AudioTrackSource::InternalSource::InternalSource(
                          num_channels_, samples10ms / num_channels_);
 
           buffer_.erase(buffer_.begin(), buffer_.begin() + samples10ms);
+        } else {
+          missed_frames_++;
+          if (missed_frames_ >= silence_frames_threshold) {
+            for (auto sink : sinks_)
+              sink->OnData(silence_buffer_, sizeof(int16_t), sample_rate_,
+                           num_channels_, samples10ms / num_channels_);
+          }
         }
 
         if (on_complete_ && buffer_.size() <= notify_threshold_samples_) {
@@ -171,6 +182,10 @@ AudioTrackSource::InternalSource::InternalSource(
         return webrtc::TimeDelta::Millis(10);
       },
       webrtc::TaskQueueBase::DelayPrecision::kHigh);
+}
+
+AudioTrackSource::InternalSource::~InternalSource() {
+  delete[] silence_buffer_;
 }
 
 bool AudioTrackSource::InternalSource::capture_frame(

--- a/webrtc-sys/src/audio_track.cpp
+++ b/webrtc-sys/src/audio_track.cpp
@@ -142,6 +142,8 @@ AudioTrackSource::InternalSource::InternalSource(
   // start sending silence when there is nothing on the queue for 10 frames
   // (100ms)
   const int silence_frames_threshold = 10;
+  missed_frames_ = silence_frames_threshold;
+
   int samples10ms = sample_rate / 100 * num_channels;
 
   silence_buffer_ = new int16_t[samples10ms]();


### PR DESCRIPTION
old
![Screenshot 2024-09-12 at 4 58 11 PM](https://github.com/user-attachments/assets/17871811-05c7-49a0-a338-cecb1e551c1b)

new
![Screenshot 2024-09-12 at 6 55 32 PM](https://github.com/user-attachments/assets/757295cd-95ec-4db3-9fcc-a7fb4df725fd)


also fix buffer reserving space using resize `instead` of `reserve` method