### PR TITLE
don't drop handles on dispose

### DIFF
--- a/livekit-ffi/src/server/mod.rs
+++ b/livekit-ffi/src/server/mod.rs
@@ -136,7 +136,6 @@ impl FfiServer {
 
     pub async fn dispose(&self) {
         self.logger.set_capture_logs(false);
-
         log::info!("disposing ffi server");
 
         // Close all rooms
@@ -152,8 +151,8 @@ impl FfiServer {
         }
 
         // Drop all handles
-        self.ffi_handles.clear();
-        self.handle_dropped_txs.clear();
+        // self.ffi_handles.clear();
+        // self.handle_dropped_txs.clear();
         *self.config.lock() = None; // Invalidate the config
     }
 

--- a/livekit-ffi/src/server/mod.rs
+++ b/livekit-ffi/src/server/mod.rs
@@ -151,8 +151,6 @@ impl FfiServer {
         }
 
         // Drop all handles
-        // self.ffi_handles.clear();
-        // self.handle_dropped_txs.clear();
         *self.config.lock() = None; // Invalidate the config
     }
 


### PR DESCRIPTION
this was making hard to sync handles with the ffi client (the client were still trying to dispose the handles after dispose)