### PR TITLE
ci: Fix wonky FFI builds

### DIFF
--- a/.github/workflows/ffi-builds.yml
+++ b/.github/workflows/ffi-builds.yml
@@ -165,10 +165,11 @@ jobs:
 
       - name: Copy/Build licenses
         run: |
-          echo "# livekit" > TEMP_LICENSE.md
-          echo "```" >> TEMP_LICENSE.md
+          echo '# livekit' > TEMP_LICENSE.md
+          echo '```' >> TEMP_LICENSE.md
           cat LICENSE >> TEMP_LICENSE.md
-          echo "```" >> TEMP_LICENSE.md
+          echo '```' >> TEMP_LICENSE.md
+          touch livekit-ffi/WEBRTC_LICENSE.md
           cat livekit-ffi/WEBRTC_LICENSE.md >> TEMP_LICENSE.md
           mv TEMP_LICENSE.md target/${{ matrix.target }}/release/LICENSE.md
         shell: bash


### PR DESCRIPTION
The FFI builds have been failing due to the WebRTC license file not existing. Since that file is only generated when compiling to Android as a target, this PR ensures the file exists in that location, and swaps double quotation marks for single ones.