### PR TITLE
Close track FFI handles automatically when a FfiRoom is closed.

### DIFF
--- a/.nanpa/free-stream-handles-when-room-is-closed.kdl
+++ b/.nanpa/free-stream-handles-when-room-is-closed.kdl
@@ -1,0 +1,1 @@
+patch type="fixed" package="livekit-ffi" "Automatically close audio/video stream handles when the associated room is closed"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "imgproc"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "yuv-sys",
 ]
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "libwebrtc"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "cxx",
  "env_logger",
@@ -1593,7 +1593,7 @@ checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "livekit"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "chrono",
  "futures-util",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "livekit-ffi"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "console-subscriber",
  "dashmap",
@@ -3293,7 +3293,7 @@ checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "webrtc-sys"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "cc",
  "cxx",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "webrtc-sys-build"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "fs2",
  "regex",
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "yuv-sys"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "bindgen",
  "cc",

--- a/livekit-ffi/src/server/mod.rs
+++ b/livekit-ffi/src/server/mod.rs
@@ -133,7 +133,7 @@ impl FfiServer {
         log::info!("initializing ffi server v{}", env!("CARGO_PKG_VERSION")); // TODO: Move this log
     }
 
-    pub async fn dispose(&self) {
+    pub async fn dispose(&'static self) {
         self.logger.set_capture_logs(false);
         log::info!("disposing ffi server");
 
@@ -146,7 +146,7 @@ impl FfiServer {
         }
 
         for room in rooms {
-            room.close().await;
+            room.close(self).await;
         }
 
         // Drop all handles

--- a/livekit-ffi/src/server/mod.rs
+++ b/livekit-ffi/src/server/mod.rs
@@ -70,6 +70,7 @@ impl FfiHandle for Arc<Mutex<resampler::SoxResampler>> {}
 impl FfiHandle for AudioFrame<'static> {}
 impl FfiHandle for BoxVideoBuffer {}
 impl FfiHandle for Box<[u8]> {}
+impl FfiHandle for () {}
 
 pub struct FfiServer {
     /// Store all Ffi handles inside an HashMap, if this isn't efficient enough

--- a/livekit-ffi/src/server/requests.rs
+++ b/livekit-ffi/src/server/requests.rs
@@ -67,7 +67,7 @@ fn on_disconnect(
         let ffi_room =
             server.retrieve_handle::<room::FfiRoom>(disconnect.room_handle).unwrap().clone();
 
-        ffi_room.close().await;
+        ffi_room.close(server).await;
 
         let _ =
             server.send_event(proto::ffi_event::Message::Disconnect(proto::DisconnectCallback {

--- a/livekit-ffi/src/server/room.rs
+++ b/livekit-ffi/src/server/room.rs
@@ -271,7 +271,7 @@ impl FfiRoom {
         for (_, &handle) in self.inner.track_handle_lookup.lock().iter() {
             if server.drop_handle(handle) {
                 // Store an empty handle for the FFI client that assumes a handle exists for this id.
-                server.store_handle(handle, vec![].into_boxed_slice());
+                server.store_handle(handle, ());
             }
         }
 

--- a/livekit-ffi/src/server/room.rs
+++ b/livekit-ffi/src/server/room.rs
@@ -267,9 +267,7 @@ impl FfiRoom {
 
     /// Close the room and stop the tasks
     pub async fn close(&self, server: &'static FfiServer) {
-        log_file(&format!("ffi_room will close: {}", self.inner.handle_id));
-
-        // close associated track handles
+        // drop associated track handles
         for (_, &handle) in self.inner.track_handle_lookup.lock().iter() {
             server.drop_handle(handle);
         }

--- a/livekit-ffi/src/server/room.rs
+++ b/livekit-ffi/src/server/room.rs
@@ -269,7 +269,10 @@ impl FfiRoom {
     pub async fn close(&self, server: &'static FfiServer) {
         // drop associated track handles
         for (_, &handle) in self.inner.track_handle_lookup.lock().iter() {
-            server.drop_handle(handle);
+            if server.drop_handle(handle) {
+                // Store an empty handle for the FFI client that assumes a handle exists for this id.
+                server.store_handle(handle, vec![].into_boxed_slice());
+            }
         }
 
         let _ = self.inner.room.close().await;

--- a/livekit-ffi/src/server/room.rs
+++ b/livekit-ffi/src/server/room.rs
@@ -266,7 +266,14 @@ impl FfiRoom {
     }
 
     /// Close the room and stop the tasks
-    pub async fn close(&self) {
+    pub async fn close(&self, server: &'static FfiServer) {
+        log_file(&format!("ffi_room will close: {}", self.inner.handle_id));
+
+        // close associated track handles
+        for (_, &handle) in self.inner.track_handle_lookup.lock().iter() {
+            server.drop_handle(handle);
+        }
+
         let _ = self.inner.room.close().await;
 
         let handle = self.handle.lock().await.take();


### PR DESCRIPTION
As shown in [this test script](https://gist.github.com/typester/4907bebe022ffd429eeb27eeb392b1ec), it seems that if the FFI client forgets to close Audio/Video Stream on their side, a memory leak occurs.
Looking at the Python-side code, the `__del__` method is supposed to dispose of FFI handles when objects like VideoStream are released. However, for some reason, in this test script, that part is not invoked, leaving the handles unclosed.

In this pull request, the `FfiRoom` is modified to automatically dispose of associated track handles when it is closed.

With the script mentioned above, after running it, the memory consumption of the test process decreased from around 110MB to about 80MB, indicating the change is effective. 
(The test was conducted in a local environment using a livekit-server with one video and one audio stream are running in a joined room)