### PR TITLE
chore: Update dependencies for wgpu room.

### DIFF
--- a/examples/wgpu_room/Cargo.toml
+++ b/examples/wgpu_room/Cargo.toml
@@ -11,13 +11,13 @@ tracing = ["console-subscriber", "tokio/tracing"]
 tokio = { version = "1", features = ["full", "parking_lot"] }
 livekit = { path = "../../livekit", features = ["native-tls"] }
 futures = "0.3"
-winit = "0.28"
+winit = "0.30.11"
 parking_lot = { version = "0.12.1", features = ["deadlock_detection"] }
 image = "0.24"
-wgpu = "0.16"
-egui = "0.22.0"
-egui-wgpu = "0.22.0"
-eframe = { version = "0.22.0", default-features = false, features = ["default_fonts", "wgpu", "persistence"] }
+wgpu = "25.0"
+egui = "0.31.1"
+egui-wgpu = "0.31.1"
+eframe = { version = "0.31.1", default-features = false, features = ["default_fonts", "wgpu", "persistence"] }
 serde = { version = "1", features = ["derive"] }
 log = "0.4"
 env_logger = "0.10.0"

--- a/examples/wgpu_room/src/app.rs
+++ b/examples/wgpu_room/src/app.rs
@@ -3,7 +3,7 @@ use crate::{
     video_grid::VideoGrid,
     video_renderer::VideoRenderer,
 };
-use egui::{Rounding, Stroke};
+use egui::{CornerRadius, Stroke};
 use livekit::{e2ee::EncryptionType, prelude::*, SimulateScenario};
 use std::collections::HashMap;
 
@@ -428,7 +428,7 @@ fn draw_video(name: &str, speaking: bool, video_renderer: &VideoRenderer, ui: &m
 
     if speaking {
         ui.painter()
-            .rect(rect, Rounding::none(), egui::Color32::GREEN, Stroke::NONE);
+            .rect(rect, CornerRadius::default(), egui::Color32::GREEN, Stroke::NONE, egui::StrokeKind::Inside);
     }
 
     // Always draw a background in case we still didn't receive a frame

--- a/examples/wgpu_room/src/main.rs
+++ b/examples/wgpu_room/src/main.rs
@@ -1,4 +1,5 @@
 use eframe::Renderer;
+use egui::ViewportBuilder;
 use parking_lot::deadlock;
 use std::thread;
 use std::time::Duration;
@@ -36,12 +37,11 @@ fn main() {
     eframe::run_native(
         "LiveKit - Rust App",
         eframe::NativeOptions {
-            follow_system_theme: true,
             centered: true,
             renderer: Renderer::Wgpu,
             ..Default::default()
         },
-        Box::new(|cc| Box::new(app::LkApp::new(cc))),
+        Box::new(|cc| Ok(Box::new(app::LkApp::new(cc)))),
     )
     .unwrap();
 }

--- a/examples/wgpu_room/src/video_grid.rs
+++ b/examples/wgpu_room/src/video_grid.rs
@@ -168,8 +168,10 @@ impl<'a> VideoGridContext<'a> {
     pub fn video_frame(&mut self, add_contents: impl FnOnce(&mut egui::Ui)) -> egui::Response {
         let frame_rect = self.layout.next_frame_rect();
 
-        let mut child_ui = self.ui.child_ui(frame_rect, egui::Layout::default());
-        add_contents(&mut child_ui);
+        if self.ui.is_visible() {
+            let mut child_ui = self.ui.child_ui(frame_rect, egui::Layout::default(), None);
+            add_contents(&mut child_ui);
+        }
 
         self.ui.allocate_rect(frame_rect, egui::Sense::hover())
     }

--- a/examples/wgpu_room/src/video_renderer.rs
+++ b/examples/wgpu_room/src/video_renderer.rs
@@ -17,8 +17,8 @@ struct RendererInternal {
     width: u32,
     height: u32,
     rgba_data: Vec<u8>,
-    texture: Option<wgpu::Texture>,
-    texture_view: Option<wgpu::TextureView>,
+    texture: Option<eframe::wgpu::Texture>,
+    texture_view: Option<eframe::wgpu::TextureView>,
     egui_texture: Option<egui::TextureId>,
 }
 
@@ -75,18 +75,18 @@ impl VideoRenderer {
                     );
 
                     internal.render_state.queue.write_texture(
-                        wgpu::ImageCopyTexture {
+                        eframe::wgpu::TexelCopyTextureInfo {
                             texture: internal.texture.as_ref().unwrap(),
                             mip_level: 0,
-                            origin: wgpu::Origin3d::default(),
-                            aspect: wgpu::TextureAspect::default(),
+                            origin: eframe::wgpu::Origin3d::default(),
+                            aspect: eframe::wgpu::TextureAspect::default(),
                         },
                         &internal.rgba_data,
-                        wgpu::ImageDataLayout {
+                        eframe::wgpu::TexelCopyBufferLayout {
                             bytes_per_row: Some(width * 4),
                             ..Default::default()
                         },
-                        wgpu::Extent3d { width, height, ..Default::default() },
+                        eframe::wgpu::Extent3d { width, height, ..Default::default() },
                     );
                 }
             }
@@ -117,22 +117,22 @@ impl RendererInternal {
         self.height = height;
         self.rgba_data.resize((width * height * 4) as usize, 0);
 
-        self.texture = Some(self.render_state.device.create_texture(&wgpu::TextureDescriptor {
+        self.texture = Some(self.render_state.device.create_texture(&eframe::wgpu::TextureDescriptor {
             label: Some("lk-videotexture"),
-            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
-            dimension: wgpu::TextureDimension::D2,
-            size: wgpu::Extent3d { width, height, ..Default::default() },
+            usage: eframe::wgpu::TextureUsages::TEXTURE_BINDING | eframe::wgpu::TextureUsages::COPY_DST,
+            dimension: eframe::wgpu::TextureDimension::D2,
+            size: eframe::wgpu::Extent3d { width, height, ..Default::default() },
             sample_count: 1,
             mip_level_count: 1,
-            format: wgpu::TextureFormat::Rgba8UnormSrgb,
-            view_formats: &[wgpu::TextureFormat::Rgba8UnormSrgb],
+            format: eframe::wgpu::TextureFormat::Rgba8UnormSrgb,
+            view_formats: &[eframe::wgpu::TextureFormat::Rgba8UnormSrgb],
         }));
 
         self.texture_view =
-            Some(self.texture.as_mut().unwrap().create_view(&wgpu::TextureViewDescriptor {
+            Some(self.texture.as_mut().unwrap().create_view(&eframe::wgpu::TextureViewDescriptor {
                 label: Some("lk-videotexture-view"),
-                format: Some(wgpu::TextureFormat::Rgba8UnormSrgb),
-                dimension: Some(wgpu::TextureViewDimension::D2),
+                format: Some(eframe::wgpu::TextureFormat::Rgba8UnormSrgb),
+                dimension: Some(eframe::wgpu::TextureViewDimension::D2),
                 mip_level_count: Some(1),
                 array_layer_count: Some(1),
                 ..Default::default()
@@ -143,14 +143,14 @@ impl RendererInternal {
             self.render_state.renderer.write().update_egui_texture_from_wgpu_texture(
                 &self.render_state.device,
                 self.texture_view.as_ref().unwrap(),
-                wgpu::FilterMode::Linear,
+                eframe::wgpu::FilterMode::Linear,
                 texture_id,
             );
         } else {
             self.egui_texture = Some(self.render_state.renderer.write().register_native_texture(
                 &self.render_state.device,
                 self.texture_view.as_ref().unwrap(),
-                wgpu::FilterMode::Linear,
+                eframe::wgpu::FilterMode::Linear,
             ));
         }
     }


### PR DESCRIPTION
enabling 200% scaling (HiDPI) on Ubuntu for monitor will cause the following error and immediate crash.

`wl_surface#26: error 2: Buffer size (1630x45) must be an integer multiple of the buffer_scale (2)`

Upgrading to the latest dependencies can fix this issue.