### PR TITLE
Add the clippy linter to CI

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,4 @@
-name: Rust Formatting
+name: Rust Formatting & Linting
 
 on:
   workflow_dispatch:
@@ -16,8 +16,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  formatting:
-    name: Check Formatting
+  linting:
+    name: Lint & Format
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || !github.event.pull_request.draft
 
@@ -29,8 +29,11 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2023-12-30
-          components: rustfmt
+          components: rustfmt, clippy
 
-      - name: Cargo fmt
-        run: |
-          cargo fmt -- --check
+      - name: rustfmt
+        run: cargo fmt -- --check
+        
+      - name: clippy
+        run: cargo clippy -- -D warnings
+        

--- a/livekit-api/src/access_token.rs
+++ b/livekit-api/src/access_token.rs
@@ -97,6 +97,7 @@ impl Default for VideoGrants {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub struct SIPGrants {
     // manage sip resources
     pub admin: bool,
@@ -104,11 +105,6 @@ pub struct SIPGrants {
     pub call: bool,
 }
 
-impl Default for SIPGrants {
-    fn default() -> Self {
-        Self { admin: false, call: false }
-    }
-}
 
 #[derive(Debug, Clone, Serialize, Default, Deserialize)]
 #[serde(default)]

--- a/livekit-api/src/services/sip.rs
+++ b/livekit-api/src/services/sip.rs
@@ -14,9 +14,8 @@
 
 use livekit_protocol as proto;
 use std::collections::HashMap;
-use std::ptr::null;
 
-use crate::access_token::{SIPGrants, VideoGrants};
+use crate::access_token::SIPGrants;
 use crate::get_env_keys;
 use crate::services::twirp_client::TwirpClient;
 use crate::services::{ServiceBase, ServiceResult, LIVEKIT_PACKAGE};

--- a/livekit-api/src/signal_client/mod.rs
+++ b/livekit-api/src/signal_client/mod.rs
@@ -182,7 +182,7 @@ impl SignalClient {
 
     /// Increment request_id for user-initiated requests and [`RequestResponse`][`proto::RequestResponse`]s
     pub fn next_request_id(&self) -> u32 {
-        self.inner.next_request_id().clone()
+        self.inner.next_request_id()
     }
 }
 

--- a/livekit-ffi/src/server/audio_stream.rs
+++ b/livekit-ffi/src/server/audio_stream.rs
@@ -66,7 +66,7 @@ impl FfiAudioStream {
                     if new_stream.num_channels == 0 { 1 } else { new_stream.num_channels as i32 };
 
                 let native_stream =
-                    NativeAudioStream::new(rtc_track, sample_rate as i32, num_channels as i32);
+                    NativeAudioStream::new(rtc_track, sample_rate, num_channels);
                 let handle = server.async_runtime.spawn(Self::native_audio_stream_task(
                     server,
                     handle_id,
@@ -177,7 +177,6 @@ impl FfiAudioStream {
                             };
                             if t.sid() == track.sid() {
                                 handle_dropped_tx.send(()).ok();
-                                return
                             }
                         }
                     }
@@ -211,7 +210,7 @@ impl FfiAudioStream {
         }
         if let Err(err) = server.send_event(proto::ffi_event::Message::AudioStreamEvent(
             proto::AudioStreamEvent {
-                stream_handle: stream_handle,
+                stream_handle,
                 message: Some(proto::audio_stream_event::Message::Eos(proto::AudioStreamEos {})),
             },
         )) {

--- a/livekit-ffi/src/server/colorcvt/cvtimpl.rs
+++ b/livekit-ffi/src/server/colorcvt/cvtimpl.rs
@@ -31,7 +31,7 @@ pub unsafe fn cvt_rgba(
     assert_eq!(buffer.r#type(), proto::VideoBufferType::Rgba);
     let proto::VideoBufferInfo { stride, width, height, data_ptr, .. } = buffer;
     let data_len = (stride * height) as usize;
-    let data = unsafe { slice::from_raw_parts(data_ptr as *const u8, data_len as usize) };
+    let data = unsafe { slice::from_raw_parts(data_ptr as *const u8, data_len) };
 
     match dst_type {
         proto::VideoBufferType::I420 => {
@@ -77,7 +77,7 @@ pub unsafe fn cvt_abgr(
     assert_eq!(buffer.r#type(), proto::VideoBufferType::Rgba);
     let proto::VideoBufferInfo { stride, width, height, data_ptr, .. } = buffer;
     let data_len = (stride * height) as usize;
-    let data = unsafe { slice::from_raw_parts(data_ptr as *const u8, data_len as usize) };
+    let data = unsafe { slice::from_raw_parts(data_ptr as *const u8, data_len) };
 
     match dst_type {
         proto::VideoBufferType::I420 => {
@@ -123,7 +123,7 @@ pub unsafe fn cvt_argb(
     assert_eq!(buffer.r#type(), proto::VideoBufferType::Argb);
     let proto::VideoBufferInfo { stride, width, height, data_ptr, .. } = buffer;
     let data_len = (stride * height) as usize;
-    let data = unsafe { slice::from_raw_parts(data_ptr as *const u8, data_len as usize) };
+    let data = unsafe { slice::from_raw_parts(data_ptr as *const u8, data_len) };
 
     match dst_type {
         proto::VideoBufferType::I420 => {
@@ -168,7 +168,7 @@ pub unsafe fn cvt_bgra(
     assert_eq!(buffer.r#type(), proto::VideoBufferType::Bgra);
     let proto::VideoBufferInfo { stride, width, height, data_ptr, .. } = buffer;
     let data_len = (stride * height) as usize;
-    let data = unsafe { slice::from_raw_parts(data_ptr as *const u8, data_len as usize) };
+    let data = unsafe { slice::from_raw_parts(data_ptr as *const u8, data_len) };
 
     match dst_type {
         proto::VideoBufferType::I420 => {
@@ -213,7 +213,7 @@ pub unsafe fn cvt_rgb24(
     assert_eq!(buffer.r#type(), proto::VideoBufferType::Rgb24);
     let proto::VideoBufferInfo { stride, width, height, data_ptr, .. } = buffer;
     let data_len = (stride * height) as usize;
-    let data = unsafe { slice::from_raw_parts(data_ptr as *const u8, data_len as usize) };
+    let data = unsafe { slice::from_raw_parts(data_ptr as *const u8, data_len) };
 
     match dst_type {
         proto::VideoBufferType::I420 => {
@@ -245,7 +245,7 @@ pub unsafe fn cvt_rgb24(
             Ok((dst, info))
         }
         _ => {
-            return Err(FfiError::InvalidRequest(
+            Err(FfiError::InvalidRequest(
                 format!("rgb24 to {:?} is not supported", dst_type).into(),
             ))
         }
@@ -338,7 +338,7 @@ pub unsafe fn cvt_i420(
             Ok((dst, info))
         }
         _ => {
-            return Err(FfiError::InvalidRequest(
+            Err(FfiError::InvalidRequest(
                 format!("i420 to {:?} is not supported", dst_type).into(),
             ))
         }
@@ -427,7 +427,7 @@ pub unsafe fn cvt_i420a(
             Ok((dst, info))
         }
         _ => {
-            return Err(FfiError::InvalidRequest(
+            Err(FfiError::InvalidRequest(
                 format!("i420a to {:?} is not supported", dst_type).into(),
             ))
         }
@@ -534,7 +534,7 @@ pub unsafe fn cvt_i422(
             Ok((dst, info))
         }
         _ => {
-            return Err(FfiError::InvalidRequest(
+            Err(FfiError::InvalidRequest(
                 format!("i422 to {:?} is not supported", dst_type).into(),
             ))
         }
@@ -640,7 +640,7 @@ pub unsafe fn cvt_i444(
             Ok((dst, info))
         }
         _ => {
-            return Err(FfiError::InvalidRequest(
+            Err(FfiError::InvalidRequest(
                 format!("i444 to {:?} is not supported", dst_type).into(),
             ))
         }
@@ -716,7 +716,7 @@ pub unsafe fn cvt_i010(
             Ok((dst, info))
         }
         _ => {
-            return Err(FfiError::InvalidRequest(
+            Err(FfiError::InvalidRequest(
                 format!("i010 to {:?} is not supported", dst_type).into(),
             ))
         }
@@ -817,7 +817,7 @@ pub unsafe fn cvt_nv12(
             Ok((dst, info))
         }
         _ => {
-            return Err(FfiError::InvalidRequest(
+            Err(FfiError::InvalidRequest(
                 format!("nv12 to {:?} is not supported", dst_type).into(),
             ))
         }

--- a/livekit-ffi/src/server/requests.rs
+++ b/livekit-ffi/src/server/requests.rs
@@ -237,7 +237,7 @@ fn on_local_track_mute(
 ) -> FfiResult<proto::LocalTrackMuteResponse> {
     let ffi_track = server.retrieve_handle::<FfiTrack>(request.track_handle)?.clone();
 
-    let mut muted = false;
+    let muted;
     match ffi_track.track {
         Track::LocalAudio(track) => {
             if request.mute {
@@ -267,7 +267,7 @@ fn on_enable_remote_track(
 ) -> FfiResult<proto::EnableRemoteTrackResponse> {
     let ffi_track = server.retrieve_handle::<FfiTrack>(request.track_handle)?.clone();
 
-    let mut enabled = false;
+    let enabled;
     match ffi_track.track {
         Track::RemoteAudio(track) => {
             if request.enabled {

--- a/livekit-ffi/src/server/requests.rs
+++ b/livekit-ffi/src/server/requests.rs
@@ -26,7 +26,7 @@ use super::{
     room::{self, FfiParticipant, FfiPublication, FfiTrack},
     video_source, video_stream, FfiError, FfiResult, FfiServer,
 };
-use crate::{conversion::track, proto};
+use crate::proto;
 
 /// Dispose the server, close all rooms and clean up all handles
 /// It is not mandatory to call this function.
@@ -258,7 +258,7 @@ fn on_local_track_mute(
         _ => return Err(FfiError::InvalidRequest("track is not a local track".into())),
     }
 
-    Ok(proto::LocalTrackMuteResponse { muted: muted })
+    Ok(proto::LocalTrackMuteResponse { muted })
 }
 
 fn on_enable_remote_track(
@@ -288,7 +288,7 @@ fn on_enable_remote_track(
         _ => return Err(FfiError::InvalidRequest("track is not a remote track".into())),
     }
 
-    Ok(proto::EnableRemoteTrackResponse { enabled: enabled })
+    Ok(proto::EnableRemoteTrackResponse { enabled })
 }
 
 /// Retrieve the stats from a track
@@ -730,7 +730,7 @@ fn on_push_sox_resampler(
 
             Ok(proto::PushSoxResamplerResponse {
                 output_ptr: output.as_ptr() as u64,
-                size: (output.len() * std::mem::size_of::<i16>()) as u32,
+                size: std::mem::size_of_val(output) as u32,
                 ..Default::default()
             })
         }
@@ -752,7 +752,7 @@ fn on_flush_sox_resampler(
     match resampler.flush() {
         Ok(output) => Ok(proto::FlushSoxResamplerResponse {
             output_ptr: output.as_ptr() as u64,
-            size: (output.len() * std::mem::size_of::<i16>()) as u32,
+            size: std::mem::size_of_val(output) as u32,
             ..Default::default()
         }),
         Err(e) => Ok(proto::FlushSoxResamplerResponse {

--- a/livekit-ffi/src/server/room.rs
+++ b/livekit-ffi/src/server/room.rs
@@ -914,7 +914,7 @@ async fn forward_event(
                 data_ptr: payload.as_ptr() as u64,
                 data_len: payload.len() as u64,
             };
-            let (sid, identity) = match participant {
+            let (_sid, identity) = match participant {
                 Some(p) => (Some(p.sid().to_string()), p.identity().to_string()),
                 None => (None, String::new()),
             };
@@ -954,7 +954,7 @@ async fn forward_event(
             ));
         }
         RoomEvent::SipDTMFReceived { code, digit, participant } => {
-            let (sid, identity) = match participant {
+            let (_sid, identity) = match participant {
                 Some(p) => (Some(p.sid().to_string()), p.identity().to_string()),
                 None => (None, String::new()),
             };

--- a/livekit-ffi/src/server/utils.rs
+++ b/livekit-ffi/src/server/utils.rs
@@ -11,7 +11,7 @@ pub async fn track_changed_trigger(
     track_finished_tx: broadcast::Sender<Track>,
 ) {
     for track_pub in participant.participant.track_publications().values() {
-        if track_pub.source() == track_source.into() {
+        if track_pub.source() == track_source {
             if let Some(track) = track_pub.track() {
                 let _ = track_tx.send(track).await;
             }
@@ -25,7 +25,7 @@ pub async fn track_changed_trigger(
                 if participant.participant.identity() != p.identity() {
                     continue;
                 }
-                if publication.source() == track_source.into() {
+                if publication.source() == track_source {
                     let _ = track_tx.send(track.into()).await;
                 }
             }
@@ -33,7 +33,7 @@ pub async fn track_changed_trigger(
                 if p.identity() != participant.participant.identity() {
                     continue;
                 }
-                if publication.source() == track_source.into() {
+                if publication.source() == track_source {
                     let _ = track_finished_tx.send(track.into());
                 }
             }
@@ -58,5 +58,5 @@ pub fn ffi_participant_from_handle(
     if ffi_participant_handle.is_err() {
         return Err(FfiError::InvalidRequest("participant not found".into()));
     }
-    return Ok(ffi_participant_handle.unwrap().clone());
+    Ok(ffi_participant_handle.unwrap().clone())
 }

--- a/livekit-ffi/src/server/video_stream.rs
+++ b/livekit-ffi/src/server/video_stream.rs
@@ -208,7 +208,7 @@ impl FfiVideoStream {
 
         let track_source = request.track_source();
         let (track_tx, mut track_rx) = mpsc::channel::<Track>(1);
-        let (track_finished_tx, track_finished_rx) = broadcast::channel::<Track>(1);
+        let (track_finished_tx, _track_finished_rx) = broadcast::channel::<Track>(1);
         server.async_runtime.spawn(utils::track_changed_trigger(
             ffi_participant,
             track_source.into(),

--- a/livekit-ffi/src/server/video_stream.rs
+++ b/livekit-ffi/src/server/video_stream.rs
@@ -63,7 +63,7 @@ impl FfiVideoStream {
                 let handle = server.async_runtime.spawn(Self::native_video_stream_task(
                     server,
                     handle_id,
-                    new_stream.format.and_then(|_| Some(new_stream.format())),
+                    new_stream.format.map(|_| new_stream.format()),
                     new_stream.normalize_stride,
                     NativeVideoStream::new(rtc_track),
                     self_dropped_rx,
@@ -93,7 +93,7 @@ impl FfiVideoStream {
         let (self_dropped_tx, self_dropped_rx) = oneshot::channel();
         let stream_type = request.r#type();
         let handle_id = server.next_id();
-        let dst_type = request.format.and_then(|_| Some(request.format()));
+        let dst_type = request.format.map(|_| request.format());
         let stream = match stream_type {
             #[cfg(not(target_arch = "wasm32"))]
             proto::VideoStreamType::VideoStreamNative => {
@@ -237,7 +237,6 @@ impl FfiVideoStream {
                             };
                             if t.sid() == track.sid() {
                                 handle_dropped_tx.send(()).ok();
-                                return
                             }
                         }
                     }

--- a/livekit-protocol/src/promise.rs
+++ b/livekit-protocol/src/promise.rs
@@ -20,6 +20,12 @@ pub struct Promise<T> {
     result: Mutex<Option<T>>,
 }
 
+impl<T: Clone> Default for Promise<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T: Clone> Promise<T> {
     pub fn new() -> Self {
         let (tx, rx) = oneshot::channel();

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -194,6 +194,7 @@ pub enum DataPacketKind {
 }
 
 #[derive(Debug, Clone)]
+#[derive(Default)]
 pub struct DataPacket {
     pub payload: Vec<u8>,
     pub topic: Option<String>,
@@ -201,16 +202,6 @@ pub struct DataPacket {
     pub destination_identities: Vec<ParticipantIdentity>,
 }
 
-impl Default for DataPacket {
-    fn default() -> Self {
-        Self {
-            payload: Vec::new(),
-            topic: None,
-            reliable: false,
-            destination_identities: Vec::new(),
-        }
-    }
-}
 
 #[derive(Default, Debug, Clone)]
 pub struct Transcription {
@@ -1264,7 +1255,7 @@ impl RoomSession {
         if identity == &self.local_participant.identity() {
             return Some(Participant::Local(self.local_participant.clone()));
         }
-        return self.get_participant_by_identity(identity).map(Participant::Remote);
+        self.get_participant_by_identity(identity).map(Participant::Remote)
     }
 }
 

--- a/livekit/src/room/participant/local_participant.rs
+++ b/livekit/src/room/participant/local_participant.rs
@@ -15,7 +15,7 @@
 use std::{
     collections::HashMap,
     fmt::Debug,
-    sync::{self, Arc},
+    sync::{Arc},
     time::Duration,
 };
 
@@ -385,19 +385,19 @@ impl LocalParticipant {
             .segments
             .into_iter()
             .map(
-                (|segment| proto::TranscriptionSegment {
+                |segment| proto::TranscriptionSegment {
                     id: segment.id,
                     start_time: segment.start_time,
                     end_time: segment.end_time,
                     text: segment.text,
                     r#final: segment.r#final,
                     language: segment.language,
-                }),
+                },
             )
             .collect();
         let transcription_packet = proto::Transcription {
             transcribed_participant_identity: packet.participant_identity,
-            segments: segments,
+            segments,
             track_id: packet.track_id,
         };
         let data = proto::DataPacket {

--- a/livekit/src/room/participant/mod.rs
+++ b/livekit/src/room/participant/mod.rs
@@ -169,7 +169,7 @@ pub(super) fn update_info(
     let old_attributes = std::mem::replace(&mut info.attributes, new_info.attributes.clone());
     let changed_attributes =
         utils::calculate_changed_attributes(old_attributes, new_info.attributes.clone());
-    if changed_attributes.len() != 0 {
+    if !changed_attributes.is_empty() {
         if let Some(cb) = inner.events.attributes_changed.lock().as_ref() {
             cb(participant.clone(), changed_attributes);
         }

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -613,7 +613,7 @@ impl SessionInner {
                                 kind: data.kind().into(),
                                 participant_sid: participant_sid.map(|s| s.try_into().unwrap()),
                                 participant_identity: participant_identity
-                                    .map(|s| s.try_into().unwrap()),
+                                    .map(|s| s.into()),
                                 payload: user.payload.clone(),
                                 topic: user.topic.clone(),
                             });
@@ -628,7 +628,7 @@ impl SessionInner {
 
                             let _ = self.emitter.send(SessionEvent::SipDTMF {
                                 participant_identity: participant_identity
-                                    .map(|s| s.try_into().unwrap()),
+                                    .map(|s| s.into()),
                                 digit: digit.map(|s| s.try_into().unwrap()),
                                 code: dtmf.code,
                             });

--- a/soxr-sys/src/lib.rs
+++ b/soxr-sys/src/lib.rs
@@ -6,8 +6,8 @@ include!("soxr.rs");
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::File;
-    use std::io::{Read, Seek, SeekFrom};
+    
+    
 
     #[test]
     fn it_works() {
@@ -80,8 +80,8 @@ mod tests {
         let mut error: soxr_error_t = ptr::null();
 
         let io_spec = soxr_io_spec {
-            itype: soxr_datatype_t_SOXR_INT16_I as u32,
-            otype: soxr_datatype_t_SOXR_INT16_I as u32,
+            itype: soxr_datatype_t_SOXR_INT16_I,
+            otype: soxr_datatype_t_SOXR_INT16_I,
             scale: 1.0,
             e: ptr::null_mut(),
             flags: 0,

--- a/webrtc-sys/build.rs
+++ b/webrtc-sys/build.rs
@@ -238,7 +238,7 @@ fn get_output_path() -> PathBuf {
     let build_target = env::var("TARGET").unwrap();
     let path =
         Path::new(&manifest_dir_string).join("../target").join(build_target).join(build_type);
-    return PathBuf::from(path);
+    path
 }
 
 fn configure_darwin_sysroot(builder: &mut cc::Build) {


### PR DESCRIPTION
We've got a good deal of linter churn, like unused or ungrouped imports, unnecessary casts, unnecessary name repetition etc.

This runs the clippy linter in CI and I also ran it once on the while project with `cargo clippy --fix`. This should keep project churn down going forward.

Open to other thoughts if anyone has them!