### PR TITLE
Update Rust toolchain installation method

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -25,6 +25,7 @@ on:
     paths:
       - livekit/**
       - libwebrtc/**
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -80,10 +80,9 @@ jobs:
         run:  |
           sudo apt install -y libva-dev libdrm-dev libnvidia-compute-570 libnvidia-decode-570 nvidia-cuda-dev -y
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: ${{ matrix.target }}
+      - name: Install Rust toolchain.
+        run: |
+          rustup add ${{ matrix.target }}
 
       - name: Build (Cargo)
         if: ${{ !contains(matrix.target, 'android') }}

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Install Rust toolchain.
         run: |
-          rustup add ${{ matrix.target }}
+          rustup target add ${{ matrix.target }}
 
       - name: Build (Cargo)
         if: ${{ !contains(matrix.target, 'android') }}


### PR DESCRIPTION
Use `rustup target add` to replace `actions-rs/toolchain@v1` because the repo of this runner has been archived

https://github.com/actions-rs/toolchain

Aand added `workflow_dispatch:` to allow the Builds CI to be triggered manually
