### PR TITLE
Avoid extra dylib dependencies

### DIFF
--- a/webrtc-sys/build.rs
+++ b/webrtc-sys/build.rs
@@ -126,9 +126,6 @@ fn main() {
             builder.flag("/std:c++20").flag("/EHsc");
         }
         "linux" => {
-            println!("cargo:rustc-link-lib=dylib=Xext");
-            println!("cargo:rustc-link-lib=dylib=X11");
-            println!("cargo:rustc-link-lib=dylib=GL");
             println!("cargo:rustc-link-lib=dylib=rt");
             println!("cargo:rustc-link-lib=dylib=dl");
             println!("cargo:rustc-link-lib=dylib=pthread");


### PR DESCRIPTION
Neither X or OpenGL related libraries are needed for livekit sdk to work in the client code.

When trying to use LiveKit Rust SDK in Zed, its Linux build fails with 

https://github.com/zed-industries/zed/actions/runs/11149886429/job/30989794892?pr=13343#step:7:768
```
  = note: mold: library not found: GL
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

which is "expected": Zed does not support OpenGL backend, using Vulkan instead.

Due to this, it does not make any sense to link with it, and it seems that neither examples I've tried checking need that?
Happy to revisit the removal list after someone with more context explains it better.