### PR TITLE
Add libwebrtc build support for riscv64

### DIFF
--- a/.github/workflows/webrtc-builds.yml
+++ b/.github/workflows/webrtc-builds.yml
@@ -54,7 +54,11 @@ jobs:
             os: buildjet-8vcpu-ubuntu-2004
             cmd: ./build_linux.sh
             arch: arm64
-
+          - name: linux
+            os: buildjet-8vcpu-ubuntu-2004
+            cmd: ./build_linux.sh
+            arch: riscv64
+            
           - name: android
             os: buildjet-8vcpu-ubuntu-2004
             cmd: ./build_android.sh

--- a/.nanpa/add-riscv64-linux-libwebrtc.kdl
+++ b/.nanpa/add-riscv64-linux-libwebrtc.kdl
@@ -1,0 +1,1 @@
+minor type="added" "Added build mechanism for riscv64"

--- a/webrtc-sys/libwebrtc/build_linux.sh
+++ b/webrtc-sys/libwebrtc/build_linux.sh
@@ -21,7 +21,7 @@ while [ "$#" -gt 0 ]; do
   case "$1" in
     --arch)
       arch="$2"
-      if [ "$arch" != "x64" ] && [ "$arch" != "arm64" ]; then
+      if [ "$arch" != "x64" ] && [ "$arch" != "arm64" ] && [ "$arch" != "riscv64" ]; then
         echo "Error: Invalid value for --arch. Must be 'x64' or 'arm64'."
         exit 1
       fi
@@ -79,12 +79,31 @@ cd ..
 
 mkdir -p "$ARTIFACTS_DIR/lib"
 
+if [[ "$arch" == "riscv64" ]]
+then
+# somehow you have to configure ffmpeg manually for riscv64
+cd src/third_party/ffmpeg && ./configure --arch=riscv64 && make -j16 || true && cd ../../../
+
+# Manually create a sysroot
+sudo apt-get install libasound2-dev libpulse-dev libavutil-dev g++-riscv64-linux-gnu debootstrap
+sudo debootstrap \
+  --arch=riscv64 \
+  --include=qtbase5-dev,qt6-base-dev,qt6-base-dev-tools,krb5-multidev,libasound2-dev,libatk-bridge2.0-dev,libatk1.0-dev,libatspi2.0-dev,libblkid-dev,libbluetooth-dev,libc-dev-bin,libc6-dev,libcrypt-dev,libcups2-dev,libcurl4-gnutls-dev,libdbus-1-dev,libdbusmenu-glib-dev,libdbusmenu-gtk3-dev,libdevmapper1.02.1,libdrm-dev,libffi-dev,libflac-dev,libgbm-dev,libgcc-12-dev,libgcrypt20-dev,libgdk-pixbuf-2.0-dev,libgl1-mesa-dev,libglib2.0-dev,libglib2.0-dev-bin,libgtk-3-dev,libgtk-4-dev,libjsoncpp-dev,libkrb5-dev,libmount-dev,libnotify-dev,libnsl-dev,libnss3-dev,libpango1.0-dev,libpci-dev,libpcre2-dev,libpipewire-0.3-dev,libpulse-dev,libre2-dev,libselinux1-dev,libsepol-dev,libspeechd-dev,libstdc++-12-dev,libstdc++-13-dev,libtirpc-dev,libudev1,libva-dev,libx11-xcb-dev,libxkbcommon-x11-dev,libxshmfence-dev,linux-libc-dev,mesa-common-dev,uuid-dev,zlib1g-dev,wayland-protocols,libasan8 \
+  sid \
+  build/linux/debian_sid_riscv64-sysroot \
+  https://snapshot.debian.org/archive/debian/20240907T023014Z/
+
+sudo chown 1000:1000 -R src/build/linux/debian_sid_riscv64-sysroot
+else
 python3 "./src/build/linux/sysroot_scripts/install-sysroot.py" --arch="$arch"
+fi
 
 debug="false"
 if [ "$profile" = "debug" ]; then
   debug="true"
 fi
+
+set -e
 
 args="is_debug=$debug  \
   target_os=\"linux\" \


### PR DESCRIPTION
This PR adds the required changes to be able to build the webrtc-sys crate on the riscv64gc-unknown-linux-gnu Rust target.

The sysroot install script of the chromium project doesn't have yet support for riscv64 so I had to install it another way, inspired from this blogpost : [https://www.kxxt.dev/blog/cross-compile-chromium-for-riscv](https://www.kxxt.dev/blog/cross-compile-chromium-for-riscv/)