### PR TITLE
fix: hardware rendering

### DIFF
--- a/webrtc-sys/build.rs
+++ b/webrtc-sys/build.rs
@@ -166,7 +166,7 @@ fn main() {
                         .file("src/vaapi/implib/libva.so.tramp.S");
 
                     builder
-                        .flag("-I/usr/local/cuda-12.3/targets/x86_64-linux/include")
+                        .flag("-I/usr/local/cuda/include")
                         .flag("-Isrc/nvidia/NvCodec/include")
                         .flag("-Isrc/nvidia/NvCodec/NvCodec")
                         .file("src/nvidia/NvCodec/NvCodec/NvDecoder/NvDecoder.cpp")

--- a/webrtc-sys/build.rs
+++ b/webrtc-sys/build.rs
@@ -166,7 +166,7 @@ fn main() {
                         .file("src/vaapi/implib/libva.so.tramp.S");
 
                     builder
-                        .flag("-I/usr/local/cuda-12.6/targets/x86_64-linux/include")
+                        .flag("-I/usr/local/cuda-12.3/targets/x86_64-linux/include")
                         .flag("-Isrc/nvidia/NvCodec/include")
                         .flag("-Isrc/nvidia/NvCodec/NvCodec")
                         .file("src/nvidia/NvCodec/NvCodec/NvDecoder/NvDecoder.cpp")

--- a/webrtc-sys/build.rs
+++ b/webrtc-sys/build.rs
@@ -166,7 +166,7 @@ fn main() {
                         .file("src/vaapi/implib/libva.so.tramp.S");
 
                     builder
-                        .flag("-I/usr/local/cuda-12.3/targets/x86_64-linux/include")
+                        .flag("-I/usr/local/cuda-12.6/targets/x86_64-linux/include")
                         .flag("-Isrc/nvidia/NvCodec/include")
                         .flag("-Isrc/nvidia/NvCodec/NvCodec")
                         .file("src/nvidia/NvCodec/NvCodec/NvDecoder/NvDecoder.cpp")

--- a/webrtc-sys/src/nvidia/h264_encoder_impl.cpp
+++ b/webrtc-sys/src/nvidia/h264_encoder_impl.cpp
@@ -325,7 +325,7 @@ int32_t NvidiaH264EncoderImpl::Encode(
           cu_context_, (void*)frame_buffer->DataY(), frame_buffer->StrideY(),
           reinterpret_cast<CUdeviceptr>(nv_enc_input_frame->inputPtr),
           nv_enc_input_frame->pitch, input_frame.width(), input_frame.height(),
-          CU_MEMORYTYPE_DEVICE, nv_enc_input_frame->bufferFormat,
+          CU_MEMORYTYPE_HOST, nv_enc_input_frame->bufferFormat,
           nv_enc_input_frame->chromaOffsets, nv_enc_input_frame->numChromaPlanes);
     }
 

--- a/webrtc-sys/src/nvidia/h264_encoder_impl.cpp
+++ b/webrtc-sys/src/nvidia/h264_encoder_impl.cpp
@@ -322,7 +322,7 @@ int32_t NvidiaH264EncoderImpl::Encode(
 
     if (cu_memory_type_ == CU_MEMORYTYPE_DEVICE) {
       NvEncoderCuda::CopyToDeviceFrame(
-          cu_context_, (void*)frame_buffer->DataY(), 0,
+          cu_context_, (void*)frame_buffer->DataY(), frame_buffer->StrideY(),
           reinterpret_cast<CUdeviceptr>(nv_enc_input_frame->inputPtr),
           nv_enc_input_frame->pitch, input_frame.width(), input_frame.height(),
           CU_MEMORYTYPE_DEVICE, nv_enc_input_frame->bufferFormat,


### PR DESCRIPTION
Resolves CUDA_ERROR_INVALID_VALUE error caused by attempting to access the video buffer from GPU instead of CPU. Previous SDK hardware rendering attempts on GPU resulted in silent failures and blank image output. This PR corrects the buffer access issue.