### PR TITLE
fix: emit track-muted event for local tracks

### DIFF
--- a/.nanpa/track-muted-event-for-local-publications.kdl
+++ b/.nanpa/track-muted-event-for-local-publications.kdl
@@ -1,0 +1,1 @@
+patch type="fixed" package="livekit" "Emit TrackMuted/TrackUnmuted events for local publications"

--- a/livekit/src/room/participant/local_participant.rs
+++ b/livekit/src/room/participant/local_participant.rs
@@ -139,7 +139,14 @@ impl LocalParticipant {
     }
 
     pub(crate) fn update_info(&self, info: proto::ParticipantInfo) {
-        super::update_info(&self.inner, &Participant::Local(self.clone()), info);
+        super::update_info(&self.inner, &Participant::Local(self.clone()), info.clone());
+
+        for track in info.tracks {
+            let track_sid = track.sid.clone().try_into().unwrap();
+            if let Some(publication) = self.get_track_publication(&track_sid) {
+                publication.update_info(track.clone());
+            }
+        }
     }
 
     pub(crate) fn set_speaking(&self, speaking: bool) {

--- a/livekit/src/room/participant/remote_participant.rs
+++ b/livekit/src/room/participant/remote_participant.rs
@@ -149,6 +149,7 @@ impl RemoteParticipant {
                 name: remote_publication.name(),
                 r#type: proto::TrackType::from(remote_publication.kind()) as i32,
                 source: proto::TrackSource::from(remote_publication.source()) as i32,
+                muted: remote_publication.is_muted(),
                 ..Default::default()
             });
 


### PR DESCRIPTION
Currently there's no way to know when a track was muted by a moderator since track changes from the server were ignored.

This updates the TrackInfo of the local participant in a similar way, to how its done for remote participants.

While this seems to work, I'm not sure if this is the correct way to do this, since the comment in https://github.com/livekit/rust-sdks/blob/main/livekit/src/room/publication/remote.rs#L157 seems to imply that this should already work for local publications?