### PR TITLE
Allow libwebrtc to build with host toolchain on Linux

### DIFF
--- a/webrtc-sys/libwebrtc/patches/gclient_ignore_platform_specific_deps.patch
+++ b/webrtc-sys/libwebrtc/patches/gclient_ignore_platform_specific_deps.patch
@@ -1,0 +1,14 @@
+diff --git a/gclient.py b/gclient.py
+index 58d5aee..8d798b2 100755
+--- a/gclient.py
++++ b/gclient.py
+@@ -1134,6 +1134,9 @@ class Dependency(gclient_utils.WorkItem, DependencySettings):
+             hooks_cwd = self.root.root_dir
+ 
+         for dep in deps_to_add:
++            if '${arch}' in dep.name or '${platform}' in dep.name:
++                print("WARN: ignoring platform-specific dep:", dep.name)
++                continue
+             if dep.verify_validity():
+                 self.add_dependency(dep)
+         self._mark_as_parsed([

--- a/webrtc-sys/libwebrtc/patches/generate_licenses_use_system_gn.patch
+++ b/webrtc-sys/libwebrtc/patches/generate_licenses_use_system_gn.patch
@@ -1,0 +1,12 @@
+--- a/tools_webrtc/libs/generate_licenses.py
++++ b/tools_webrtc/libs/generate_licenses.py
+@@ -175,8 +187,7 @@ class LicenseBuilder:
+     @staticmethod
+     def _run_gn(buildfile_dir, target):
+         cmd = [
+-            sys.executable,
+-            os.path.join(find_depot_tools.DEPOT_TOOLS_PATH, 'gn.py'),
++            'gn',
+             'desc',
+             '--all',
+             '--format=json',

--- a/webrtc-sys/libwebrtc/patches/gn_use_system_python3.patch
+++ b/webrtc-sys/libwebrtc/patches/gn_use_system_python3.patch
@@ -1,0 +1,13 @@
+diff --git a/.gn b/.gn
+index 5de9689..1913f0b 100644
+--- a/.gn
++++ b/.gn
+@@ -13,7 +13,7 @@ buildconfig = "//build/config/BUILDCONFIG.gn"
+ 
+ # The python interpreter to use by default. On Windows, this will look
+ # for vpython3.exe and vpython3.bat.
+-script_executable = "vpython3"
++script_executable = "python3"
+ 
+ # The secondary source root is a parallel directory tree where
+ # GN build files are placed when they can not be placed directly


### PR DESCRIPTION
Introduces a new parameter `--toolchain` whose value defaults to `sysroot`, but can be changed to `host` to build libwebrtc in the host environment.

This could be later used in webrtc-sys' build.rs so that WebRTC could be built natively and conveniently inside `cargo build`, when building everything from source is desired (e.g. in a Linux distro).