### PR TITLE
fix soxr: remove FE_INVALID optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "livekit-ffi"
-version = "0.12.20"
+version = "0.12.21"
 dependencies = [
  "bytes",
  "console-subscriber",

--- a/soxr-sys/src/rint.h
+++ b/soxr-sys/src/rint.h
@@ -17,18 +17,18 @@
   #define rint32F rint32D
   #define rint16F rint16D
   //#define FE_INVALID 1
-  static __inline int fe_test_invalid(void) {
-    int status_word;
-    __asm__ __volatile__("fnstsw %%ax": "=a"(status_word));
-    return status_word & FE_INVALID;
-  }
-  static __inline int fe_clear_invalid(void) {
-    int32_t status[7];
-    __asm__ __volatile__("fnstenv %0": "=m"(status));
-    status[1] &= ~FE_INVALID;
-    __asm__ __volatile__("fldenv %0": : "m"(*status));
-    return 0;
-  }
+  // static __inline int fe_test_invalid(void) {
+  //   int status_word;
+  //   __asm__ __volatile__("fnstsw %%ax": "=a"(status_word));
+  //   return status_word & FE_INVALID;
+  // }
+  // static __inline int fe_clear_invalid(void) {
+  //   int32_t status[7];
+  //   __asm__ __volatile__("fnstenv %0": "=m"(status));
+  //   status[1] &= ~FE_INVALID;
+  //   __asm__ __volatile__("fldenv %0": : "m"(*status));
+  //   return 0;
+  // }
 #elif defined _MSC_VER && defined _M_IX86
   #define FPU_RINT32
   #define FPU_RINT16
@@ -43,18 +43,18 @@
   #define rint16D(y,x) rint16d(&(y),x)
   #define rint16F(y,x) rint16f(&(y),x)
   //#define FE_INVALID 1
-  static __inline int fe_test_invalid(void) {
-    short status_word;
-    __asm fnstsw status_word
-    return status_word & FE_INVALID;
-  }
-  static __inline int fe_clear_invalid(void) {
-    int32_t status[7];
-    __asm fnstenv status
-    status[1] &= ~FE_INVALID;
-    __asm fldenv status
-    return 0;
-  }
+  // static __inline int fe_test_invalid(void) {
+  //   short status_word;
+  //   __asm fnstsw status_word
+  //   return status_word & FE_INVALID;
+  // }
+  // static __inline int fe_clear_invalid(void) {
+  //   int32_t status[7];
+  //   __asm fnstenv status
+  //   status[1] &= ~FE_INVALID;
+  //   __asm fldenv status
+  //   return 0;
+  // }
 #elif defined _MSC_VER && defined _M_X64
   #include <emmintrin.h>
   #include <float.h>
@@ -71,16 +71,16 @@
   #define rint16D(y,x) rint16d(&(y),x)
   #define rint16F(y,x) rint16d(&(y),(double)(x))
   //#define FE_INVALID 1
-  #define fe_test_invalid() (_statusfp() & _SW_INVALID)
-  #define fe_clear_invalid _clearfp /* Note: clears all. */
+  // #define fe_test_invalid() (_statusfp() & _SW_INVALID)
+  // #define fe_clear_invalid _clearfp /* Note: clears all. */
 #elif HAVE_LRINT && LONG_MAX == 2147483647L && HAVE_FENV_H
   #include <math.h>
   #include <fenv.h>
   #define FPU_RINT32
   #define rint32D(y,x) ((y)=lrint(x))
   #define rint32F(y,x) ((y)=lrintf(x))
-  #define fe_test_invalid() fetestexcept(FE_INVALID)
-  #define fe_clear_invalid() feclearexcept(FE_INVALID)
+  // #define fe_test_invalid() fetestexcept(FE_INVALID)
+  // #define fe_clear_invalid() feclearexcept(FE_INVALID)
 #endif
 
 #if !defined FPU_RINT32

--- a/soxr-sys/src/rint.h
+++ b/soxr-sys/src/rint.h
@@ -16,7 +16,7 @@
   #define rint16D(a,b) __asm__ __volatile__("fistps %0": "=m"(a): "t"(b): "st")
   #define rint32F rint32D
   #define rint16F rint16D
-  #define FE_INVALID 1
+  //#define FE_INVALID 1
   static __inline int fe_test_invalid(void) {
     int status_word;
     __asm__ __volatile__("fnstsw %%ax": "=a"(status_word));
@@ -42,7 +42,7 @@
   #define rint32F(y,x) rint32f(&(y),x)
   #define rint16D(y,x) rint16d(&(y),x)
   #define rint16F(y,x) rint16f(&(y),x)
-  #define FE_INVALID 1
+  //#define FE_INVALID 1
   static __inline int fe_test_invalid(void) {
     short status_word;
     __asm fnstsw status_word
@@ -70,7 +70,7 @@
   #define rint32F(y,x) rint32f(&(y),x)
   #define rint16D(y,x) rint16d(&(y),x)
   #define rint16F(y,x) rint16d(&(y),(double)(x))
-  #define FE_INVALID 1
+  //#define FE_INVALID 1
   #define fe_test_invalid() (_statusfp() & _SW_INVALID)
   #define fe_clear_invalid _clearfp /* Note: clears all. */
 #elif HAVE_LRINT && LONG_MAX == 2147483647L && HAVE_FENV_H


### PR DESCRIPTION
Remove FE_INVALID-based exception handling since FPU doesn't detect float-to-int overflows.  
Now that we perform explicit bounds checking, the exception-based path offers no performance benefit.  
Ensures safe and portable clipping behavior across all platforms.  
