### PR TITLE
Add support for swapping out the HTTP Client 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
 
 [[package]]
+name = "async-tls"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ae3c9eba89d472a0e4fe1dea433df78fbbe63d2b764addaf2ba3a6bde89a5e"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "rustls",
+ "rustls-pemfile",
+ "webpki-roots 0.22.6",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +246,7 @@ checksum = "ef0f8d64ef9351752fbe5462f242c625d9c4910d2bc3f7ec44c43857ca123f5d"
 dependencies = [
  "async-native-tls",
  "async-std",
+ "async-tls",
  "futures-io",
  "futures-util",
  "log",
@@ -2349,7 +2363,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.3",
  "winreg",
 ]
 
@@ -2916,7 +2930,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls",
  "tungstenite 0.20.1",
- "webpki-roots",
+ "webpki-roots 0.25.3",
 ]
 
 [[package]]
@@ -3284,6 +3298,25 @@ checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ members = [
 
 [workspace.dependencies]
 libwebrtc = { version = "0.3.7", path = "libwebrtc" }
-livekit-api = { version = "0.4.1", path = "livekit-api" }
+livekit-api = { version = "0.4.1", path = "livekit-api", default-features = false }
 livekit-ffi = { version = "0.12.3", path = "livekit-ffi" }
 livekit-protocol = { version = "0.3.6", path = "livekit-protocol" }
-livekit-runtime = { version = "0.3.1", path = "livekit-runtime" }
+livekit-runtime = { version = "0.3.1", path = "livekit-runtime", default-features = false }
 livekit = { version = "0.7.0", path = "livekit" }
 soxr-sys = { version = "0.1.0", path = "soxr-sys" }
 webrtc-sys-build = { version = "0.3.5", path = "webrtc-sys/build" }

--- a/livekit-api/Cargo.toml
+++ b/livekit-api/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/livekit/rust-sdks"
 # By default ws TLS is not enabled
 #
 # FIXME: ensure configurations beyond the one in Zed still work
-default = ["services-tokio", "access-token", "webhooks"]
+default = ["services-tokio", "webhooks"]
 
 signal-client-tokio = [
     "dep:tokio-tungstenite",
@@ -42,8 +42,10 @@ signal-client-dispatcher = [
 services-tokio = ["dep:reqwest"]
 services-dispatcher = ["dep:serde_json"]
 services-async = ["dep:isahc"]
-access-token = ["dep:jsonwebtoken"]
-webhooks = ["access-token", "dep:serde_json", "dep:base64"]
+webhooks = ["dep:serde_json", "dep:base64"]
+
+# Deprecated: old feature that does nothing.
+access-token = []
 
 # Note that the following features only change the behavior of tokio-tungstenite.
 # It doesn't change the behavior of libwebrtc/webrtc-sys
@@ -88,7 +90,6 @@ scopeguard = "1.2.0"
 [dependencies.jsonwebtoken]
 version = "9"
 default-features = false
-optional = true
 
 [dependencies.livekit-runtime]
 version = "0.3.0"

--- a/livekit-api/Cargo.toml
+++ b/livekit-api/Cargo.toml
@@ -8,8 +8,6 @@ repository = "https://github.com/livekit/rust-sdks"
 
 [features]
 # By default ws TLS is not enabled
-#
-# FIXME: ensure configurations beyond the one in Zed still work
 default = ["services-tokio", "webhooks"]
 
 signal-client-tokio = [

--- a/livekit-api/Cargo.toml
+++ b/livekit-api/Cargo.toml
@@ -8,6 +8,8 @@ repository = "https://github.com/livekit/rust-sdks"
 
 [features]
 # By default ws TLS is not enabled
+#
+# FIXME: ensure configurations beyond the one in Zed still work
 default = ["services-tokio", "access-token", "webhooks"]
 
 signal-client-tokio = [
@@ -16,29 +18,29 @@ signal-client-tokio = [
     "dep:futures-util",
     "dep:reqwest",
     "dep:livekit-runtime",
-    "livekit-runtime/tokio"
+    "livekit-runtime/tokio",
 ]
 
 signal-client-async = [
-    "__signal-client-async-compatible",
-    "livekit-runtime/async"
-]
-
-signal-client-dispatcher = [
-    "__signal-client-async-compatible",
-    "livekit-runtime/dispatcher"
-]
-
-__signal-client-async-compatible = [
     "dep:async-tungstenite",
-    "dep:tokio", # For macros and sync
+    "dep:tokio",             # For macros and sync
     "dep:futures-util",
     "dep:isahc",
     "dep:livekit-runtime",
+    "livekit-runtime/async",
 ]
 
+signal-client-dispatcher = [
+    "dep:async-tungstenite",
+    "dep:tokio",                  # For macros and sync
+    "dep:futures-util",
+    "dep:livekit-runtime",
+    "livekit-runtime/dispatcher",
+    "dep:serde_json",
+]
 
 services-tokio = ["dep:reqwest"]
+services-dispatcher = ["dep:serde_json"]
 services-async = ["dep:isahc"]
 access-token = ["dep:jsonwebtoken"]
 webhooks = ["access-token", "dep:serde_json", "dep:base64"]
@@ -48,7 +50,7 @@ webhooks = ["access-token", "dep:serde_json", "dep:base64"]
 native-tls = [
     "tokio-tungstenite?/native-tls",
     "async-tungstenite?/async-native-tls",
-    "reqwest?/native-tls"
+    "reqwest?/native-tls",
 ]
 native-tls-vendored = [
     "tokio-tungstenite?/native-tls-vendored",
@@ -56,6 +58,7 @@ native-tls-vendored = [
 ]
 rustls-tls-native-roots = [
     "tokio-tungstenite?/rustls-tls-native-roots",
+    "async-tungstenite?/async-tls",
     "reqwest?/rustls-tls-native-roots",
 ]
 rustls-tls-webpki-roots = [
@@ -79,18 +82,48 @@ serde_json = { version = "1.0", optional = true }
 base64 = { version = "0.21", optional = true }
 
 # access_token & services
-jsonwebtoken = { version = "9", default-features = false, optional = true }
-
-# signal_client
-livekit-runtime = { path = "../livekit-runtime", version = "0.3.0", optional = true}
-tokio-tungstenite = { version = "0.20", optional = true }
-async-tungstenite = { version = "0.25.0", features = [ "async-std-runtime", "async-native-tls"], optional = true }
-tokio = { version = "1", default-features = false, features = ["sync", "macros", "signal"], optional = true }
-futures-util = { version = "0.3", default-features = false, features = [ "sink" ], optional = true }
-
-# This dependency must be kept in sync with reqwest's version
 http = "0.2.1"
-reqwest = { version = "0.11", default-features = false, features = [ "json" ], optional = true }
-isahc = { version = "1.7.2", default-features = false, features = [ "json", "text-decoding" ], optional = true }
-
 scopeguard = "1.2.0"
+
+[dependencies.jsonwebtoken]
+version = "9"
+default-features = false
+optional = true
+
+[dependencies.livekit-runtime]
+version = "0.3.0"
+path = "../livekit-runtime"
+optional = true
+
+[dependencies.tokio-tungstenite]
+version = "0.20"
+optional = true
+
+[dependencies.async-tungstenite]
+optional = true
+version = "0.25.0"
+features = ["async-std-runtime", "async-native-tls"]
+
+[dependencies.futures-util]
+version = "0.3"
+default-features = false
+features = ["sink"]
+optional = true
+
+[dependencies.tokio]
+version = "1"
+default-features = false
+features = ["sync", "macros", "signal"]
+optional = true
+
+[dependencies.reqwest]
+version = "0.11"
+default-features = false
+features = ["json"]
+optional = true
+
+[dependencies.isahc]
+features = ["json", "text-decoding"]
+optional = true
+version = "1.7.2"
+default-features = false

--- a/livekit-api/src/lib.rs
+++ b/livekit-api/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "access-token")]
+#[cfg_attr(feature = "access-token", deprecated(note = "access-token feature is no longer optional, and so is deprecated"))]
 pub mod access_token;
 
 #[cfg(any(

--- a/livekit-api/src/lib.rs
+++ b/livekit-api/src/lib.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg_attr(feature = "access-token", deprecated(note = "access-token feature is no longer optional, and so is deprecated"))]
+#[cfg_attr(
+    feature = "access-token",
+    deprecated(note = "access-token feature is no longer optional, and so is deprecated")
+)]
 pub mod access_token;
 
 #[cfg(any(

--- a/livekit-api/src/lib.rs
+++ b/livekit-api/src/lib.rs
@@ -15,7 +15,11 @@
 #[cfg(feature = "access-token")]
 pub mod access_token;
 
-#[cfg(any(feature = "services-tokio", feature = "services-async"))]
+#[cfg(any(
+    feature = "services-tokio",
+    feature = "services-async",
+    feature = "services-dispatcher"
+))]
 pub mod services;
 
 #[cfg(any(
@@ -30,9 +34,13 @@ pub mod signal_client;
     feature = "signal-client-async",
     feature = "signal-client-dispatcher",
     feature = "services-tokio",
-    feature = "services-async"
+    feature = "services-async",
+    feature = "services-dispatcher",
 ))]
 mod http_client;
+
+#[cfg(any(feature = "signal-client-dispatcher", feature = "services-dispatcher",))]
+pub use http_client::{set_http_client, HttpClient, Response};
 
 #[cfg(feature = "webhooks")]
 pub mod webhooks;

--- a/livekit-api/src/services/twirp_client.rs
+++ b/livekit-api/src/services/twirp_client.rs
@@ -30,7 +30,7 @@ pub enum TwirpError {
     #[cfg(feature = "services-tokio")]
     #[error("failed to execute the request: {0}")]
     Request(#[from] reqwest::Error),
-    #[cfg(feature = "services-async")]
+    #[cfg(any(feature = "services-async", feature = "services-dispatcher"))]
     #[error("failed to execute the request: {0}")]
     Request(#[from] std::io::Error),
     #[error("twirp error: {0}")]

--- a/livekit-api/src/signal_client/mod.rs
+++ b/livekit-api/src/signal_client/mod.rs
@@ -32,7 +32,7 @@ use tokio::sync::{mpsc, Mutex as AsyncMutex, RwLock as AsyncRwLock};
 #[cfg(feature = "signal-client-tokio")]
 use tokio_tungstenite::tungstenite::Error as WsError;
 
-#[cfg(feature = "__signal-client-async-compatible")]
+#[cfg(any(feature = "signal-client-dispatcher", feature = "signal-client-async"))]
 use async_tungstenite::tungstenite::Error as WsError;
 
 use crate::{http_client, signal_client::signal_stream::SignalStream};

--- a/livekit-api/src/signal_client/signal_stream.rs
+++ b/livekit-api/src/signal_client/signal_stream.rs
@@ -30,7 +30,7 @@ use tokio_tungstenite::{
     MaybeTlsStream, WebSocketStream,
 };
 
-#[cfg(feature = "__signal-client-async-compatible")]
+#[cfg(any(feature = "signal-client-dispatcher", feature = "signal-client-async"))]
 use async_tungstenite::{
     async_std::connect_async,
     async_std::ClientStream as MaybeTlsStream,

--- a/livekit-protocol/src/livekit.rs
+++ b/livekit-protocol/src/livekit.rs
@@ -3837,7 +3837,7 @@ pub struct SendDataRequest {
     #[prost(string, optional, tag="5")]
     pub topic: ::core::option::Option<::prost::alloc::string::String>,
 }
-///
+
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SendDataResponse {

--- a/livekit/Cargo.toml
+++ b/livekit/Cargo.toml
@@ -8,11 +8,13 @@ repository = "https://github.com/livekit/rust-sdks"
 
 [features]
 # By default ws TLS is not enabled
+# TODO SWITCH BACK
 default = ["tokio"]
 
 async = ["livekit-api/signal-client-async"]
 tokio = ["livekit-api/signal-client-tokio"]
 dispatcher = ["livekit-api/signal-client-dispatcher"]
+services-dispatcher = ["livekit-api/services-dispatcher"]
 
 
 # Note that the following features only change the behavior of tokio-tungstenite.
@@ -34,9 +36,14 @@ livekit-protocol = { workspace = true }
 prost = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1", default-features = false, features = ["sync", "macros"] }
+tokio = { version = "1", default-features = false, features = [
+    "sync",
+    "macros",
+] }
 parking_lot = { version = "0.12" }
-futures-util = { version = "0.3", default-features = false, features = ["sink"] }
+futures-util = { version = "0.3", default-features = false, features = [
+    "sink",
+] }
 thiserror = "1.0"
 lazy_static = "1.4"
 log = "0.4"

--- a/livekit/Cargo.toml
+++ b/livekit/Cargo.toml
@@ -8,7 +8,6 @@ repository = "https://github.com/livekit/rust-sdks"
 
 [features]
 # By default ws TLS is not enabled
-# TODO SWITCH BACK
 default = ["tokio"]
 
 async = ["livekit-api/signal-client-async"]

--- a/livekit/src/lib.rs
+++ b/livekit/src/lib.rs
@@ -27,7 +27,6 @@ pub mod prelude;
 
 #[cfg(feature = "dispatcher")]
 pub mod dispatcher {
-    pub use livekit_runtime::set_dispatcher;
-    pub use livekit_runtime::Dispatcher;
-    pub use livekit_runtime::Runnable;
+    pub use livekit_api::{set_http_client, HttpClient, Response};
+    pub use livekit_runtime::{set_dispatcher, Dispatcher, Runnable};
 }


### PR DESCRIPTION
This PR updates the http_client to follow the `dispatcher` pattern. 