### PR TITLE
expose libwebrtc's ProhibitLibsrtpInitialization

### DIFF
--- a/webrtc-sys/build.rs
+++ b/webrtc-sys/build.rs
@@ -47,6 +47,7 @@ fn main() {
         "src/yuv_helper.rs",
         "src/audio_resampler.rs",
         "src/android.rs",
+        "src/prohibit_libsrtp_initialization.rs",
     ]);
 
     builder.files(&[
@@ -73,6 +74,7 @@ fn main() {
         "src/audio_resampler.cpp",
         "src/frame_cryptor.cpp",
         "src/global_task_queue.cpp",
+        "src/prohibit_libsrtp_initialization.cpp",
     ]);
 
     let webrtc_dir = webrtc_sys_build::webrtc_dir();

--- a/webrtc-sys/include/livekit/prohibit_libsrtp_initialization.h
+++ b/webrtc-sys/include/livekit/prohibit_libsrtp_initialization.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace livekit {
+void ProhibitLibsrtpInitialization();
+}

--- a/webrtc-sys/src/lib.rs
+++ b/webrtc-sys/src/lib.rs
@@ -25,6 +25,7 @@ pub mod media_stream;
 pub mod media_stream_track;
 pub mod peer_connection;
 pub mod peer_connection_factory;
+pub mod prohibit_libsrtp_initialization;
 pub mod rtc_error;
 pub mod rtp_parameters;
 pub mod rtp_receiver;

--- a/webrtc-sys/src/prohibit_libsrtp_initialization.cpp
+++ b/webrtc-sys/src/prohibit_libsrtp_initialization.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "pc/srtp_session.h"
+
+namespace livekit {
+void ProhibitLibsrtpInitialization() {
+    cricket::ProhibitLibsrtpInitialization();
+}
+}

--- a/webrtc-sys/src/prohibit_libsrtp_initialization.rs
+++ b/webrtc-sys/src/prohibit_libsrtp_initialization.rs
@@ -1,0 +1,22 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cxx::bridge(namespace = "livekit")]
+pub mod ffi {
+    unsafe extern "C++" {
+        include!("livekit/prohibit_libsrtp_initialization.h");
+
+        fn ProhibitLibsrtpInitialization();
+    }
+}


### PR DESCRIPTION
This allows for applications to intialize `libsrtp` for their own direct use, without `libwebrtc` later breaking because it can't initialize `libsrtp`)