### PR TITLE
Fix webrtc crate build issue

### DIFF
--- a/.nanpa/bump-webrtc-sys.kdl
+++ b/.nanpa/bump-webrtc-sys.kdl
@@ -1,0 +1,2 @@
+patch type="added" package="webrtc-sys" "Expose DataChannel.bufferedAmount property"
+patch type="fixed" package="libwebrtc" "Fix build issue"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,7 +1605,7 @@ checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "livekit"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "chrono",
  "futures-util",
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "livekit-api"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-tungstenite",
  "base64",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "livekit-ffi"
-version = "0.12.8"
+version = "0.12.10"
 dependencies = [
  "console-subscriber",
  "dashmap",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "livekit-runtime"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "async-io 2.3.1",
  "async-std",

--- a/libwebrtc/Cargo.toml
+++ b/libwebrtc/Cargo.toml
@@ -18,8 +18,8 @@ thiserror = "1.0"
 jni = "0.21"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-webrtc-sys = { path = "../webrtc-sys", version = "0.3.5" }
-livekit-runtime = { path = "../livekit-runtime", version = "0.3.0" }
+webrtc-sys = { workspace = true }
+livekit-runtime = { workspace = true }
 lazy_static = "1.4"
 parking_lot = { version = "0.12" }
 tokio = { version = "1", default-features = false, features = ["sync", "macros"] }


### PR DESCRIPTION
In #545, I bumped the version of the `libwebrtc` crate but not the `webrtc-sys` crate. However, both needed to be bumped.

To fix this issue, I will bump webrtc-sys and re-bump libwebrtc to depend on the newer version of webrtc-sys.