### PR TITLE
0.12.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1615,7 +1615,7 @@ checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "livekit"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "bmrng",
  "bytes",
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "livekit-ffi"
-version = "0.12.23"
+version = "0.12.24"
 dependencies = [
  "bytes",
  "console-subscriber",


### PR DESCRIPTION
not sure if this makes a difference but in #640 i forgot to run build locally and update the lockfile. i'll update the tag after merging this but i don't think the FFI binaries need to be updated because they'd have fixed their lockfile as part of the build process anyways. 