### PR TITLE
Expose room updates, support MoveParticipant (protocol 15)

### DIFF
--- a/livekit-api/src/services/sip.rs
+++ b/livekit-api/src/services/sip.rs
@@ -236,6 +236,7 @@ impl SIPClient {
                         // TODO: support these attributes
                         include_headers: Default::default(),
                         media_encryption: Default::default(),
+                        destination_country: Default::default(),
                     }),
                 },
                 self.base.auth_header(

--- a/livekit-api/src/signal_client/mod.rs
+++ b/livekit-api/src/signal_client/mod.rs
@@ -47,7 +47,7 @@ pub type SignalEvents = mpsc::UnboundedReceiver<SignalEvent>;
 pub type SignalResult<T> = Result<T, SignalError>;
 
 pub const JOIN_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
-pub const PROTOCOL_VERSION: u32 = 15;
+pub const PROTOCOL_VERSION: u32 = 16;
 
 #[derive(Error, Debug)]
 pub enum SignalError {

--- a/livekit-ffi/protocol/participant.proto
+++ b/livekit-ffi/protocol/participant.proto
@@ -71,4 +71,5 @@ enum DisconnectReason {
   // SIP protocol failure or unexpected response
   SIP_TRUNK_FAILURE = 13;
   CONNECTION_TIMEOUT = 14;
+  MEDIA_FAILURE = 15;
 }

--- a/livekit-ffi/protocol/room.proto
+++ b/livekit-ffi/protocol/room.proto
@@ -376,6 +376,10 @@ message RoomEvent {
     // Data stream (high level)
     ByteStreamOpened byte_stream_opened = 34;
     TextStreamOpened text_stream_opened = 35;
+    // Room info updated
+    RoomInfo room_updated = 36;
+    // Participant moved to new room
+    RoomInfo moved = 37;
   }
 }
 
@@ -385,6 +389,13 @@ message RoomInfo {
   required string metadata = 3;
   required uint64 lossy_dc_buffered_amount_low_threshold = 4;
   required uint64 reliable_dc_buffered_amount_low_threshold = 5;
+  required uint32 empty_timeout = 6;
+  required uint32 departure_timeout = 7;
+  required uint32 max_participants = 8;
+  required int64 creation_time = 9;
+  required uint32 num_participants = 10;
+  required uint32 num_publishers = 11;
+  required bool active_recording = 12;
 }
 
 message OwnedRoom {

--- a/livekit-ffi/protocol/room.proto
+++ b/livekit-ffi/protocol/room.proto
@@ -380,6 +380,8 @@ message RoomEvent {
     RoomInfo room_updated = 36;
     // Participant moved to new room
     RoomInfo moved = 37;
+    // carry over all participant info updates, including sid
+    ParticipantsUpdated participants_updated = 38;
   }
 }
 
@@ -401,6 +403,10 @@ message RoomInfo {
 message OwnedRoom {
   required FfiOwnedHandle handle = 1;
   required RoomInfo info = 2;
+}
+
+message ParticipantsUpdated {
+  repeated ParticipantInfo participants = 1;
 }
 
 message ParticipantConnected { required OwnedParticipant info = 1; }

--- a/livekit-ffi/src/conversion/participant.rs
+++ b/livekit-ffi/src/conversion/participant.rs
@@ -62,6 +62,7 @@ impl From<DisconnectReason> for proto::DisconnectReason {
             DisconnectReason::UserRejected => proto::DisconnectReason::UserRejected,
             DisconnectReason::SipTrunkFailure => proto::DisconnectReason::SipTrunkFailure,
             DisconnectReason::ConnectionTimeout => proto::DisconnectReason::ConnectionTimeout,
+            DisconnectReason::MediaFailure => proto::DisconnectReason::MediaFailure,
         }
     }
 }

--- a/livekit-ffi/src/conversion/participant.rs
+++ b/livekit-ffi/src/conversion/participant.rs
@@ -13,12 +13,18 @@
 // limitations under the License.
 
 use crate::{proto, server::participant::FfiParticipant};
+use livekit::prelude::*;
 use livekit::DisconnectReason;
 use livekit::ParticipantKind;
 
 impl From<&FfiParticipant> for proto::ParticipantInfo {
     fn from(value: &FfiParticipant) -> Self {
-        let participant = &value.participant;
+        From::<&Participant>::from(&value.participant)
+    }
+}
+
+impl From<&Participant> for proto::ParticipantInfo {
+    fn from(participant: &Participant) -> Self {
         Self {
             sid: participant.sid().into(),
             name: participant.name(),

--- a/livekit-ffi/src/conversion/room.rs
+++ b/livekit-ffi/src/conversion/room.rs
@@ -24,6 +24,7 @@ use livekit::{
         native::frame_cryptor::EncryptionState,
         prelude::{ContinualGatheringPolicy, IceServer, IceTransportsType, RtcConfiguration},
     },
+    RoomInfo,
 };
 
 impl From<EncryptionState> for proto::EncryptionState {
@@ -99,6 +100,7 @@ impl From<DisconnectReason> for proto::DisconnectReason {
             DisconnectReason::UserRejected => Self::UserRejected,
             DisconnectReason::SipTrunkFailure => Self::SipTrunkFailure,
             DisconnectReason::ConnectionTimeout => Self::ConnectionTimeout,
+            DisconnectReason::MediaFailure => Self::MediaFailure,
         }
     }
 }
@@ -249,7 +251,7 @@ impl From<proto::AudioEncoding> for AudioEncoding {
 impl From<&FfiRoom> for proto::RoomInfo {
     fn from(value: &FfiRoom) -> Self {
         let room = &value.inner.room;
-        Self {
+        proto::RoomInfo {
             sid: room.maybe_sid().map(|x| x.to_string()),
             name: room.name(),
             metadata: room.metadata(),
@@ -259,6 +261,36 @@ impl From<&FfiRoom> for proto::RoomInfo {
             reliable_dc_buffered_amount_low_threshold: room
                 .data_channel_options(DataPacketKind::Reliable)
                 .buffered_amount_low_threshold,
+            empty_timeout: room.empty_timeout(),
+            departure_timeout: room.departure_timeout(),
+            max_participants: room.max_participants(),
+            creation_time: room.creation_time(),
+            num_participants: room.num_participants(),
+            num_publishers: room.num_publishers(),
+            active_recording: room.active_recording(),
+        }
+    }
+}
+
+impl From<RoomInfo> for proto::RoomInfo {
+    fn from(room: RoomInfo) -> Self {
+        proto::RoomInfo {
+            sid: room.sid.map(|x| x.to_string()),
+            name: room.name,
+            metadata: room.metadata,
+            lossy_dc_buffered_amount_low_threshold: room
+                .lossy_dc_options
+                .buffered_amount_low_threshold,
+            reliable_dc_buffered_amount_low_threshold: room
+                .reliable_dc_options
+                .buffered_amount_low_threshold,
+            empty_timeout: room.empty_timeout,
+            departure_timeout: room.departure_timeout,
+            max_participants: room.max_participants,
+            creation_time: room.creation_time,
+            num_participants: room.num_participants,
+            num_publishers: room.num_publishers,
+            active_recording: room.active_recording,
         }
     }
 }

--- a/livekit-ffi/src/livekit.proto.rs
+++ b/livekit-ffi/src/livekit.proto.rs
@@ -1739,6 +1739,7 @@ pub enum DisconnectReason {
     /// SIP protocol failure or unexpected response
     SipTrunkFailure = 13,
     ConnectionTimeout = 14,
+    MediaFailure = 15,
 }
 impl DisconnectReason {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -1762,6 +1763,7 @@ impl DisconnectReason {
             DisconnectReason::UserRejected => "USER_REJECTED",
             DisconnectReason::SipTrunkFailure => "SIP_TRUNK_FAILURE",
             DisconnectReason::ConnectionTimeout => "CONNECTION_TIMEOUT",
+            DisconnectReason::MediaFailure => "MEDIA_FAILURE",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -1782,6 +1784,7 @@ impl DisconnectReason {
             "USER_REJECTED" => Some(Self::UserRejected),
             "SIP_TRUNK_FAILURE" => Some(Self::SipTrunkFailure),
             "CONNECTION_TIMEOUT" => Some(Self::ConnectionTimeout),
+            "MEDIA_FAILURE" => Some(Self::MediaFailure),
             _ => None,
         }
     }
@@ -3329,7 +3332,7 @@ pub struct OwnedBuffer {
 pub struct RoomEvent {
     #[prost(uint64, required, tag="1")]
     pub room_handle: u64,
-    #[prost(oneof="room_event::Message", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35")]
+    #[prost(oneof="room_event::Message", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37")]
     pub message: ::core::option::Option<room_event::Message>,
 }
 /// Nested message and enum types in `RoomEvent`.
@@ -3409,6 +3412,12 @@ pub mod room_event {
         ByteStreamOpened(super::ByteStreamOpened),
         #[prost(message, tag="35")]
         TextStreamOpened(super::TextStreamOpened),
+        /// Room info updated
+        #[prost(message, tag="36")]
+        RoomUpdated(super::RoomInfo),
+        /// Participant moved to new room
+        #[prost(message, tag="37")]
+        Moved(super::RoomInfo),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3424,6 +3433,20 @@ pub struct RoomInfo {
     pub lossy_dc_buffered_amount_low_threshold: u64,
     #[prost(uint64, required, tag="5")]
     pub reliable_dc_buffered_amount_low_threshold: u64,
+    #[prost(uint32, required, tag="6")]
+    pub empty_timeout: u32,
+    #[prost(uint32, required, tag="7")]
+    pub departure_timeout: u32,
+    #[prost(uint32, required, tag="8")]
+    pub max_participants: u32,
+    #[prost(int64, required, tag="9")]
+    pub creation_time: i64,
+    #[prost(uint32, required, tag="10")]
+    pub num_participants: u32,
+    #[prost(uint32, required, tag="11")]
+    pub num_publishers: u32,
+    #[prost(bool, required, tag="12")]
+    pub active_recording: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/livekit-ffi/src/livekit.proto.rs
+++ b/livekit-ffi/src/livekit.proto.rs
@@ -3332,7 +3332,7 @@ pub struct OwnedBuffer {
 pub struct RoomEvent {
     #[prost(uint64, required, tag="1")]
     pub room_handle: u64,
-    #[prost(oneof="room_event::Message", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37")]
+    #[prost(oneof="room_event::Message", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38")]
     pub message: ::core::option::Option<room_event::Message>,
 }
 /// Nested message and enum types in `RoomEvent`.
@@ -3418,6 +3418,9 @@ pub mod room_event {
         /// Participant moved to new room
         #[prost(message, tag="37")]
         Moved(super::RoomInfo),
+        /// carry over all participant info updates, including sid
+        #[prost(message, tag="38")]
+        ParticipantsUpdated(super::ParticipantsUpdated),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3455,6 +3458,12 @@ pub struct OwnedRoom {
     pub handle: FfiOwnedHandle,
     #[prost(message, required, tag="2")]
     pub info: RoomInfo,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ParticipantsUpdated {
+    #[prost(message, repeated, tag="1")]
+    pub participants: ::prost::alloc::vec::Vec<ParticipantInfo>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/livekit-ffi/src/server/room.rs
+++ b/livekit-ffi/src/server/room.rs
@@ -629,7 +629,6 @@ impl RoomInner {
                     send_chat_message.sender_identity,
                 )
                 .await;
-            let sent_message = res.as_ref().unwrap().clone();
             match res {
                 Ok(message) => {
                     let _ = server.send_event(proto::ffi_event::Message::ChatMessage(
@@ -652,7 +651,6 @@ impl RoomInner {
                     ));
                 }
             }
-            drop(sent_message);
         });
         server.watch_panic(handle);
         proto::SendChatMessageResponse { async_id }
@@ -676,7 +674,6 @@ impl RoomInner {
                     edit_chat_message.sender_identity,
                 )
                 .await;
-            let sent_message: ChatMessage = res.as_ref().unwrap().clone();
             match res {
                 Ok(message) => {
                     let _ = server.send_event(proto::ffi_event::Message::ChatMessage(
@@ -699,7 +696,6 @@ impl RoomInner {
                     ));
                 }
             }
-            drop(sent_message);
         });
         server.watch_panic(handle);
         proto::SendChatMessageResponse { async_id }

--- a/livekit-ffi/src/server/room.rs
+++ b/livekit-ffi/src/server/room.rs
@@ -1368,6 +1368,16 @@ async fn forward_event(
         RoomEvent::Moved { room } => {
             let _ = send_event(proto::room_event::Message::Moved(room.into()));
         }
+        RoomEvent::ParticipantsUpdated { participants } => {
+            let _ = send_event(proto::room_event::Message::ParticipantsUpdated(
+                proto::ParticipantsUpdated {
+                    participants: participants
+                        .into_iter()
+                        .map(|p| proto::ParticipantInfo::from(&p))
+                        .collect(),
+                },
+            ));
+        }
         _ => {
             log::warn!("unhandled room event: {:?}", event);
         }

--- a/livekit-protocol/src/livekit.serde.rs
+++ b/livekit-protocol/src/livekit.serde.rs
@@ -1636,6 +1636,9 @@ impl serde::Serialize for AvailabilityResponse {
         if self.supports_resume {
             len += 1;
         }
+        if self.terminate {
+            len += 1;
+        }
         if !self.participant_name.is_empty() {
             len += 1;
         }
@@ -1657,6 +1660,9 @@ impl serde::Serialize for AvailabilityResponse {
         }
         if self.supports_resume {
             struct_ser.serialize_field("supportsResume", &self.supports_resume)?;
+        }
+        if self.terminate {
+            struct_ser.serialize_field("terminate", &self.terminate)?;
         }
         if !self.participant_name.is_empty() {
             struct_ser.serialize_field("participantName", &self.participant_name)?;
@@ -1685,6 +1691,7 @@ impl<'de> serde::Deserialize<'de> for AvailabilityResponse {
             "available",
             "supports_resume",
             "supportsResume",
+            "terminate",
             "participant_name",
             "participantName",
             "participant_identity",
@@ -1700,6 +1707,7 @@ impl<'de> serde::Deserialize<'de> for AvailabilityResponse {
             JobId,
             Available,
             SupportsResume,
+            Terminate,
             ParticipantName,
             ParticipantIdentity,
             ParticipantMetadata,
@@ -1729,6 +1737,7 @@ impl<'de> serde::Deserialize<'de> for AvailabilityResponse {
                             "jobId" | "job_id" => Ok(GeneratedField::JobId),
                             "available" => Ok(GeneratedField::Available),
                             "supportsResume" | "supports_resume" => Ok(GeneratedField::SupportsResume),
+                            "terminate" => Ok(GeneratedField::Terminate),
                             "participantName" | "participant_name" => Ok(GeneratedField::ParticipantName),
                             "participantIdentity" | "participant_identity" => Ok(GeneratedField::ParticipantIdentity),
                             "participantMetadata" | "participant_metadata" => Ok(GeneratedField::ParticipantMetadata),
@@ -1755,6 +1764,7 @@ impl<'de> serde::Deserialize<'de> for AvailabilityResponse {
                 let mut job_id__ = None;
                 let mut available__ = None;
                 let mut supports_resume__ = None;
+                let mut terminate__ = None;
                 let mut participant_name__ = None;
                 let mut participant_identity__ = None;
                 let mut participant_metadata__ = None;
@@ -1778,6 +1788,12 @@ impl<'de> serde::Deserialize<'de> for AvailabilityResponse {
                                 return Err(serde::de::Error::duplicate_field("supportsResume"));
                             }
                             supports_resume__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Terminate => {
+                            if terminate__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("terminate"));
+                            }
+                            terminate__ = Some(map_.next_value()?);
                         }
                         GeneratedField::ParticipantName => {
                             if participant_name__.is_some() {
@@ -1814,6 +1830,7 @@ impl<'de> serde::Deserialize<'de> for AvailabilityResponse {
                     job_id: job_id__.unwrap_or_default(),
                     available: available__.unwrap_or_default(),
                     supports_resume: supports_resume__.unwrap_or_default(),
+                    terminate: terminate__.unwrap_or_default(),
                     participant_name: participant_name__.unwrap_or_default(),
                     participant_identity: participant_identity__.unwrap_or_default(),
                     participant_metadata: participant_metadata__.unwrap_or_default(),
@@ -5371,6 +5388,122 @@ impl<'de> serde::Deserialize<'de> for DataChannelInfo {
         deserializer.deserialize_struct("livekit.DataChannelInfo", FIELDS, GeneratedVisitor)
     }
 }
+impl serde::Serialize for DataChannelReceiveState {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.publisher_sid.is_empty() {
+            len += 1;
+        }
+        if self.last_seq != 0 {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("livekit.DataChannelReceiveState", len)?;
+        if !self.publisher_sid.is_empty() {
+            struct_ser.serialize_field("publisherSid", &self.publisher_sid)?;
+        }
+        if self.last_seq != 0 {
+            struct_ser.serialize_field("lastSeq", &self.last_seq)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for DataChannelReceiveState {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "publisher_sid",
+            "publisherSid",
+            "last_seq",
+            "lastSeq",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            PublisherSid,
+            LastSeq,
+            __SkipField__,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "publisherSid" | "publisher_sid" => Ok(GeneratedField::PublisherSid),
+                            "lastSeq" | "last_seq" => Ok(GeneratedField::LastSeq),
+                            _ => Ok(GeneratedField::__SkipField__),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = DataChannelReceiveState;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct livekit.DataChannelReceiveState")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<DataChannelReceiveState, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut publisher_sid__ = None;
+                let mut last_seq__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::PublisherSid => {
+                            if publisher_sid__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("publisherSid"));
+                            }
+                            publisher_sid__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::LastSeq => {
+                            if last_seq__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("lastSeq"));
+                            }
+                            last_seq__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
+                    }
+                }
+                Ok(DataChannelReceiveState {
+                    publisher_sid: publisher_sid__.unwrap_or_default(),
+                    last_seq: last_seq__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("livekit.DataChannelReceiveState", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for DataPacket {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -5388,6 +5521,12 @@ impl serde::Serialize for DataPacket {
         if !self.destination_identities.is_empty() {
             len += 1;
         }
+        if self.sequence != 0 {
+            len += 1;
+        }
+        if !self.participant_sid.is_empty() {
+            len += 1;
+        }
         if self.value.is_some() {
             len += 1;
         }
@@ -5402,6 +5541,12 @@ impl serde::Serialize for DataPacket {
         }
         if !self.destination_identities.is_empty() {
             struct_ser.serialize_field("destinationIdentities", &self.destination_identities)?;
+        }
+        if self.sequence != 0 {
+            struct_ser.serialize_field("sequence", &self.sequence)?;
+        }
+        if !self.participant_sid.is_empty() {
+            struct_ser.serialize_field("participantSid", &self.participant_sid)?;
         }
         if let Some(v) = self.value.as_ref() {
             match v {
@@ -5458,6 +5603,9 @@ impl<'de> serde::Deserialize<'de> for DataPacket {
             "participantIdentity",
             "destination_identities",
             "destinationIdentities",
+            "sequence",
+            "participant_sid",
+            "participantSid",
             "user",
             "speaker",
             "sip_dtmf",
@@ -5485,6 +5633,8 @@ impl<'de> serde::Deserialize<'de> for DataPacket {
             Kind,
             ParticipantIdentity,
             DestinationIdentities,
+            Sequence,
+            ParticipantSid,
             User,
             Speaker,
             SipDtmf,
@@ -5522,6 +5672,8 @@ impl<'de> serde::Deserialize<'de> for DataPacket {
                             "kind" => Ok(GeneratedField::Kind),
                             "participantIdentity" | "participant_identity" => Ok(GeneratedField::ParticipantIdentity),
                             "destinationIdentities" | "destination_identities" => Ok(GeneratedField::DestinationIdentities),
+                            "sequence" => Ok(GeneratedField::Sequence),
+                            "participantSid" | "participant_sid" => Ok(GeneratedField::ParticipantSid),
                             "user" => Ok(GeneratedField::User),
                             "speaker" => Ok(GeneratedField::Speaker),
                             "sipDtmf" | "sip_dtmf" => Ok(GeneratedField::SipDtmf),
@@ -5556,6 +5708,8 @@ impl<'de> serde::Deserialize<'de> for DataPacket {
                 let mut kind__ = None;
                 let mut participant_identity__ = None;
                 let mut destination_identities__ = None;
+                let mut sequence__ = None;
+                let mut participant_sid__ = None;
                 let mut value__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
@@ -5576,6 +5730,20 @@ impl<'de> serde::Deserialize<'de> for DataPacket {
                                 return Err(serde::de::Error::duplicate_field("destinationIdentities"));
                             }
                             destination_identities__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Sequence => {
+                            if sequence__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("sequence"));
+                            }
+                            sequence__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::ParticipantSid => {
+                            if participant_sid__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("participantSid"));
+                            }
+                            participant_sid__ = Some(map_.next_value()?);
                         }
                         GeneratedField::User => {
                             if value__.is_some() {
@@ -5670,6 +5838,8 @@ impl<'de> serde::Deserialize<'de> for DataPacket {
                     kind: kind__.unwrap_or_default(),
                     participant_identity: participant_identity__.unwrap_or_default(),
                     destination_identities: destination_identities__.unwrap_or_default(),
+                    sequence: sequence__.unwrap_or_default(),
+                    participant_sid: participant_sid__.unwrap_or_default(),
                     value: value__,
                 })
             }
@@ -7599,6 +7769,7 @@ impl serde::Serialize for DisconnectReason {
             Self::UserRejected => "USER_REJECTED",
             Self::SipTrunkFailure => "SIP_TRUNK_FAILURE",
             Self::ConnectionTimeout => "CONNECTION_TIMEOUT",
+            Self::MediaFailure => "MEDIA_FAILURE",
         };
         serializer.serialize_str(variant)
     }
@@ -7625,6 +7796,7 @@ impl<'de> serde::Deserialize<'de> for DisconnectReason {
             "USER_REJECTED",
             "SIP_TRUNK_FAILURE",
             "CONNECTION_TIMEOUT",
+            "MEDIA_FAILURE",
         ];
 
         struct GeneratedVisitor;
@@ -7680,6 +7852,7 @@ impl<'de> serde::Deserialize<'de> for DisconnectReason {
                     "USER_REJECTED" => Ok(DisconnectReason::UserRejected),
                     "SIP_TRUNK_FAILURE" => Ok(DisconnectReason::SipTrunkFailure),
                     "CONNECTION_TIMEOUT" => Ok(DisconnectReason::ConnectionTimeout),
+                    "MEDIA_FAILURE" => Ok(DisconnectReason::MediaFailure),
                     _ => Err(serde::de::Error::unknown_variant(value, FIELDS)),
                 }
             }
@@ -21297,12 +21470,24 @@ impl serde::Serialize for ReconnectResponse {
         if self.client_configuration.is_some() {
             len += 1;
         }
+        if self.server_info.is_some() {
+            len += 1;
+        }
+        if self.last_message_seq != 0 {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("livekit.ReconnectResponse", len)?;
         if !self.ice_servers.is_empty() {
             struct_ser.serialize_field("iceServers", &self.ice_servers)?;
         }
         if let Some(v) = self.client_configuration.as_ref() {
             struct_ser.serialize_field("clientConfiguration", v)?;
+        }
+        if let Some(v) = self.server_info.as_ref() {
+            struct_ser.serialize_field("serverInfo", v)?;
+        }
+        if self.last_message_seq != 0 {
+            struct_ser.serialize_field("lastMessageSeq", &self.last_message_seq)?;
         }
         struct_ser.end()
     }
@@ -21318,12 +21503,18 @@ impl<'de> serde::Deserialize<'de> for ReconnectResponse {
             "iceServers",
             "client_configuration",
             "clientConfiguration",
+            "server_info",
+            "serverInfo",
+            "last_message_seq",
+            "lastMessageSeq",
         ];
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             IceServers,
             ClientConfiguration,
+            ServerInfo,
+            LastMessageSeq,
             __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -21348,6 +21539,8 @@ impl<'de> serde::Deserialize<'de> for ReconnectResponse {
                         match value {
                             "iceServers" | "ice_servers" => Ok(GeneratedField::IceServers),
                             "clientConfiguration" | "client_configuration" => Ok(GeneratedField::ClientConfiguration),
+                            "serverInfo" | "server_info" => Ok(GeneratedField::ServerInfo),
+                            "lastMessageSeq" | "last_message_seq" => Ok(GeneratedField::LastMessageSeq),
                             _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
@@ -21369,6 +21562,8 @@ impl<'de> serde::Deserialize<'de> for ReconnectResponse {
             {
                 let mut ice_servers__ = None;
                 let mut client_configuration__ = None;
+                let mut server_info__ = None;
+                let mut last_message_seq__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::IceServers => {
@@ -21383,6 +21578,20 @@ impl<'de> serde::Deserialize<'de> for ReconnectResponse {
                             }
                             client_configuration__ = map_.next_value()?;
                         }
+                        GeneratedField::ServerInfo => {
+                            if server_info__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("serverInfo"));
+                            }
+                            server_info__ = map_.next_value()?;
+                        }
+                        GeneratedField::LastMessageSeq => {
+                            if last_message_seq__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("lastMessageSeq"));
+                            }
+                            last_message_seq__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
                         GeneratedField::__SkipField__ => {
                             let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
@@ -21391,6 +21600,8 @@ impl<'de> serde::Deserialize<'de> for ReconnectResponse {
                 Ok(ReconnectResponse {
                     ice_servers: ice_servers__.unwrap_or_default(),
                     client_configuration: client_configuration__,
+                    server_info: server_info__,
+                    last_message_seq: last_message_seq__.unwrap_or_default(),
                 })
             }
         }
@@ -27133,6 +27344,9 @@ impl serde::Serialize for SipOutboundConfig {
         if !self.hostname.is_empty() {
             len += 1;
         }
+        if !self.destination_country.is_empty() {
+            len += 1;
+        }
         if self.transport != 0 {
             len += 1;
         }
@@ -27151,6 +27365,9 @@ impl serde::Serialize for SipOutboundConfig {
         let mut struct_ser = serializer.serialize_struct("livekit.SIPOutboundConfig", len)?;
         if !self.hostname.is_empty() {
             struct_ser.serialize_field("hostname", &self.hostname)?;
+        }
+        if !self.destination_country.is_empty() {
+            struct_ser.serialize_field("destinationCountry", &self.destination_country)?;
         }
         if self.transport != 0 {
             let v = SipTransport::try_from(self.transport)
@@ -27180,6 +27397,8 @@ impl<'de> serde::Deserialize<'de> for SipOutboundConfig {
     {
         const FIELDS: &[&str] = &[
             "hostname",
+            "destination_country",
+            "destinationCountry",
             "transport",
             "auth_username",
             "authUsername",
@@ -27194,6 +27413,7 @@ impl<'de> serde::Deserialize<'de> for SipOutboundConfig {
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Hostname,
+            DestinationCountry,
             Transport,
             AuthUsername,
             AuthPassword,
@@ -27222,6 +27442,7 @@ impl<'de> serde::Deserialize<'de> for SipOutboundConfig {
                     {
                         match value {
                             "hostname" => Ok(GeneratedField::Hostname),
+                            "destinationCountry" | "destination_country" => Ok(GeneratedField::DestinationCountry),
                             "transport" => Ok(GeneratedField::Transport),
                             "authUsername" | "auth_username" => Ok(GeneratedField::AuthUsername),
                             "authPassword" | "auth_password" => Ok(GeneratedField::AuthPassword),
@@ -27247,6 +27468,7 @@ impl<'de> serde::Deserialize<'de> for SipOutboundConfig {
                     V: serde::de::MapAccess<'de>,
             {
                 let mut hostname__ = None;
+                let mut destination_country__ = None;
                 let mut transport__ = None;
                 let mut auth_username__ = None;
                 let mut auth_password__ = None;
@@ -27259,6 +27481,12 @@ impl<'de> serde::Deserialize<'de> for SipOutboundConfig {
                                 return Err(serde::de::Error::duplicate_field("hostname"));
                             }
                             hostname__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::DestinationCountry => {
+                            if destination_country__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("destinationCountry"));
+                            }
+                            destination_country__ = Some(map_.next_value()?);
                         }
                         GeneratedField::Transport => {
                             if transport__.is_some() {
@@ -27301,6 +27529,7 @@ impl<'de> serde::Deserialize<'de> for SipOutboundConfig {
                 }
                 Ok(SipOutboundConfig {
                     hostname: hostname__.unwrap_or_default(),
+                    destination_country: destination_country__.unwrap_or_default(),
                     transport: transport__.unwrap_or_default(),
                     auth_username: auth_username__.unwrap_or_default(),
                     auth_password: auth_password__.unwrap_or_default(),
@@ -27330,6 +27559,9 @@ impl serde::Serialize for SipOutboundTrunkInfo {
             len += 1;
         }
         if !self.address.is_empty() {
+            len += 1;
+        }
+        if !self.destination_country.is_empty() {
             len += 1;
         }
         if self.transport != 0 {
@@ -27371,6 +27603,9 @@ impl serde::Serialize for SipOutboundTrunkInfo {
         }
         if !self.address.is_empty() {
             struct_ser.serialize_field("address", &self.address)?;
+        }
+        if !self.destination_country.is_empty() {
+            struct_ser.serialize_field("destinationCountry", &self.destination_country)?;
         }
         if self.transport != 0 {
             let v = SipTransport::try_from(self.transport)
@@ -27420,6 +27655,8 @@ impl<'de> serde::Deserialize<'de> for SipOutboundTrunkInfo {
             "name",
             "metadata",
             "address",
+            "destination_country",
+            "destinationCountry",
             "transport",
             "numbers",
             "auth_username",
@@ -27443,6 +27680,7 @@ impl<'de> serde::Deserialize<'de> for SipOutboundTrunkInfo {
             Name,
             Metadata,
             Address,
+            DestinationCountry,
             Transport,
             Numbers,
             AuthUsername,
@@ -27478,6 +27716,7 @@ impl<'de> serde::Deserialize<'de> for SipOutboundTrunkInfo {
                             "name" => Ok(GeneratedField::Name),
                             "metadata" => Ok(GeneratedField::Metadata),
                             "address" => Ok(GeneratedField::Address),
+                            "destinationCountry" | "destination_country" => Ok(GeneratedField::DestinationCountry),
                             "transport" => Ok(GeneratedField::Transport),
                             "numbers" => Ok(GeneratedField::Numbers),
                             "authUsername" | "auth_username" => Ok(GeneratedField::AuthUsername),
@@ -27510,6 +27749,7 @@ impl<'de> serde::Deserialize<'de> for SipOutboundTrunkInfo {
                 let mut name__ = None;
                 let mut metadata__ = None;
                 let mut address__ = None;
+                let mut destination_country__ = None;
                 let mut transport__ = None;
                 let mut numbers__ = None;
                 let mut auth_username__ = None;
@@ -27544,6 +27784,12 @@ impl<'de> serde::Deserialize<'de> for SipOutboundTrunkInfo {
                                 return Err(serde::de::Error::duplicate_field("address"));
                             }
                             address__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::DestinationCountry => {
+                            if destination_country__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("destinationCountry"));
+                            }
+                            destination_country__ = Some(map_.next_value()?);
                         }
                         GeneratedField::Transport => {
                             if transport__.is_some() {
@@ -27615,6 +27861,7 @@ impl<'de> serde::Deserialize<'de> for SipOutboundTrunkInfo {
                     name: name__.unwrap_or_default(),
                     metadata: metadata__.unwrap_or_default(),
                     address: address__.unwrap_or_default(),
+                    destination_country: destination_country__.unwrap_or_default(),
                     transport: transport__.unwrap_or_default(),
                     numbers: numbers__.unwrap_or_default(),
                     auth_username: auth_username__.unwrap_or_default(),
@@ -27644,6 +27891,9 @@ impl serde::Serialize for SipOutboundTrunkUpdate {
         if self.transport.is_some() {
             len += 1;
         }
+        if self.destination_country.is_some() {
+            len += 1;
+        }
         if self.numbers.is_some() {
             len += 1;
         }
@@ -27670,6 +27920,9 @@ impl serde::Serialize for SipOutboundTrunkUpdate {
             let v = SipTransport::try_from(*v)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", *v)))?;
             struct_ser.serialize_field("transport", &v)?;
+        }
+        if let Some(v) = self.destination_country.as_ref() {
+            struct_ser.serialize_field("destinationCountry", v)?;
         }
         if let Some(v) = self.numbers.as_ref() {
             struct_ser.serialize_field("numbers", v)?;
@@ -27703,6 +27956,8 @@ impl<'de> serde::Deserialize<'de> for SipOutboundTrunkUpdate {
         const FIELDS: &[&str] = &[
             "address",
             "transport",
+            "destination_country",
+            "destinationCountry",
             "numbers",
             "auth_username",
             "authUsername",
@@ -27718,6 +27973,7 @@ impl<'de> serde::Deserialize<'de> for SipOutboundTrunkUpdate {
         enum GeneratedField {
             Address,
             Transport,
+            DestinationCountry,
             Numbers,
             AuthUsername,
             AuthPassword,
@@ -27748,6 +28004,7 @@ impl<'de> serde::Deserialize<'de> for SipOutboundTrunkUpdate {
                         match value {
                             "address" => Ok(GeneratedField::Address),
                             "transport" => Ok(GeneratedField::Transport),
+                            "destinationCountry" | "destination_country" => Ok(GeneratedField::DestinationCountry),
                             "numbers" => Ok(GeneratedField::Numbers),
                             "authUsername" | "auth_username" => Ok(GeneratedField::AuthUsername),
                             "authPassword" | "auth_password" => Ok(GeneratedField::AuthPassword),
@@ -27775,6 +28032,7 @@ impl<'de> serde::Deserialize<'de> for SipOutboundTrunkUpdate {
             {
                 let mut address__ = None;
                 let mut transport__ = None;
+                let mut destination_country__ = None;
                 let mut numbers__ = None;
                 let mut auth_username__ = None;
                 let mut auth_password__ = None;
@@ -27794,6 +28052,12 @@ impl<'de> serde::Deserialize<'de> for SipOutboundTrunkUpdate {
                                 return Err(serde::de::Error::duplicate_field("transport"));
                             }
                             transport__ = map_.next_value::<::std::option::Option<SipTransport>>()?.map(|x| x as i32);
+                        }
+                        GeneratedField::DestinationCountry => {
+                            if destination_country__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("destinationCountry"));
+                            }
+                            destination_country__ = map_.next_value()?;
                         }
                         GeneratedField::Numbers => {
                             if numbers__.is_some() {
@@ -27839,6 +28103,7 @@ impl<'de> serde::Deserialize<'de> for SipOutboundTrunkUpdate {
                 Ok(SipOutboundTrunkUpdate {
                     address: address__,
                     transport: transport__,
+                    destination_country: destination_country__,
                     numbers: numbers__,
                     auth_username: auth_username__,
                     auth_password: auth_password__,
@@ -30674,12 +30939,18 @@ impl serde::Serialize for SessionDescription {
         if !self.sdp.is_empty() {
             len += 1;
         }
+        if self.id != 0 {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("livekit.SessionDescription", len)?;
         if !self.r#type.is_empty() {
             struct_ser.serialize_field("type", &self.r#type)?;
         }
         if !self.sdp.is_empty() {
             struct_ser.serialize_field("sdp", &self.sdp)?;
+        }
+        if self.id != 0 {
+            struct_ser.serialize_field("id", &self.id)?;
         }
         struct_ser.end()
     }
@@ -30693,12 +30964,14 @@ impl<'de> serde::Deserialize<'de> for SessionDescription {
         const FIELDS: &[&str] = &[
             "type",
             "sdp",
+            "id",
         ];
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Type,
             Sdp,
+            Id,
             __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -30723,6 +30996,7 @@ impl<'de> serde::Deserialize<'de> for SessionDescription {
                         match value {
                             "type" => Ok(GeneratedField::Type),
                             "sdp" => Ok(GeneratedField::Sdp),
+                            "id" => Ok(GeneratedField::Id),
                             _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
@@ -30744,6 +31018,7 @@ impl<'de> serde::Deserialize<'de> for SessionDescription {
             {
                 let mut r#type__ = None;
                 let mut sdp__ = None;
+                let mut id__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Type => {
@@ -30758,6 +31033,14 @@ impl<'de> serde::Deserialize<'de> for SessionDescription {
                             }
                             sdp__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::Id => {
+                            if id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("id"));
+                            }
+                            id__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
                         GeneratedField::__SkipField__ => {
                             let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
@@ -30766,6 +31049,7 @@ impl<'de> serde::Deserialize<'de> for SessionDescription {
                 Ok(SessionDescription {
                     r#type: r#type__.unwrap_or_default(),
                     sdp: sdp__.unwrap_or_default(),
+                    id: id__.unwrap_or_default(),
                 })
             }
         }
@@ -34265,6 +34549,9 @@ impl serde::Serialize for SyncState {
         if !self.track_sids_disabled.is_empty() {
             len += 1;
         }
+        if !self.datachannel_receive_states.is_empty() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("livekit.SyncState", len)?;
         if let Some(v) = self.answer.as_ref() {
             struct_ser.serialize_field("answer", v)?;
@@ -34283,6 +34570,9 @@ impl serde::Serialize for SyncState {
         }
         if !self.track_sids_disabled.is_empty() {
             struct_ser.serialize_field("trackSidsDisabled", &self.track_sids_disabled)?;
+        }
+        if !self.datachannel_receive_states.is_empty() {
+            struct_ser.serialize_field("datachannelReceiveStates", &self.datachannel_receive_states)?;
         }
         struct_ser.end()
     }
@@ -34303,6 +34593,8 @@ impl<'de> serde::Deserialize<'de> for SyncState {
             "offer",
             "track_sids_disabled",
             "trackSidsDisabled",
+            "datachannel_receive_states",
+            "datachannelReceiveStates",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -34313,6 +34605,7 @@ impl<'de> serde::Deserialize<'de> for SyncState {
             DataChannels,
             Offer,
             TrackSidsDisabled,
+            DatachannelReceiveStates,
             __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -34341,6 +34634,7 @@ impl<'de> serde::Deserialize<'de> for SyncState {
                             "dataChannels" | "data_channels" => Ok(GeneratedField::DataChannels),
                             "offer" => Ok(GeneratedField::Offer),
                             "trackSidsDisabled" | "track_sids_disabled" => Ok(GeneratedField::TrackSidsDisabled),
+                            "datachannelReceiveStates" | "datachannel_receive_states" => Ok(GeneratedField::DatachannelReceiveStates),
                             _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
@@ -34366,6 +34660,7 @@ impl<'de> serde::Deserialize<'de> for SyncState {
                 let mut data_channels__ = None;
                 let mut offer__ = None;
                 let mut track_sids_disabled__ = None;
+                let mut datachannel_receive_states__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Answer => {
@@ -34404,6 +34699,12 @@ impl<'de> serde::Deserialize<'de> for SyncState {
                             }
                             track_sids_disabled__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::DatachannelReceiveStates => {
+                            if datachannel_receive_states__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("datachannelReceiveStates"));
+                            }
+                            datachannel_receive_states__ = Some(map_.next_value()?);
+                        }
                         GeneratedField::__SkipField__ => {
                             let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
@@ -34416,6 +34717,7 @@ impl<'de> serde::Deserialize<'de> for SyncState {
                     data_channels: data_channels__.unwrap_or_default(),
                     offer: offer__,
                     track_sids_disabled: track_sids_disabled__.unwrap_or_default(),
+                    datachannel_receive_states: datachannel_receive_states__.unwrap_or_default(),
                 })
             }
         }

--- a/livekit/src/proto.rs
+++ b/livekit/src/proto.rs
@@ -48,6 +48,7 @@ impl From<DisconnectReason> for participant::DisconnectReason {
             DisconnectReason::UserRejected => Self::UserRejected,
             DisconnectReason::SipTrunkFailure => Self::SipTrunkFailure,
             DisconnectReason::ConnectionTimeout => Self::ConnectionTimeout,
+            DisconnectReason::MediaFailure => Self::MediaFailure,
         }
     }
 }

--- a/livekit/src/room/data_stream/outgoing.rs
+++ b/livekit/src/room/data_stream/outgoing.rs
@@ -200,6 +200,8 @@ impl RawStream {
             participant_identity: String::new(), // populate later
             destination_identities: destination_identities.into_iter().map(|id| id.0).collect(),
             value: Some(livekit_protocol::data_packet::Value::StreamHeader(header)),
+            // TODO: placeholder for reliable data transport
+            ..Default::default()
         }
     }
 

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -221,6 +221,12 @@ pub enum RoomEvent {
         kind: DataPacketKind,
         threshold: u64,
     },
+    RoomUpdated {
+        room: RoomInfo,
+    },
+    Moved {
+        room: RoomInfo,
+    },
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -391,14 +397,24 @@ impl Debug for Room {
     }
 }
 
-struct RoomInfo {
-    metadata: String,
-    state: ConnectionState,
-    lossy_dc_options: DataChannelOptions,
-    reliable_dc_options: DataChannelOptions,
+#[derive(Clone, Debug)]
+pub struct RoomInfo {
+    pub sid: Option<RoomSid>,
+    pub name: String,
+    pub metadata: String,
+    pub state: ConnectionState,
+    pub lossy_dc_options: DataChannelOptions,
+    pub reliable_dc_options: DataChannelOptions,
+    pub empty_timeout: u32,
+    pub departure_timeout: u32,
+    pub max_participants: u32,
+    pub creation_time: i64,
+    pub num_publishers: u32,
+    pub num_participants: u32,
+    pub active_recording: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DataChannelOptions {
     pub buffered_amount_low_threshold: u64,
 }
@@ -411,8 +427,7 @@ impl Default for DataChannelOptions {
 
 pub(crate) struct RoomSession {
     rtc_engine: Arc<RtcEngine>,
-    sid: Promise<RoomSid>,
-    name: String,
+    sid_promise: Promise<RoomSid>,
     info: RwLock<RoomInfo>,
     dispatcher: Dispatcher<RoomEvent>,
     options: RoomOptions,
@@ -434,9 +449,10 @@ struct Handle {
 
 impl Debug for RoomSession {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let info = self.info.read();
         f.debug_struct("SessionInner")
-            .field("sid", &self.sid.try_result())
-            .field("name", &self.name)
+            .field("sid", &info.sid)
+            .field("name", &info.name)
             .field("rtc_engine", &self.rtc_engine)
             .finish()
     }
@@ -562,11 +578,19 @@ impl Room {
 
         let room_info = join_response.room.unwrap();
         let inner = Arc::new(RoomSession {
-            sid: Promise::new(),
-            name: room_info.name,
+            sid_promise: Promise::new(),
             info: RwLock::new(RoomInfo {
-                state: ConnectionState::Disconnected,
+                sid: room_info.sid.try_into().ok(),
+                name: room_info.name,
                 metadata: room_info.metadata,
+                empty_timeout: room_info.empty_timeout,
+                departure_timeout: room_info.departure_timeout,
+                max_participants: room_info.max_participants,
+                creation_time: room_info.creation_time,
+                num_publishers: room_info.num_publishers,
+                num_participants: room_info.num_participants,
+                active_recording: room_info.active_recording,
+                state: ConnectionState::Disconnected,
                 lossy_dc_options: Default::default(),
                 reliable_dc_options: Default::default(),
             }),
@@ -675,15 +699,20 @@ impl Room {
     }
 
     pub async fn sid(&self) -> RoomSid {
-        self.inner.sid.result().await
+        // sid could have been updated due to room move
+        let sid = self.inner.info.read().sid.clone();
+        if sid.is_none() {
+            return self.inner.sid_promise.result().await;
+        }
+        sid.unwrap()
     }
 
     pub fn maybe_sid(&self) -> Option<RoomSid> {
-        self.inner.sid.try_result()
+        self.inner.info.read().sid.clone()
     }
 
     pub fn name(&self) -> String {
-        self.inner.name.clone()
+        self.inner.info.read().name.clone()
     }
 
     pub fn metadata(&self) -> String {
@@ -711,6 +740,34 @@ impl Room {
             DataPacketKind::Lossy => self.inner.info.read().lossy_dc_options.clone(),
             DataPacketKind::Reliable => self.inner.info.read().reliable_dc_options.clone(),
         }
+    }
+
+    pub fn empty_timeout(&self) -> u32 {
+        self.inner.info.read().empty_timeout
+    }
+
+    pub fn departure_timeout(&self) -> u32 {
+        self.inner.info.read().departure_timeout
+    }
+
+    pub fn max_participants(&self) -> u32 {
+        self.inner.info.read().max_participants
+    }
+
+    pub fn creation_time(&self) -> i64 {
+        self.inner.info.read().creation_time
+    }
+
+    pub fn num_participants(&self) -> u32 {
+        self.inner.info.read().num_participants
+    }
+
+    pub fn num_publishers(&self) -> u32 {
+        self.inner.info.read().num_publishers
+    }
+
+    pub fn active_recording(&self) -> bool {
+        self.inner.info.read().active_recording
     }
 }
 
@@ -759,6 +816,7 @@ impl RoomSession {
                 self.handle_media_track(track, stream, transceiver)
             }
             EngineEvent::RoomUpdate { room } => self.handle_room_update(room),
+            EngineEvent::RoomMoved { moved } => self.handle_room_moved(moved),
             EngineEvent::Resuming(tx) => self.handle_resuming(tx),
             EngineEvent::Resumed(tx) => self.handle_resumed(tx),
             EngineEvent::SignalResumed { reconnect_response, tx } => {
@@ -1099,10 +1157,12 @@ impl RoomSession {
             answer: Some(proto::SessionDescription {
                 sdp: answer.to_string(),
                 r#type: answer.sdp_type().to_string(),
+                id: 0,
             }),
             offer: Some(proto::SessionDescription {
                 sdp: offer.to_string(),
                 r#type: offer.sdp_type().to_string(),
+                id: 0,
             }),
             track_sids_disabled: Vec::default(), // TODO: New protocol version
             subscription: Some(proto::UpdateSubscription {
@@ -1112,6 +1172,8 @@ impl RoomSession {
             }),
             publish_tracks: self.local_participant.published_tracks_info(),
             data_channels: dcs,
+            // unimplemented, stubbed for now
+            datachannel_receive_states: Vec::new(),
         };
 
         log::debug!("sending sync state {:?}", sync_state);
@@ -1121,15 +1183,66 @@ impl RoomSession {
     fn handle_room_update(self: &Arc<Self>, room: proto::Room) {
         let mut info = self.info.write();
         let old_metadata = std::mem::replace(&mut info.metadata, room.metadata.clone());
+        let mut updated = false;
         if old_metadata != room.metadata {
+            updated = true;
             self.dispatcher.dispatch(&RoomEvent::RoomMetadataChanged {
                 old_metadata,
                 metadata: info.metadata.clone(),
             });
         }
         if !room.sid.is_empty() {
-            let _ = self.sid.resolve(room.sid.try_into().unwrap());
+            let sid = room.sid.try_into().ok();
+            info.sid = sid.clone();
+            if let Some(sid) = sid {
+                let _ = self.sid_promise.resolve(sid);
+            }
         }
+        if info.name != room.name {
+            updated = true;
+            info.name = room.name;
+        }
+        if info.empty_timeout != room.empty_timeout {
+            updated = true;
+            info.empty_timeout = room.empty_timeout;
+        }
+        if info.departure_timeout != room.departure_timeout {
+            updated = true;
+            info.departure_timeout = room.departure_timeout;
+        }
+        if info.max_participants != room.max_participants {
+            updated = true;
+            info.max_participants = room.max_participants;
+        }
+        if info.num_participants != room.num_participants {
+            updated = true;
+            info.num_participants = room.num_participants;
+        }
+        if info.num_publishers != room.num_publishers {
+            updated = true;
+            info.num_publishers = room.num_publishers;
+        }
+        if info.active_recording != room.active_recording {
+            updated = true;
+            info.active_recording = room.active_recording;
+        }
+        info.creation_time = room.creation_time_ms;
+        if updated {
+            self.dispatcher.dispatch(&RoomEvent::RoomUpdated { room: info.clone() });
+        }
+    }
+
+    fn handle_room_moved(self: &Arc<Self>, moved: proto::RoomMovedResponse) {
+        self.handle_refresh_token(self.rtc_engine.session().signal_client().url(), moved.token);
+        if let Some(local_participant) = moved.participant {
+            self.local_participant.update_info(local_participant);
+        }
+        self.handle_participant_update(moved.other_participants);
+        if let Some(room) = moved.room {
+            self.handle_room_update(room);
+        }
+        let info = self.info.read();
+        self.dispatcher.dispatch(&RoomEvent::Moved { room: info.clone() });
     }
 
     fn handle_resuming(self: &Arc<Self>, tx: oneshot::Sender<()>) {

--- a/livekit/src/room/participant/mod.rs
+++ b/livekit/src/room/participant/mod.rs
@@ -63,6 +63,7 @@ pub enum DisconnectReason {
     UserRejected,
     SipTrunkFailure,
     ConnectionTimeout,
+    MediaFailure,
 }
 
 #[derive(Debug, Clone)]

--- a/livekit/src/rtc_engine/mod.rs
+++ b/livekit/src/rtc_engine/mod.rs
@@ -138,6 +138,9 @@ pub enum EngineEvent {
     RoomUpdate {
         room: proto::Room,
     },
+    RoomMoved {
+        moved: proto::RoomMovedResponse,
+    },
     /// The following events are used to notify the room about the reconnection state
     /// Since the room needs to also sync state in a good timing with the server.
     /// We synchronize the state with a one-shot channel.
@@ -540,6 +543,9 @@ impl EngineInner {
             }
             SessionEvent::RoomUpdate { room } => {
                 let _ = self.engine_tx.send(EngineEvent::RoomUpdate { room });
+            }
+            SessionEvent::RoomMoved { moved } => {
+                let _ = self.engine_tx.send(EngineEvent::RoomMoved { moved });
             }
             SessionEvent::LocalTrackSubscribed { track_sid } => {
                 let _ = self.engine_tx.send(EngineEvent::LocalTrackSubscribed { track_sid });

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -152,6 +152,9 @@ pub enum SessionEvent {
     RoomUpdate {
         room: proto::Room,
     },
+    RoomMoved {
+        moved: proto::RoomMovedResponse,
+    },
     LocalTrackSubscribed {
         track_sid: String,
     },
@@ -683,6 +686,7 @@ impl SessionInner {
                     .send(proto::signal_request::Message::Answer(proto::SessionDescription {
                         r#type: "answer".to_string(),
                         sdp: answer.to_string(),
+                        id: 0,
                     }))
                     .await;
             }
@@ -734,6 +738,9 @@ impl SessionInner {
             proto::signal_response::Message::RoomUpdate(room_update) => {
                 let _ =
                     self.emitter.send(SessionEvent::RoomUpdate { room: room_update.room.unwrap() });
+            }
+            proto::signal_response::Message::RoomMoved(room_moved) => {
+                let _ = self.emitter.send(SessionEvent::RoomMoved { moved: room_moved });
             }
             proto::signal_response::Message::TrackSubscribed(track_subscribed) => {
                 let _ = self.emitter.send(SessionEvent::LocalTrackSubscribed {
@@ -803,6 +810,7 @@ impl SessionInner {
                     .send(proto::signal_request::Message::Offer(proto::SessionDescription {
                         r#type: "offer".to_string(),
                         sdp: offer.to_string(),
+                        id: 0,
                     }))
                     .await;
             }


### PR DESCRIPTION
giving clients other information about the room so they could receive all updates

also ensure that we pass through full participant updates, since sid is expected to change in certain situations (reconnect, move)

FYI @bcherry 