### PR TITLE
Fix packaging issue in livekit-ffi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,7 +1655,7 @@ dependencies = [
 
 [[package]]
 name = "livekit-ffi"
-version = "0.12.12"
+version = "0.12.13"
 dependencies = [
  "console-subscriber",
  "dashmap",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "livekit-protocol"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "futures-util",
  "livekit-runtime",

--- a/livekit-ffi/.nanpa/rival-fang-bride.kdl
+++ b/livekit-ffi/.nanpa/rival-fang-bride.kdl
@@ -1,0 +1,1 @@
+patch type="fixed" package="livekit-ffi" "Fixed a packaging issue"

--- a/livekit-ffi/Cargo.toml
+++ b/livekit-ffi/Cargo.toml
@@ -19,8 +19,8 @@ tracing = ["tokio/tracing", "console-subscriber"]
 
 [dependencies]
 livekit = { workspace = true }
-soxr-sys = { path = "../soxr-sys" }
-imgproc = { path = "../imgproc" }
+soxr-sys = { workspace = true }
+imgproc = { workspace = true }
 livekit-protocol = { workspace = true }
 tokio = { version = "1", features = ["full", "parking_lot"] }
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }


### PR DESCRIPTION
Definitions of dependencies without specifying versions cause [a packaging issue](https://github.com/livekit/rust-sdks/actions/runs/13659444398/job/38186921358) in livekit-ffi. Using a workspace definition resolves this.

We don't use a published crate for FFI, so this doesn't block any releases of foreign language SDKs, but I will fix this just in case.