### PR TITLE
bump livekit-protocol

### DIFF
--- a/.nanpa/bump-protocol.kdl
+++ b/.nanpa/bump-protocol.kdl
@@ -1,0 +1,1 @@
+patch type="fixed" package="livekit-protocol" "Fixed a dependency issue"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "libwebrtc"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "cxx",
  "env_logger",
@@ -3346,7 +3346,7 @@ checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "webrtc-sys"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "cc",
  "cxx",


### PR DESCRIPTION
Current released version of livekit-protocol depends old version of livekit-runtime, and it causes build issue for crates that depends on livekit-protocol. Needs to be updated with latest dependency.