### PR TITLE
Fix `wgpu_room` to work with recent SDK

### DIFF
--- a/examples/wgpu_room/src/service.rs
+++ b/examples/wgpu_room/src/service.rs
@@ -122,14 +122,14 @@ async fn service_task(inner: Arc<ServiceInner>, mut cmd_rx: mpsc::UnboundedRecei
                     key_provider,
                 });
 
+                let mut options = RoomOptions::default();
+                options.auto_subscribe = auto_subscribe;
+                options.e2ee = e2ee;
+
                 let res = Room::connect(
                     &url,
                     &token,
-                    RoomOptions {
-                        auto_subscribe,
-                        e2ee,
-                        ..Default::default()
-                    },
+                    options,
                 )
                 .await;
 


### PR DESCRIPTION
This is a pull request to make the `wgpu_room` example compatible with the latest SDK.

In the current SDK, the `RoomOptions` struct is marked with `#[non_exhaustive]`, which prevents initializing the struct as shown in the example code from an external crate.

I have modified the example code to be compatible with the `non_exhaustive` struct, allowing it to compile successfully.
