### PR TITLE
bump livekit-ffi to 0.12.5

### DIFF
--- a/.nanpa/bump-ffi.kdl
+++ b/.nanpa/bump-ffi.kdl
@@ -1,0 +1,1 @@
+patch type="added" package="livekit-ffi" "Fix deadlock issue in nested RPC calls."

--- a/.nanpa/bump-ffi.kdl
+++ b/.nanpa/bump-ffi.kdl
@@ -1,1 +1,2 @@
 patch type="added" package="livekit-ffi" "Fix deadlock issue in nested RPC calls."
+patch type="added" package="livekit" "bump"


### PR DESCRIPTION
Including fix for deadlock in nested RPC calls: #532 