### PR TITLE
Expose AEC dump

### DIFF
--- a/livekit-ffi/protocol/audio_frame.proto
+++ b/livekit-ffi/protocol/audio_frame.proto
@@ -54,9 +54,9 @@ message NewAudioSourceRequest {
 }
 message NewAudioSourceResponse { required OwnedAudioSource source = 1; }
 
-// Push a frame to an AudioSource 
+// Push a frame to an AudioSource
 // The data provided must be available as long as the client receive the callback.
-message CaptureAudioFrameRequest { 
+message CaptureAudioFrameRequest {
   required uint64 source_handle = 1;
   required AudioFrameBufferInfo buffer = 2;
 }
@@ -137,6 +137,21 @@ message ApmSetStreamDelayResponse {
   optional string error = 1;
 }
 
+message ApmAecDumpCreateAndAttachRequest {
+  required uint64 apm_handle = 1;
+  required string file_path = 2;
+  optional int64 max_log_size_bytes = 3;
+}
+
+message ApmAecDumpCreateAndAttachResponse {
+  optional string error = 1;
+}
+
+message ApmAecDumpDetachRequest {
+  required uint64 apm_handle = 1;
+}
+
+message ApmAecDumpDetachResponse {}
 
 // New resampler using SoX (much better quality)
 
@@ -154,7 +169,7 @@ message NewSoxResamplerResponse {
     OwnedSoxResampler resampler = 1;
     string error = 2;
   }
-  
+
 }
 
 message PushSoxResamplerRequest {
@@ -240,7 +255,7 @@ message OwnedAudioStream {
 
 message AudioStreamEvent {
   required uint64 stream_handle = 1;
-  oneof message { 
+  oneof message {
     AudioFrameReceived frame_received = 2;
     AudioStreamEOS eos = 3;
   }

--- a/livekit-ffi/protocol/ffi.proto
+++ b/livekit-ffi/protocol/ffi.proto
@@ -148,7 +148,10 @@ message FfiRequest {
     TextStreamWriterWriteRequest text_stream_write = 65;
     TextStreamWriterCloseRequest text_stream_close = 66;
 
-    // NEXT_ID: 67
+    ApmAecDumpCreateAndAttachRequest apm_aec_dump_create_and_attach = 67;
+    ApmAecDumpDetachRequest apm_aec_dump_detach = 68;
+
+    // NEXT_ID: 69
   }
 }
 
@@ -243,7 +246,10 @@ message FfiResponse {
     TextStreamWriterWriteResponse text_stream_write = 64;
     TextStreamWriterCloseResponse text_stream_close = 65;
 
-    // NEXT_ID: 66
+    ApmAecDumpCreateAndAttachResponse apm_aec_dump_create_and_attach = 66;
+    ApmAecDumpDetachResponse apm_aec_dump_detach = 67;
+
+    // NEXT_ID: 68
   }
 }
 

--- a/livekit-ffi/src/livekit.proto.rs
+++ b/livekit-ffi/src/livekit.proto.rs
@@ -4131,7 +4131,7 @@ pub struct NewAudioSourceResponse {
     #[prost(message, required, tag="1")]
     pub source: OwnedAudioSource,
 }
-/// Push a frame to an AudioSource 
+/// Push a frame to an AudioSource
 /// The data provided must be available as long as the client receive the callback.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -4272,6 +4272,32 @@ pub struct ApmSetStreamDelayRequest {
 pub struct ApmSetStreamDelayResponse {
     #[prost(string, optional, tag="1")]
     pub error: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ApmAecDumpCreateAndAttachRequest {
+    #[prost(uint64, required, tag="1")]
+    pub apm_handle: u64,
+    #[prost(string, required, tag="2")]
+    pub file_path: ::prost::alloc::string::String,
+    #[prost(int64, optional, tag="3")]
+    pub max_log_size_bytes: ::core::option::Option<i64>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ApmAecDumpCreateAndAttachResponse {
+    #[prost(string, optional, tag="1")]
+    pub error: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ApmAecDumpDetachRequest {
+    #[prost(uint64, required, tag="1")]
+    pub apm_handle: u64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ApmAecDumpDetachResponse {
 }
 // New resampler using SoX (much better quality)
 
@@ -4804,7 +4830,7 @@ pub struct RpcMethodInvocationEvent {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FfiRequest {
-    #[prost(oneof="ffi_request::Message", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 48, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66")]
+    #[prost(oneof="ffi_request::Message", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 48, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68")]
     pub message: ::core::option::Option<ffi_request::Message>,
 }
 /// Nested message and enum types in `FfiRequest`.
@@ -4952,13 +4978,17 @@ pub mod ffi_request {
         TextStreamWrite(super::TextStreamWriterWriteRequest),
         #[prost(message, tag="66")]
         TextStreamClose(super::TextStreamWriterCloseRequest),
+        #[prost(message, tag="67")]
+        ApmAecDumpCreateAndAttach(super::ApmAecDumpCreateAndAttachRequest),
+        #[prost(message, tag="68")]
+        ApmAecDumpDetach(super::ApmAecDumpDetachRequest),
     }
 }
 /// This is the output of livekit_ffi_request function.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FfiResponse {
-    #[prost(oneof="ffi_response::Message", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 47, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65")]
+    #[prost(oneof="ffi_response::Message", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 47, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67")]
     pub message: ::core::option::Option<ffi_response::Message>,
 }
 /// Nested message and enum types in `FfiResponse`.
@@ -5104,6 +5134,10 @@ pub mod ffi_response {
         TextStreamWrite(super::TextStreamWriterWriteResponse),
         #[prost(message, tag="65")]
         TextStreamClose(super::TextStreamWriterCloseResponse),
+        #[prost(message, tag="66")]
+        ApmAecDumpCreateAndAttach(super::ApmAecDumpCreateAndAttachResponse),
+        #[prost(message, tag="67")]
+        ApmAecDumpDetach(super::ApmAecDumpDetachResponse),
     }
 }
 /// To minimize complexity, participant events are not included in the protocol.

--- a/webrtc-sys/include/livekit/apm.h
+++ b/webrtc-sys/include/livekit/apm.h
@@ -19,10 +19,13 @@
 #include <memory>
 
 #include "api/scoped_refptr.h"
+#include "api/task_queue/task_queue_base.h"
 #include "api/video_codecs/video_decoder_factory.h"
 #include "api/video_codecs/video_encoder_factory.h"
 #include "modules/audio_processing/aec3/echo_canceller3.h"
 #include "modules/audio_processing/audio_buffer.h"
+#include "livekit/global_task_queue.h"
+#include "rust/cxx.h"
 
 namespace livekit {
 
@@ -62,8 +65,14 @@ class AudioProcessingModule {
 
   int set_stream_delay_ms(int delay_ms);
 
+  bool create_and_attach_aec_dump(rust::Str file_name,
+                                  int64_t max_log_size_bytes);
+
+  void detach_aec_dump();
+
  private:
   rtc::scoped_refptr<webrtc::AudioProcessing> apm_;
+  std::unique_ptr<webrtc::TaskQueueBase, webrtc::TaskQueueDeleter> aec_dump_queue_;
 };
 
 std::unique_ptr<AudioProcessingModule> create_apm(

--- a/webrtc-sys/src/apm.cpp
+++ b/webrtc-sys/src/apm.cpp
@@ -50,4 +50,21 @@ std::unique_ptr<AudioProcessingModule> create_apm(
   return std::make_unique<AudioProcessingModule>(config);
 }
 
+bool AudioProcessingModule::create_and_attach_aec_dump(rust::Str file_name,
+                                                       int64_t max_log_size_bytes) {
+  if (!aec_dump_queue_) {
+    aec_dump_queue_ = GetGlobalTaskQueueFactory()->CreateTaskQueue(
+        "aec-dump", webrtc::TaskQueueFactory::Priority::LOW);
+  }
+  return apm_->CreateAndAttachAecDump(
+      absl::string_view(file_name.data(), file_name.size()),
+      max_log_size_bytes,
+      aec_dump_queue_.get());
+}
+
+void AudioProcessingModule::detach_aec_dump() {
+  apm_->DetachAecDump();
+  aec_dump_queue_.reset();
+}
+
 }  // namespace livekit

--- a/webrtc-sys/src/apm.rs
+++ b/webrtc-sys/src/apm.rs
@@ -43,6 +43,14 @@ pub mod ffi {
 
         fn set_stream_delay_ms(self: Pin<&mut AudioProcessingModule>, delay: i32) -> i32;
 
+        fn create_and_attach_aec_dump(
+            self: Pin<&mut AudioProcessingModule>,
+            file_name: &str,
+            max_log_size_bytes: i64,
+        ) -> bool;
+
+        fn detach_aec_dump(self: Pin<&mut AudioProcessingModule>);
+
         fn create_apm(
             echo_canceller_enabled: bool,
             gain_controller_enabled: bool,


### PR DESCRIPTION
Expose `webrtc::AecDump` functionality to more easily evaluate AEC performance in client implementations.