### PR TITLE
Use rust::String::lossy for stringification to avoid crashing due to non-utf8 content

### DIFF
--- a/webrtc-sys/src/jsep.cpp
+++ b/webrtc-sys/src/jsep.cpp
@@ -53,7 +53,7 @@ rust::String IceCandidate::candidate() const {
 rust::String IceCandidate::stringify() const {
   std::string str;
   ice_candidate_->ToString(&str);
-  return rust::String{str};
+  return rust::String::lossy(str);
 }
 
 std::unique_ptr<webrtc::IceCandidateInterface> IceCandidate::release() {
@@ -85,7 +85,7 @@ SdpType SessionDescription::sdp_type() const {
 rust::String SessionDescription::stringify() const {
   std::string str;
   session_description_->ToString(&str);
-  return rust::String{str};
+  return rust::String::lossy(str);
 }
 
 std::unique_ptr<SessionDescription> SessionDescription::clone() const {


### PR DESCRIPTION
This was causing crashes [here](https://github.com/zed-industries/zed/blob/76936fa5b44103136375a823e5b76476ae82683e/crates/live_kit_client/examples/test_app.rs#L106) in Zed's live kit test app when run on Linux.