### PR TITLE
Fix `play_from_disk` example to work with recent SDK

### DIFF
--- a/examples/play_from_disk/src/main.rs
+++ b/examples/play_from_disk/src/main.rs
@@ -123,12 +123,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .await
         .unwrap();
     let room = Arc::new(room);
-    log::info!("Connected to room: {} - {}", room.name(), room.sid());
+    log::info!("Connected to room: {} - {}", room.name(), room.sid().await);
 
     let source = NativeAudioSource::new(
         AudioSourceOptions::default(),
         header.sample_rate,
         header.num_channels as u32,
+        1000,
     );
 
     let track = LocalAudioTrack::create_audio_track("file", RtcAudioSource::Native(source.clone()));

--- a/examples/play_from_disk/src/main.rs
+++ b/examples/play_from_disk/src/main.rs
@@ -7,10 +7,10 @@ use livekit::{
     },
     Room, RoomOptions,
 };
-use std::{env, mem::size_of, sync::Arc, time::Duration};
+use std::{env, io::SeekFrom, mem::size_of, sync::Arc, time::Duration};
 use std::{error::Error, io};
 use thiserror::Error;
-use tokio::io::{AsyncRead, AsyncReadExt, BufReader};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, BufReader};
 
 #[derive(Debug, Error)]
 pub enum WavError {
@@ -20,7 +20,7 @@ pub enum WavError {
     Io(#[from] io::Error),
 }
 
-pub struct WavReader<R: AsyncRead + Unpin> {
+pub struct WavReader<R: AsyncRead + AsyncSeek + Unpin> {
     reader: R,
 }
 
@@ -39,7 +39,7 @@ pub struct WavHeader {
     bits_per_sample: u16,
 }
 
-impl<R: AsyncRead + Unpin> WavReader<R> {
+impl<R: AsyncRead + AsyncSeek + Unpin> WavReader<R> {
     pub fn new(reader: R) -> Self {
         Self { reader }
     }
@@ -76,8 +76,19 @@ impl<R: AsyncRead + Unpin> WavReader<R> {
         let byte_rate = self.reader.read_u32_le().await?;
         let block_align = self.reader.read_u16_le().await?;
         let bits_per_sample = self.reader.read_u16_le().await?;
-        self.reader.read_exact(&mut data_chunk).await?;
-        let data_size = self.reader.read_u32_le().await?;
+
+        let mut data_size = 0;
+        loop {
+            self.reader.read_exact(&mut data_chunk).await?;
+            data_size = self.reader.read_u32_le().await?;
+
+            if &data_chunk == b"data" {
+                break;
+            } else {
+                // skip non data chunks
+                self.reader.seek(SeekFrom::Current(data_size.into())).await?;
+            }
+        }
 
         if &data_chunk != b"data" {
             return Err(WavError::InvalidHeader("Invalid data chunk"));


### PR DESCRIPTION
This pull request fixes the `play_from_disk` example, which could not be compiled with the latest SDK codebase, similar to #528.

Additionally, the included WAV file (change-sophie.wav) contains unexpected chunks in its header, causing the parser to fail. I added logic to skip chunks until the data chunk is found.

With these two fixes, the example works correctly on my local environment.