### PR TITLE
bump livekit-ffi to 0.12.4

### DIFF
--- a/.nanpa/bump-ffi.kdl
+++ b/.nanpa/bump-ffi.kdl
@@ -1,0 +1,1 @@
+patch type="added" package="livekit-ffi" "bump libwebrtc to m125"


### PR DESCRIPTION
the previous nanpa bump didn't properly update livekit-ffi, due to a nanparc/Cargo.toml mismatch.