### PR TITLE
fix ci failed to build on livekit-runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "livekit-ffi"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "console-subscriber",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "livekit",
     "livekit-api",

--- a/livekit-runtime/Cargo.toml
+++ b/livekit-runtime/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 repository = "https://github.com/livekit/rust-sdks"
 
 [features]
+default = ["dispatcher"]
 tokio = ["dep:tokio", "dep:tokio-stream"]
 async = [
     "dep:async-std",


### PR DESCRIPTION
fix CI:
1. error: could not compile `livekit-runtime` (lib) due to 1 previous error; 17 warnings emitted
2. Rust Formatting / Check Formatting (pull_request)