### PR TITLE
fix-livekit-ffi-build-on-ios-failure

### DIFF
--- a/livekit-ffi/build.rs
+++ b/livekit-ffi/build.rs
@@ -42,7 +42,7 @@ fn main() {
 
             std::fs::copy(license, out_file).unwrap();
         }
-        "macos" => {
+        "macos" | "ios" => {
             println!("cargo:rustc-link-arg=-ObjC");
         }
         _ => {


### PR DESCRIPTION
fix livekit-ffi build on ios failure
https://github.com/livekit/rust-sdks/actions/runs/12096245495/job/33730331197

```bash
thread 'main' panicked at livekit-ffi/build.rs:49:13:
Unsupported target, ios
```