### PR TITLE
Add license to `soxr-sys/Cargo.toml`

### DIFF
--- a/soxr-sys/Cargo.toml
+++ b/soxr-sys/Cargo.toml
@@ -3,6 +3,7 @@ name = "soxr-sys"
 version = "0.1.0"
 authors = ["Theo Monnom <theo.8bits@gmail.com"]
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 


### PR DESCRIPTION
Motivation for this is a bit of a corner case:

* Including a local checkout of livekit rust-sdks as a package

* Installing Zed from source. This requires licenses specified by all packages.