### PR TITLE
Make `deadlock_detection` an optional feature and disable it by default.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "imgproc"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "yuv-sys",
 ]
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "libwebrtc"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "cxx",
  "env_logger",
@@ -1593,7 +1593,7 @@ checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "livekit"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "chrono",
  "futures-util",
@@ -3293,7 +3293,7 @@ checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "webrtc-sys"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "cc",
  "cxx",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "webrtc-sys-build"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "fs2",
  "regex",
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "yuv-sys"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "bindgen",
  "cc",

--- a/livekit-ffi/Cargo.toml
+++ b/livekit-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "livekit-ffi"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2021"
 license = "Apache-2.0"
 description = "FFI interface for bindings in other languages"

--- a/livekit-ffi/Cargo.toml
+++ b/livekit-ffi/Cargo.toml
@@ -1,18 +1,19 @@
 [package]
 name = "livekit-ffi"
-version = "0.12.4"
+version = "0.12.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "FFI interface for bindings in other languages"
 repository = "https://github.com/livekit/rust-sdks"
 
 [features]
-default = ["rustls-tls-native-roots"]
+default = ["rustls-tls-native-roots", "parking_lot"]
 native-tls = ["livekit/native-tls"]
 native-tls-vendored = ["livekit/native-tls-vendored"]
 rustls-tls-native-roots = ["livekit/rustls-tls-native-roots"]
 rustls-tls-webpki-roots = ["livekit/rustls-tls-webpki-roots"]
 __rustls-tls = ["livekit/__rustls-tls"]
+deadlock_detection = ["parking_lot/deadlock_detection"]
 
 # Enable tokio-console to debug tasks
 tracing = ["tokio/tracing", "console-subscriber"]
@@ -24,7 +25,7 @@ imgproc = { path = "../imgproc" }
 livekit-protocol = { workspace = true }
 tokio = { version = "1", features = ["full", "parking_lot"] }
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
-parking_lot = { version = "0.12", features = ["deadlock_detection"] }
+parking_lot = { version = "0.12", optional = true }
 prost = "0.12"
 prost-types = "0.12"
 lazy_static = "1.4"

--- a/livekit-ffi/src/server/mod.rs
+++ b/livekit-ffi/src/server/mod.rs
@@ -25,9 +25,9 @@ use std::{
 use dashmap::{mapref::one::MappedRef, DashMap};
 use downcast_rs::{impl_downcast, Downcast};
 use livekit::webrtc::{native::audio_resampler::AudioResampler, prelude::*};
-use parking_lot::Mutex;
 #[cfg(feature = "deadlock_detection")]
 use parking_lot::deadlock;
+use parking_lot::Mutex;
 use tokio::{sync::oneshot, task::JoinHandle};
 
 use crate::{proto, proto::FfiEvent, FfiError, FfiHandleId, FfiResult, INVALID_HANDLE};

--- a/livekit-ffi/src/server/mod.rs
+++ b/livekit-ffi/src/server/mod.rs
@@ -25,7 +25,9 @@ use std::{
 use dashmap::{mapref::one::MappedRef, DashMap};
 use downcast_rs::{impl_downcast, Downcast};
 use livekit::webrtc::{native::audio_resampler::AudioResampler, prelude::*};
-use parking_lot::{deadlock, Mutex};
+use parking_lot::Mutex;
+#[cfg(feature = "deadlock_detection")]
+use parking_lot::deadlock;
 use tokio::{sync::oneshot, task::JoinHandle};
 
 use crate::{proto, proto::FfiEvent, FfiError, FfiHandleId, FfiResult, INVALID_HANDLE};
@@ -96,6 +98,7 @@ impl Default for FfiServer {
         console_subscriber::init();
 
         // Create a background thread which checks for deadlocks every 10s
+        #[cfg(feature = "deadlock_detection")]
         thread::spawn(move || loop {
             thread::sleep(Duration::from_secs(10));
             let deadlocks = deadlock::check_deadlock();


### PR DESCRIPTION
It seems that `parking_lot`'s `deadlock_detection` feature causes CPU usage to continuously increase when running for extended periods. I haven't investigated the details yet, but since this feature is likely intended for debugging, I have modified it to be disabled by default. It can now only be enabled by explicitly specifying `--features=deadlock_detection`.
