### PR TITLE
Fix enconding presets

### DIFF
--- a/livekit/src/room/options.rs
+++ b/livekit/src/room/options.rs
@@ -179,7 +179,7 @@ pub fn compute_appropriate_encoding(
 
     for preset in presets {
         encoding = preset.encoding.clone();
-        if preset.width >= size {
+        if preset.width > size {
             break;
         }
     }
@@ -257,6 +257,7 @@ pub fn into_rtp_encodings(
         })
     }
 
+    encodings.reverse();
     encodings
 }
 


### PR DESCRIPTION
Fixes an issue with compute_appropriate_encoding, where the last preset in the list with the highest FPS wasn't considered.

Changes the order in into_rtp_encodings to have the highest quality first.