### PR TITLE
 Fix panic in Promise::try_result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,7 +1605,7 @@ checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "livekit"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "chrono",
  "futures-util",
@@ -1655,7 +1655,7 @@ dependencies = [
 
 [[package]]
 name = "livekit-ffi"
-version = "0.12.10"
+version = "0.12.12"
 dependencies = [
  "console-subscriber",
  "dashmap",

--- a/livekit-protocol/src/promise.rs
+++ b/livekit-protocol/src/promise.rs
@@ -55,6 +55,6 @@ impl<T: Clone> Promise<T> {
     }
 
     pub fn try_result(&self) -> Option<T> {
-        self.result.try_read().unwrap().clone()
+        self.result.try_read().ok().and_then(|result| result.clone())
     }
 }

--- a/livekit-protocol/src/promise.rs
+++ b/livekit-protocol/src/promise.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use tokio::sync::{oneshot, Mutex};
+use tokio::sync::{oneshot, Mutex, RwLock};
 
 pub struct Promise<T> {
     tx: Mutex<Option<oneshot::Sender<T>>>,
     rx: Mutex<Option<oneshot::Receiver<T>>>,
-    result: Mutex<Option<T>>,
+    result: RwLock<Option<T>>,
 }
 
 impl<T: Clone> Promise<T> {
@@ -37,14 +37,24 @@ impl<T: Clone> Promise<T> {
     }
 
     pub async fn result(&self) -> T {
-        let mut rx = self.rx.lock().await;
-        if rx.is_some() {
-            self.result.lock().await.replace(rx.take().unwrap().await.unwrap());
+        {
+            let result_read = self.result.read().await;
+            if let Some(result) = result_read.clone() {
+                return result;
+            }
         }
-        self.result.lock().await.clone().unwrap()
+
+        let mut rx = self.rx.lock().await;
+        if let Some(rx) = rx.take() {
+            let result = rx.await.unwrap();
+            *self.result.write().await = Some(result.clone());
+            result
+        } else {
+            self.result.read().await.clone().unwrap()
+        }
     }
 
     pub fn try_result(&self) -> Option<T> {
-        self.result.try_lock().unwrap().clone()
+        self.result.try_read().unwrap().clone()
     }
 }


### PR DESCRIPTION
Panic occurring in `Promise::try_result` is undesirable, so it has been replaced with RwLock to prevent panics.
