### PR TITLE
await transcription and dtmf handles on room close

### DIFF
--- a/livekit-ffi/src/server/room.rs
+++ b/livekit-ffi/src/server/room.rs
@@ -271,6 +271,8 @@ impl FfiRoom {
             let _ = handle.close_tx.send(());
             let _ = handle.event_handle.await;
             let _ = handle.data_handle.await;
+            let _ = handle.transcription_handle.await;
+            let _ = handle.sip_dtmf_handle.await;
         }
     }
 }


### PR DESCRIPTION
This looked like a bug/oversight that I found while working on RPC. It's also getting flagged by the build (unused vars) but we have a pretty noisy build log so its drowned out.