### PR TITLE
Add i420_to_nv12

### DIFF
--- a/.nanpa/i420_to_nv12.kdl
+++ b/.nanpa/i420_to_nv12.kdl
@@ -1,0 +1,1 @@
+minor type="added" "Add i420_to_nv12"

--- a/libwebrtc/src/native/yuv_helper.rs
+++ b/libwebrtc/src/native/yuv_helper.rs
@@ -245,6 +245,51 @@ i420_to_rgba!(i420_to_bgra);
 i420_to_rgba!(i420_to_abgr);
 i420_to_rgba!(i420_to_rgba);
 
+pub fn i420_to_nv12(
+    src_y: &[u8],
+    src_stride_y: u32,
+    src_u: &[u8],
+    src_stride_u: u32,
+    src_v: &[u8],
+    src_stride_v: u32,
+    dst_y: &mut [u8],
+    dst_stride_y: u32,
+    dst_uv: &mut [u8],
+    dst_stride_uv: u32,
+    width: i32,
+    height: i32,
+) {
+    i420_assert_safety(
+        src_y,
+        src_stride_y,
+        src_u,
+        src_stride_u,
+        src_v,
+        src_stride_v,
+        width,
+        height,
+    );
+    nv12_assert_safety(dst_y, dst_stride_y, dst_uv, dst_stride_uv, width, height);
+
+    unsafe {
+        yuv_sys::ffi::i420_to_nv12(
+            src_y.as_ptr(),
+            src_stride_y as i32,
+            src_u.as_ptr(),
+            src_stride_u as i32,
+            src_v.as_ptr(),
+            src_stride_v as i32,
+            dst_y.as_mut_ptr(),
+            dst_stride_y as i32,
+            dst_uv.as_mut_ptr(),
+            dst_stride_uv as i32,
+            width,
+            height,
+        )
+        .unwrap();
+    }
+}
+
 pub fn nv12_to_i420(
     src_y: &[u8],
     src_stride_y: u32,

--- a/webrtc-sys/include/livekit/yuv_helper.h
+++ b/webrtc-sys/include/livekit/yuv_helper.h
@@ -164,6 +164,23 @@ static void nv12_to_i420(const uint8_t* src_y,
                                     dst_v, dst_stride_v, width, height));
 }
 
+static void i420_to_nv12(const uint8_t* src_y,
+                         int src_stride_y,
+                         const uint8_t* src_u,
+                         int src_stride_u,
+                         uint8_t* src_v,
+                         int src_stride_v,
+                         uint8_t* dst_y,
+                         int dst_stride_y,
+                         uint8_t* dst_uv,
+                         int dst_stride_uv,
+                         int width,
+                         int height) {
+  THROW_ON_ERROR(webrtc::NV12ToI420(src_y, src_stride_y, src_u, src_stride_u,
+                                    src_v, src_stride_v, dst_y, dst_stride_y,
+                                    dst_uv, dst_stride_uv, width, height));
+}
+
 static void i444_to_i420(const uint8_t* src_y,
                          int src_stride_y,
                          const uint8_t* src_u,

--- a/webrtc-sys/src/yuv_helper.rs
+++ b/webrtc-sys/src/yuv_helper.rs
@@ -121,6 +121,21 @@ pub mod ffi {
             height: i32,
         ) -> Result<()>;
 
+        unsafe fn i420_to_nv12(
+            src_y: *const u8,
+            src_stride_y: i32,
+            src_u: *const u8,
+            src_stride_u: i32,
+            src_v: *const u8,
+            src_stride_v: i32,
+            dst_y: *mut u8,
+            dst_stride_y: i32,
+            dst_uv: *mut u8,
+            dst_stride_uv: i32,
+            width: i32,
+            height: i32,
+        ) -> Result<()>;
+
         unsafe fn i444_to_i420(
             src_y: *const u8,
             src_stride_y: i32,


### PR DESCRIPTION
Currently our graphics framework at Zed requires NV12 buffers, but using the high-quality VP8 codec, we receive I420 buffers from livekit.

It'd be nice to figure out how to avoid that (and have libwebrtc do whatever conversions are needed internally), but in the meantime we need to call this on the received data.