### PR TITLE
Allow passing test room options

### DIFF
--- a/livekit/tests/common/e2e.rs
+++ b/livekit/tests/common/e2e.rs
@@ -26,27 +26,35 @@ impl TestEnvironment {
 
 /// Creates the specified number of connections to a shared room for testing.
 pub async fn test_rooms(count: usize) -> Result<Vec<(Room, UnboundedReceiver<RoomEvent>)>> {
+    test_rooms_with_options((0..count).map(|_| RoomOptions::default())).await
+}
+
+/// Creates multiple connections to a shared room for testing, one for each configuration.
+pub async fn test_rooms_with_options(
+    options: impl IntoIterator<Item = RoomOptions>,
+) -> Result<Vec<(Room, UnboundedReceiver<RoomEvent>)>> {
     let test_env = TestEnvironment::from_env_or_defaults();
     let room_name = format!("test_room_{}", create_random_uuid());
 
-    let tokens = (0..count)
+    let tokens = options
         .into_iter()
-        .map(|id| -> Result<String> {
+        .enumerate()
+        .map(|(id, options)| -> Result<(String, RoomOptions)> {
             let grants =
                 VideoGrants { room_join: true, room: room_name.clone(), ..Default::default() };
-            Ok(AccessToken::with_api_key(&test_env.api_key, &test_env.api_secret)
+            let token = AccessToken::with_api_key(&test_env.api_key, &test_env.api_secret)
                 .with_ttl(Duration::from_secs(30 * 60)) // 30 minutes
                 .with_grants(grants)
                 .with_identity(&format!("p{}", id))
                 .to_jwt()
-                .context("Failed to generate JWT")?)
+                .context("Failed to generate JWT")?;
+            Ok((token, options))
         })
         .collect::<Result<Vec<_>>>()?;
 
-    let rooms = try_join_all(tokens.into_iter().map(|token| {
+    let rooms = try_join_all(tokens.into_iter().map(|(token, options)| {
         let server_url = test_env.server_url.clone();
         async move {
-            let options = RoomOptions::default();
             Room::connect(&server_url, &token, options).await.context("Failed to connect to room")
         }
     }))


### PR DESCRIPTION
Allow creating test rooms with options:
```rust
let mut rooms = test_rooms_with_options([
    RoomOptions::default(),  // room 0
    RoomOptions::default(),  // room 1
    // ....
    RoomOptions::default(),  // room n
]).await?;
```