### PR TITLE
ci: add deploy key to nanpa CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.NANPA_KEY }}
       - uses: nbsp/ilo@v1
         with:
           packages: ${{ github.event.inputs.packages }}


### PR DESCRIPTION
i've enabled deploy keys and set them to override branch protections, then added this key to the environmental variable. this line should replace the SSH key used by nanpa to be this key, which has elevated permissions.