### PR TITLE
Data channel reliability

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,8 +35,10 @@ jobs:
             target: x86_64-pc-windows-msvc
           - os: macos-latest
             target: x86_64-apple-darwin
+            e2e-testing: true
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            e2e-testing: true
 
     name: Test (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
@@ -53,16 +55,28 @@ jobs:
           sudo apt install -y libssl-dev libx11-dev libgl1-mesa-dev libxext-dev libva-dev libdrm-dev libnvidia-decode-570 libnvidia-compute-570 nvidia-cuda-dev
 
       - name: Install LiveKit server
-        run: curl -sSL https://get.livekit.io | bash
+        if: ${{ matrix.e2e-testing }}
+        run: |
+          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+            curl -sSL https://get.livekit.io | bash
+          elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+            brew install livekit
+          fi
 
       - uses: actions/checkout@v3
         with:
           submodules: true
 
       - name: Run LiveKit server
+        if: ${{ matrix.e2e-testing }}
         run: livekit-server --dev &
 
-      - name: Test
+      - name: Test (no E2E)
+        if: ${{ !matrix.e2e-testing }}
         run: cargo +nightly test --release --verbose --target ${{ matrix.target }} -- --nocapture
+
+      - name: Test (with E2E)
+        if: ${{ matrix.e2e-testing }}
+        run: cargo +nightly test --release --verbose --target ${{ matrix.target }} --features __lk-e2e-test -- --nocapture
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,9 +52,15 @@ jobs:
           sudo apt update -y
           sudo apt install -y libssl-dev libx11-dev libgl1-mesa-dev libxext-dev libva-dev libdrm-dev libnvidia-decode-570 libnvidia-compute-570 nvidia-cuda-dev
 
+      - name: Install LiveKit server
+        run: curl -sSL https://get.livekit.io | bash
+
       - uses: actions/checkout@v3
         with:
           submodules: true
+
+      - name: Run LiveKit server
+        run: livekit-server --dev &
 
       - name: Test
         run: cargo +nightly test --release --verbose --target ${{ matrix.target }} -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "async-channel"
@@ -1618,6 +1618,7 @@ checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 name = "livekit"
 version = "0.7.16"
 dependencies = [
+ "anyhow",
  "bmrng",
  "bytes",
  "chrono",

--- a/livekit/Cargo.toml
+++ b/livekit/Cargo.toml
@@ -22,9 +22,8 @@ native-tls-vendored = ["livekit-api/native-tls-vendored"]
 rustls-tls-native-roots = ["livekit-api/rustls-tls-native-roots"]
 rustls-tls-webpki-roots = ["livekit-api/rustls-tls-webpki-roots"]
 __rustls-tls = ["livekit-api/__rustls-tls"]
-
-# internal features (used by livekit-ffi)
-__lk-internal = []
+__lk-internal = [] # internal features (used by livekit-ffi)
+__lk-e2e-test = [] # end-to-end testing with a LiveKit server
 
 [dependencies]
 livekit-runtime = { workspace = true, default-features = false }

--- a/livekit/Cargo.toml
+++ b/livekit/Cargo.toml
@@ -45,3 +45,6 @@ semver = "1.0"
 libloading = { version = "0.8.6" }
 bytes = "1.10.1"
 bmrng = "0.5.2"
+
+[dev-dependencies]
+anyhow = "1.0.99"

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -1178,8 +1178,7 @@ impl RoomSession {
             }),
             publish_tracks: self.local_participant.published_tracks_info(),
             data_channels: dcs,
-            // unimplemented, stubbed for now
-            datachannel_receive_states: Vec::new(),
+            datachannel_receive_states: session.data_channel_receive_states()
         };
 
         log::debug!("sending sync state {:?}", sync_state);

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -353,7 +353,7 @@ pub struct RoomOptions {
     pub e2ee: Option<E2eeOptions>,
     pub rtc_config: RtcConfiguration,
     pub join_retries: u32,
-    pub sdk_options: RoomSdkOptions
+    pub sdk_options: RoomSdkOptions,
 }
 
 impl Default for RoomOptions {
@@ -372,7 +372,7 @@ impl Default for RoomOptions {
                 ice_transport_type: IceTransportsType::All,
             },
             join_retries: 3,
-            sdk_options: RoomSdkOptions::default()
+            sdk_options: RoomSdkOptions::default(),
         }
     }
 }
@@ -1175,7 +1175,7 @@ impl RoomSession {
             }),
             publish_tracks: self.local_participant.published_tracks_info(),
             data_channels: dcs,
-            datachannel_receive_states: session.data_channel_receive_states()
+            datachannel_receive_states: session.data_channel_receive_states(),
         };
 
         log::debug!("sending sync state {:?}", sync_state);

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -353,15 +353,7 @@ pub struct RoomOptions {
     pub e2ee: Option<E2eeOptions>,
     pub rtc_config: RtcConfiguration,
     pub join_retries: u32,
-    pub sdk_options: RoomSdkOptions,
-    pub preregistration: Option<PreRegistration>,
-}
-
-#[derive(Debug, Clone)]
-#[non_exhaustive]
-pub struct PreRegistration {
-    text_stream_topics: Vec<String>,
-    byte_stream_topics: Vec<String>,
+    pub sdk_options: RoomSdkOptions
 }
 
 impl Default for RoomOptions {
@@ -380,8 +372,7 @@ impl Default for RoomOptions {
                 ice_transport_type: IceTransportsType::All,
             },
             join_retries: 3,
-            sdk_options: RoomSdkOptions::default(),
-            preregistration: None,
+            sdk_options: RoomSdkOptions::default()
         }
     }
 }

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -568,8 +568,6 @@ impl Room {
         let (incoming_stream_manager, open_rx) = IncomingStreamManager::new();
         let (outgoing_stream_manager, packet_rx) = OutgoingStreamManager::new();
 
-        let identity = local_participant.identity().clone();
-
         let room_info = join_response.room.unwrap();
         let inner = Arc::new(RoomSession {
             sid_promise: Promise::new(),
@@ -662,7 +660,6 @@ impl Room {
         ));
         let outgoing_stream_handle = livekit_runtime::spawn(outgoing_data_stream_task(
             packet_rx,
-            identity,
             rtc_engine.clone(),
             close_rx.resubscribe(),
         ));
@@ -1727,15 +1724,12 @@ async fn incoming_data_stream_task(
 /// Receives packets from the outgoing stream manager and send them.
 async fn outgoing_data_stream_task(
     mut packet_rx: UnboundedRequestReceiver<proto::DataPacket, Result<(), EngineError>>,
-    participant_identity: ParticipantIdentity,
     engine: Arc<RtcEngine>,
     mut close_rx: broadcast::Receiver<()>,
 ) {
     loop {
         tokio::select! {
-            Ok((mut packet, responder)) = packet_rx.recv() => {
-                // Set packet's participant identity field
-                packet.participant_identity = participant_identity.0.clone();
+            Ok((packet, responder)) = packet_rx.recv() => {
                 let result = engine.publish_data(packet, DataPacketKind::Reliable).await;
                 let _ = responder.respond(result);
             },

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -568,7 +568,8 @@ impl Room {
         let (incoming_stream_manager, open_rx) = IncomingStreamManager::new();
         let (outgoing_stream_manager, packet_rx) = OutgoingStreamManager::new();
 
-        let identity = local_participant.identity().clone();
+        let local_participant_identity = local_participant.identity();
+        let local_participant_sid = local_participant.sid();
 
         let room_info = join_response.room.unwrap();
         let inner = Arc::new(RoomSession {
@@ -662,7 +663,8 @@ impl Room {
         ));
         let outgoing_stream_handle = livekit_runtime::spawn(outgoing_data_stream_task(
             packet_rx,
-            identity,
+            local_participant_sid,
+            local_participant_identity,
             rtc_engine.clone(),
             close_rx.resubscribe(),
         ));
@@ -1727,6 +1729,7 @@ async fn incoming_data_stream_task(
 /// Receives packets from the outgoing stream manager and send them.
 async fn outgoing_data_stream_task(
     mut packet_rx: UnboundedRequestReceiver<proto::DataPacket, Result<(), EngineError>>,
+    participant_sid: ParticipantSid,
     participant_identity: ParticipantIdentity,
     engine: Arc<RtcEngine>,
     mut close_rx: broadcast::Receiver<()>,
@@ -1735,6 +1738,7 @@ async fn outgoing_data_stream_task(
         tokio::select! {
             Ok((mut packet, responder)) = packet_rx.recv() => {
                 // Set packet's participant identity field
+                packet.participant_sid = participant_sid.clone().into();
                 packet.participant_identity = participant_identity.0.clone();
                 let result = engine.publish_data(packet, DataPacketKind::Reliable).await;
                 let _ = responder.respond(result);

--- a/livekit/src/room/utils/mod.rs
+++ b/livekit/src/room/utils/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-pub mod ttl_map;
+pub(crate) mod ttl_map;
 pub mod take_cell;
 pub mod utf8_chunk;
 

--- a/livekit/src/room/utils/mod.rs
+++ b/livekit/src/room/utils/mod.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
-pub(crate) mod tx_queue;
-pub(crate) mod ttl_map;
 pub mod take_cell;
+pub(crate) mod ttl_map;
+pub(crate) mod tx_queue;
 pub mod utf8_chunk;
 
 pub fn calculate_changed_attributes(

--- a/livekit/src/room/utils/mod.rs
+++ b/livekit/src/room/utils/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+pub(crate) mod tx_queue;
 pub(crate) mod ttl_map;
 pub mod take_cell;
 pub mod utf8_chunk;

--- a/livekit/src/room/utils/mod.rs
+++ b/livekit/src/room/utils/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+pub mod ttl_map;
 pub mod take_cell;
 pub mod utf8_chunk;
 

--- a/livekit/src/room/utils/ttl_map.rs
+++ b/livekit/src/room/utils/ttl_map.rs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 use std::{
-    collections::HashMap, fmt::Debug, hash::Hash, time::{Duration, SystemTime}
+    collections::HashMap,
+    fmt::Debug,
+    hash::Hash,
+    time::{Duration, SystemTime},
 };
 
 /// Time to live (TTL) map

--- a/livekit/src/room/utils/ttl_map.rs
+++ b/livekit/src/room/utils/ttl_map.rs
@@ -13,21 +13,21 @@
 // limitations under the License.
 
 use std::{
-    collections::HashMap,
-    hash::Hash,
-    time::{Duration, SystemTime},
+    collections::HashMap, fmt::Debug, hash::Hash, time::{Duration, SystemTime}
 };
 
 /// Time to live (TTL) map
 ///
 /// Elements older than the TTL duration are automatically removed.
 ///
+#[derive(Debug)]
 pub struct TtlMap<K, V> {
     inner: HashMap<K, Entry<V>>,
     last_cleanup: SystemTime,
     ttl: Duration,
 }
 
+#[derive(Debug)]
 struct Entry<V> {
     value: V,
     expires_at: SystemTime,

--- a/livekit/src/room/utils/ttl_map.rs
+++ b/livekit/src/room/utils/ttl_map.rs
@@ -1,0 +1,140 @@
+// Copyright 2025 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    collections::HashMap,
+    hash::Hash,
+    time::{Duration, SystemTime},
+};
+
+/// Time to live (TTL) map
+///
+/// Elements older than the TTL duration are automatically removed.
+///
+pub struct TtlMap<K, V> {
+    inner: HashMap<K, Entry<V>>,
+    last_cleanup: SystemTime,
+    ttl: Duration,
+}
+
+struct Entry<V> {
+    value: V,
+    expires_at: SystemTime,
+}
+
+impl<K, V> TtlMap<K, V> {
+    /// Creates an empty `TtlMap`.
+    pub fn new(ttl: Duration) -> Self {
+        Self { inner: HashMap::new(), last_cleanup: SystemTime::now(), ttl }
+    }
+
+    /// Returns the number of elements in the map.
+    pub fn len(&mut self) -> usize {
+        self.cleanup();
+        self.inner.len()
+    }
+
+    /// An iterator visiting all key-value pairs in arbitrary order.
+    /// The iterator element type is `(&'a K, &'a V)`.
+    pub fn iter(&mut self) -> impl Iterator<Item = (&K, &V)> {
+        self.cleanup();
+        self.inner.iter().map(|(key, entry)| (key, &entry.value))
+    }
+
+    /// Removes expired elements.
+    fn cleanup(&mut self) {
+        let now = SystemTime::now();
+        self.inner.retain(|_, entry| entry.expires_at >= now);
+        self.last_cleanup = now;
+    }
+}
+
+impl<K, V> TtlMap<K, V>
+where
+    K: Eq + Hash,
+{
+    /// Returns a reference to the value corresponding to the key.
+    pub fn get(&mut self, k: &K) -> Option<&V> {
+        let expires_at = self.inner.get(k).map(|entry| entry.expires_at)?;
+        let now = SystemTime::now();
+        if expires_at < now {
+            _ = self.inner.remove(k);
+            return None;
+        }
+        Some(&self.inner.get(k).unwrap().value)
+    }
+
+    /// Sets the value for the given key.
+    pub fn set(&mut self, k: K, v: Option<V>) {
+        let now = SystemTime::now();
+        let Ok(elapsed) = now.duration_since(self.last_cleanup) else {
+            log::error!("System clock anomaly detected");
+            return;
+        };
+        let half_ttl = self.ttl.div_f64(2.0);
+        if elapsed > half_ttl {
+            self.cleanup();
+        }
+
+        let Some(value) = v else {
+            _ = self.inner.remove(&k);
+            return;
+        };
+        let expires_at = now + self.ttl;
+        let entry = Entry { value, expires_at };
+        self.inner.insert(k, entry);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use tokio::time::sleep;
+
+    const SHORT_TTL: Duration = Duration::from_millis(100);
+
+    #[tokio::test]
+    async fn test_expiration() {
+        let mut map = TtlMap::<char, u8>::new(SHORT_TTL);
+        map.set('a', Some(1));
+        map.set('b', Some(2));
+        map.set('c', Some(3));
+
+        assert_eq!(map.len(), 3);
+        assert!(map.get(&'a').is_some());
+        assert!(map.get(&'b').is_some());
+        assert!(map.get(&'c').is_some());
+
+        sleep(SHORT_TTL).await;
+
+        assert_eq!(map.len(), 0);
+        assert!(map.get(&'a').is_none());
+        assert!(map.get(&'b').is_none());
+        assert!(map.get(&'c').is_none());
+    }
+
+    #[test]
+    fn test_iter() {
+        let mut map = TtlMap::<char, u8>::new(SHORT_TTL);
+        map.set('a', Some(1));
+        map.set('b', Some(2));
+        map.set('c', Some(3));
+
+        let elements: HashSet<_> = map.iter().map(|(k, v)| (*k, *v)).collect();
+        assert!(elements.contains(&('a', 1)));
+        assert!(elements.contains(&('b', 2)));
+        assert!(elements.contains(&('c', 3)));
+    }
+}

--- a/livekit/src/room/utils/tx_queue.rs
+++ b/livekit/src/room/utils/tx_queue.rs
@@ -17,16 +17,13 @@ use std::collections::VecDeque;
 #[derive(Debug)]
 pub struct TxQueue<T> {
     inner: VecDeque<T>,
-    buffered_size: usize
+    buffered_size: usize,
 }
 
 impl<T: TxQueueItem> TxQueue<T> {
     /// Creates an empty queue.
     pub fn new() -> Self {
-        Self {
-            inner: VecDeque::new(),
-            buffered_size: 0
-        }
+        Self { inner: VecDeque::new(), buffered_size: 0 }
     }
 
     /// Number of elements in the queue.

--- a/livekit/src/room/utils/tx_queue.rs
+++ b/livekit/src/room/utils/tx_queue.rs
@@ -1,0 +1,116 @@
+// Copyright 2025 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::VecDeque;
+
+#[derive(Debug)]
+pub struct TxQueue<T> {
+    inner: VecDeque<T>,
+    buffered_size: usize
+}
+
+impl<T: TxQueueItem> TxQueue<T> {
+    /// Creates an empty queue.
+    pub fn new() -> Self {
+        Self {
+            inner: VecDeque::new(),
+            buffered_size: 0
+        }
+    }
+
+    /// Number of elements in the queue.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Total size in bytes of all items currently in the queue.
+    pub fn buffered_size(&self) -> usize {
+        self.buffered_size
+    }
+
+    /// Provides a reference to the front element, or `None if the queue is empty.
+    pub fn peek(&self) -> Option<&T> {
+        self.inner.front()
+    }
+
+    /// Appends an item to the back of the queue.
+    pub fn enqueue(&mut self, item: T) {
+        let size = item.buffered_size();
+        self.inner.push_back(item);
+        self.buffered_size += size;
+    }
+
+    /// Removes the first item and returns it, or `None` if the queue is empty.
+    pub fn dequeue(&mut self) -> Option<T> {
+        let item = self.inner.pop_front()?;
+        let size = item.buffered_size();
+        self.buffered_size -= size;
+        return Some(item);
+    }
+
+    /// Dequeue and discard items until the buffered size is less than or
+    /// equal to the given target.
+    pub fn trim(&mut self, target_buffer_size: usize) {
+        while self.buffered_size > target_buffer_size {
+            _ = self.dequeue()
+        }
+    }
+}
+
+/// Item in a [`TxQueue`].
+pub trait TxQueueItem {
+    /// Amount in bytes this item adds to the [`TxQueue`]'s buffered size.
+    fn buffered_size(&self) -> usize;
+}
+
+impl TxQueueItem for Vec<u8> {
+    fn buffered_size(&self) -> usize {
+        self.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TxQueue;
+
+    #[test]
+    fn test_buffered_size() {
+        let mut queue = TxQueue::new();
+
+        queue.enqueue(vec![0xFF, 0xFA]);
+        assert_eq!(queue.buffered_size(), 2);
+
+        queue.enqueue(vec![0x0F, 0xFC, 0xAF]);
+        assert_eq!(queue.buffered_size(), 5);
+
+        assert_eq!(queue.dequeue(), Some(vec![0xFF, 0xFA]));
+        assert_eq!(queue.buffered_size, 3);
+
+        assert_eq!(queue.dequeue(), Some(vec![0x0F, 0xFC, 0xAF]));
+        assert_eq!(queue.buffered_size, 0);
+
+        assert_eq!(queue.dequeue(), None);
+    }
+
+    #[test]
+    fn test_trim() {
+        let mut queue = TxQueue::new();
+        queue.enqueue(vec![0xFF, 0xFA]);
+        queue.enqueue(vec![0x0F, 0xFC, 0xAF]);
+        queue.enqueue(vec![0xAA]);
+
+        queue.trim(1);
+        assert_eq!(queue.buffered_size(), 1);
+    }
+}

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -1000,7 +1000,7 @@ impl SessionInner {
                             };
 
                             let _ = self.emitter.send(SessionEvent::Data {
-                                kind: data.kind().into(),
+                                kind,
                                 participant_sid: participant_sid.map(|s| s.try_into().unwrap()),
                                 participant_identity: participant_identity
                                     .map(|s| s.try_into().unwrap()),

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -825,7 +825,7 @@ impl SessionInner {
                     log::warn!("Track event with no streams");
                 }
             }
-            RtcEvent::Data { data, binary } => {
+            RtcEvent::Data { data, binary, kind } => {
                 if !binary {
                     Err(EngineError::Internal("text messages aren't supported".into()))?;
                 }

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -976,7 +976,9 @@ impl SessionInner {
                     Err(EngineError::Internal("text messages aren't supported".into()))?;
                 }
 
-                let data = proto::DataPacket::decode(&*data).unwrap();
+                let data = proto::DataPacket::decode(&*data).map_err(|err| {
+                    EngineError::Internal(format!("failed to decode data packet: {}", err).into())
+                })?;
                 if kind == DataPacketKind::Reliable {
                     self.update_reliable_received_state(&data);
                 }

--- a/livekit/tests/common/mod.rs
+++ b/livekit/tests/common/mod.rs
@@ -1,0 +1,56 @@
+use anyhow::{Context, Result};
+use futures_util::future::try_join_all;
+use libwebrtc::native::create_random_uuid;
+use livekit::{Room, RoomEvent, RoomOptions};
+use livekit_api::access_token::{AccessToken, VideoGrants};
+use std::{env, time::Duration};
+use tokio::sync::mpsc::UnboundedReceiver;
+
+struct TestEnvironment {
+    api_key: String,
+    api_secret: String,
+    server_url: String,
+}
+
+impl TestEnvironment {
+    /// Reads API key, secret, and server URL from the environment, using the
+    /// development defaults for values that are not present.
+    pub fn from_env_or_defaults() -> Self {
+        Self {
+            api_key: env::var("LIVEKIT_API_KEY").unwrap_or("devkey".into()),
+            api_secret: env::var("LIVEKIT_API_SECRET").unwrap_or("secret".into()),
+            server_url: env::var("LIVEKIT_URL").unwrap_or("http://localhost:7880".into()),
+        }
+    }
+}
+
+/// Creates the specified number of connections to a shared room for testing.
+pub async fn test_rooms(count: usize) -> Result<Vec<(Room, UnboundedReceiver<RoomEvent>)>> {
+    let test_env = TestEnvironment::from_env_or_defaults();
+    let room_name = format!("test_room_{}", create_random_uuid());
+
+    let tokens = (0..count)
+        .into_iter()
+        .map(|id| -> Result<String> {
+            let grants =
+                VideoGrants { room_join: true, room: room_name.clone(), ..Default::default() };
+            Ok(AccessToken::with_api_key(&test_env.api_key, &test_env.api_secret)
+                .with_ttl(Duration::from_secs(30 * 60)) // 30 minutes
+                .with_grants(grants)
+                .with_identity(&format!("p{}", id))
+                .to_jwt()
+                .context("Failed to generate JWT")?)
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let rooms = try_join_all(tokens.into_iter().map(|token| {
+        let server_url = test_env.server_url.clone();
+        async move {
+            let options = RoomOptions::default();
+            Room::connect(&server_url, &token, options).await.context("Failed to connect to room")
+        }
+    }))
+    .await?;
+
+    Ok(rooms)
+}

--- a/livekit/tests/data_channel_test.rs
+++ b/livekit/tests/data_channel_test.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)]
 use crate::common::test_rooms;
 use anyhow::{anyhow, Result};
 use livekit::{DataPacket, RoomEvent, SimulateScenario};
@@ -6,6 +7,15 @@ use tokio::{sync::oneshot, time};
 
 mod common;
 
+// These tests depend on a LiveKit server, and thus are not enabled by default;
+// to run them, start a local LiveKit server in development mode, and enable the
+// E2E test feature:
+//
+// > livekit-server --dev
+// > cargo test --features __lk-e2e-test
+//
+
+#[cfg(feature = "__lk-e2e-test")]
 #[tokio::test]
 async fn test_reliable_retry() -> Result<()> {
     const ITERATIONS: usize = 128;

--- a/livekit/tests/data_channel_test.rs
+++ b/livekit/tests/data_channel_test.rs
@@ -77,7 +77,7 @@ async fn test_reliable_retry() -> Result<()> {
         time::sleep(Duration::from_millis(10)).await;
     }
 
-    match time::timeout(Duration::from_secs(30), expectation).await {
+    match time::timeout(Duration::from_secs(15), expectation).await {
         Ok(Ok(())) => Ok(()),
         Ok(Err(_)) => Err(anyhow!("Not all packets were received")),
         Err(_) => Err(anyhow!("Timed out waiting for packets")),

--- a/livekit/tests/data_channel_test.rs
+++ b/livekit/tests/data_channel_test.rs
@@ -1,0 +1,75 @@
+use crate::common::test_rooms;
+use anyhow::{anyhow, Result};
+use livekit::{DataPacket, RoomEvent, SimulateScenario};
+use std::{sync::Arc, time::Duration};
+use tokio::{sync::oneshot, time};
+
+mod common;
+
+#[tokio::test]
+async fn test_reliable_retry() -> Result<()> {
+    const ITERATIONS: usize = 128;
+    const PAYLOAD_SIZE: usize = 4096;
+
+    // Set up test rooms
+    let mut rooms = test_rooms(2).await?;
+    let (sending_room, _) = rooms.pop().unwrap();
+    let (receiving_room, mut receiving_event_rx) = rooms.pop().unwrap();
+
+    let sending_room = Arc::new(sending_room);
+    let receiving_room = Arc::new(receiving_room);
+
+    let receiving_identity = receiving_room.local_participant().identity();
+    let (fulfill, expectation) = oneshot::channel();
+
+    tokio::spawn({
+        let sending_room = sending_room.clone();
+        async move {
+            time::sleep(Duration::from_millis(200)).await;
+            _ = sending_room.simulate_scenario(SimulateScenario::SignalReconnect).await;
+            println!("Reconnecting sending room");
+        }
+    });
+    tokio::spawn({
+        let receiving_room = receiving_room.clone();
+        async move {
+            time::sleep(Duration::from_millis(400)).await;
+            _ = receiving_room.simulate_scenario(SimulateScenario::SignalReconnect).await;
+            println!("Reconnecting receiving room");
+        }
+    });
+
+    tokio::spawn({
+        let fulfill = fulfill;
+        async move {
+            let mut packets_received = 0;
+            while let Some(event) = receiving_event_rx.recv().await {
+                if let RoomEvent::DataReceived { payload, .. } = event {
+                    assert_eq!(payload.len(), PAYLOAD_SIZE);
+                    packets_received += 1;
+                    if packets_received == ITERATIONS {
+                        fulfill.send(()).ok();
+                        break;
+                    }
+                }
+            }
+        }
+    });
+
+    for _ in 0..ITERATIONS {
+        let packet = DataPacket {
+            reliable: true,
+            payload: [0xFA; PAYLOAD_SIZE].to_vec(),
+            destination_identities: vec![receiving_identity.clone()],
+            ..Default::default()
+        };
+        sending_room.local_participant().publish_data(packet).await?;
+        time::sleep(Duration::from_millis(10)).await;
+    }
+
+    match time::timeout(Duration::from_secs(30), expectation).await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(_)) => Err(anyhow!("Not all packets were received")),
+        Err(_) => Err(anyhow!("Timed out waiting for packets")),
+    }
+}


### PR DESCRIPTION
**Summary of changes**:
- Implement data channel reliability improvements from other SDKs:
  - livekit/client-sdk-js/pull/1546
  - livekit/client-sdk-swift/pull/737
- Refactor handling of incoming data packets
  - Take value enum out of packet to avoid large clones 
  - Prefer packet level participant info fields over deprecated user packet fields
- Retain local participant info in session layer
  - Ensure all outgoing data packets have their participant SID and identity fields set
- End-to-end testing: introduce testing with a LiveKit server
  - Utilities for reading configuration from environment, creating multiple room connections
  - Test case to evaluate reliable data channel performance
  - Enable in CI (macOS and Linux only)