### PR TITLE
fix duration overflow

### DIFF
--- a/livekit/src/room/participant/local_participant.rs
+++ b/livekit/src/room/participant/local_participant.rs
@@ -738,7 +738,7 @@ impl LocalParticipant {
                 id: id.clone(),
                 method: data.method.clone(),
                 payload: data.payload.clone(),
-                response_timeout: data.response_timeout - max_round_trip_latency,
+                response_timeout: data.response_timeout,
                 version: 1,
             })
             .await


### PR DESCRIPTION
There is no point about reducing the timeout if we don't know the latency.. It's hardcoded to 2s. 

Fixes substraction overflow