### PR TITLE
update workflows to use workflow_call

### DIFF
--- a/.github/workflows/ffi-builds.yml
+++ b/.github/workflows/ffi-builds.yml
@@ -213,7 +213,7 @@ jobs:
     needs: build
     permissions:
       contents: write
-    if: startsWith(env.TAG_NAME, 'rust-sdks/livekit-ffi@')
+    if: startsWith(inputs.tag || github.ref_name, 'rust-sdks/livekit-ffi@')
     env:
       GH_TOKEN: ${{ github.token }}
     steps:

--- a/.github/workflows/ffi-builds.yml
+++ b/.github/workflows/ffi-builds.yml
@@ -19,9 +19,15 @@ on:
     tags:
       - "rust-sdks/livekit-ffi@*"
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      tag:
+        required: false
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
+  TAG_NAME: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   build:
@@ -207,7 +213,7 @@ jobs:
     needs: build
     permissions:
       contents: write
-    if: startsWith(github.ref, 'refs/tags/rust-sdks/livekit-ffi')
+    if: startsWith(env.TAG_NAME, 'rust-sdks/livekit-ffi@')
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
@@ -222,5 +228,5 @@ jobs:
 
       - name: Create draft release
         run: |
-          gh release create ${{ github.ref_name }} --draft --title "${{ github.ref_name }}"
-          gh release upload ${{ github.ref_name }} ${{ github.workspace }}/ffi-builds/*
+          gh release create ${{ env.TAG_NAME }} --draft --title "${{ env.TAG_NAME }}"
+          gh release upload ${{ env.TAG_NAME }} ${{ github.workspace }}/ffi-builds/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
     if: ${{ github.repository_owner == 'livekit' }}
     permissions:
       contents: write
+    outputs:
+      ffi_tag: ${{ steps.ffi.outputs.ffi_tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -34,19 +36,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
-      - name: Trigger FFI workflow if needed
+      - name: Extract ffi tag
+        id: ffi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASES: ${{ steps.release-plz.outputs.releases }}
         run: |
           set -e
-          echo "releases: $RELEASES"
-
           ffi_tag=$(echo "$RELEASES" | jq -r '.[].tag' | grep 'rust-sdks/livekit-ffi@' || true)
-          if [ -n "$ffi_tag" ]; then
-            echo "Found ffi_tag: $ffi_tag"
-            gh workflow run ffi-builds.yml --ref $ffi_tag
-          fi
+          echo "ffi_tag=$ffi_tag"
+          echo "ffi_tag=$ffi_tag" >> $GITHUB_OUTPUT
+
+  call-ffi:
+    name: Call FFI Builds
+    if: ${{ needs.release-plz-release.outputs.ffi_tag != '' }}
+    uses: ./.github/workflows/ffi-builds.yml
+    needs: release-plz-release
+    with:
+      tag: ${{ needs.release-plz-release.outputs.ffi_tag }}
 
   # Create a PR with the new versions and changelog, preparing the next release.
   release-plz-pr:


### PR DESCRIPTION
Switch from `gh workflow run` to `workflow_call` because triggering `ffi-builds.yml` from `release.yml` via `gh` results in a 403 error somehow
