### PR TITLE
add livekit-ffi to release-plz management

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -61,6 +61,7 @@ release = true
 name = "livekit-ffi"
 changelog_path = "livekit-ffi/CHANGELOG.md"
 publish = true
+publish_no_verify = true
 release = true
 git_release_enable = false # existing CI manages GitHub release
 changelog_include = [

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -50,3 +50,23 @@ name = "yuv-sys"
 changelog_path = "yuv-sys/CHANGELOG.md"
 publish = true
 release = true
+
+[[package]]
+name = "soxr-sys"
+changelog_path = "soxr-sys/CHANGELOG.md"
+publish = true
+release = true
+
+[[package]]
+name = "livekit-ffi"
+changelog_path = "livekit-ffi/CHANGELOG.md"
+publish = true
+release = true
+git_release_enable = false # existing CI manages GitHub release
+changelog_include = [
+  "livekit",
+  "soxr-sys",
+  "imgproc",
+  "livekit-protocol",
+  "webrtc-sys-build",
+]


### PR DESCRIPTION
`release-plz` manages:
- generate changelogs
- tag ffi (to trigger existing release CI
- publish it to crates.io

Existing CI:
- triggered by tag created by release-plz
- build and release as the same way to current FFI release workflow

Note: we need to publish livekit-ffi to crates.io to make this work. I will do it before merging this