### PR TITLE
Check RPC version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "livekit-ffi"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "console-subscriber",
  "dashmap",

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -703,6 +703,7 @@ impl RoomSession {
                         method,
                         payload,
                         response_timeout_ms,
+                        version,
                     )
                     .await;
             }

--- a/livekit/src/room/participant/rpc.rs
+++ b/livekit/src/room/participant/rpc.rs
@@ -60,6 +60,7 @@ pub enum RpcErrorCode {
     RecipientNotFound = 1401,
     RequestPayloadTooLarge = 1402,
     UnsupportedServer = 1403,
+    UnsupportedVersion = 1404,
 }
 
 impl RpcErrorCode {
@@ -76,6 +77,7 @@ impl RpcErrorCode {
             Self::RecipientNotFound => "Recipient not found",
             Self::RequestPayloadTooLarge => "Request payload too large",
             Self::UnsupportedServer => "RPC not supported by server",
+            Self::UnsupportedVersion => "Unsupported RPC version",
         }
     }
 }


### PR DESCRIPTION
This rejects requests with the wrong version, which we hopefully don't need to use but does allow us optionality in the future to change the protocol in a breaking way.