### PR TITLE
Fix build failure on macOS for developers who have multiple clang installations 

### DIFF
--- a/webrtc-sys/build.rs
+++ b/webrtc-sys/build.rs
@@ -318,7 +318,7 @@ fn configure_darwin_sysroot(builder: &mut cc::Build) {
     let sysroot = String::from_utf8_lossy(&sysroot.stdout);
     let sysroot = sysroot.trim();
 
-    let search_dirs = Command::new("clang").arg("--print-search-dirs").output().unwrap();
+    let search_dirs = Command::new("cc").arg("--print-search-dirs").output().unwrap();
 
     let search_dirs = String::from_utf8_lossy(&search_dirs.stdout);
     for line in search_dirs.lines() {


### PR DESCRIPTION
## Problem

The webrtc-sys build script was using `Command::new("clang")` to discover compiler library paths. On a system with Homebrew's llvm package installed, this command could resolve to `/usr/local/bin/clang` instead of the required Xcode toolchain compiler.

This caused the script to pass incorrect library search paths to the linker, resulting in errors like:
```
ld: warning: search path '/usr/local/lib/clang/22/lib/darwin' not found
ld: library 'clang_rt.osx' not found
```

## Solution

The fix is to change `Command::new("clang")` to `Command::new("cc")` within the `configure_darwin_sysroot` function in build.rs.

On macOS, `cc` is the system's default compiler alias and is guaranteed to respect the toolchain set by `xcode-select`. This ensures that even if other versions of clang are in the PATH, the build script will always get the correct search paths from the active Xcode toolchain.

This makes the build process more robust and resilient to variations in the user's local environment.

