### PR TITLE
fix: don't overwrite the url path in twirp-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "livekit-ffi"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "console-subscriber",
  "dashmap",

--- a/livekit-api/src/services/twirp_client.rs
+++ b/livekit-api/src/services/twirp_client.rs
@@ -102,7 +102,10 @@ impl TwirpClient {
         mut headers: HeaderMap,
     ) -> TwirpResult<R> {
         let mut url = url::Url::parse(&self.host)?;
-        url.set_path(&format!("{}/{}.{}/{}", self.prefix, self.pkg, service, method));
+
+        if let Ok(mut segs) = url.path_segments_mut() {
+            segs.push(&format!("{}/{}.{}/{}", self.prefix, self.pkg, service, method));
+        }
 
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/protobuf"));
 


### PR DESCRIPTION
The twirp client overwrites the URL path, which can lead to unexpected behavior. This was already fixed for other parts of the code base (https://github.com/livekit/rust-sdks/issues/217).