### PR TITLE
Fix empty audio frames after resample

### DIFF
--- a/webrtc-sys/src/audio_track.cpp
+++ b/webrtc-sys/src/audio_track.cpp
@@ -101,7 +101,7 @@ void NativeAudioSink::OnData(const void* audio_data,
   const int16_t* data = static_cast<const int16_t*>(audio_data);
 
   if (sample_rate_ != sample_rate || num_channels_ != number_of_channels) {
-    webrtc::InterleavedView<const int16_t> source(static_cast<const int16_t*>(data),
+    webrtc::InterleavedView<const int16_t> source(data,
                                          number_of_frames,
                                          number_of_channels);
     // resample/remix before capturing

--- a/webrtc-sys/src/audio_track.cpp
+++ b/webrtc-sys/src/audio_track.cpp
@@ -22,6 +22,7 @@
 #include <memory>
 
 #include "api/audio_options.h"
+#include "api/audio/audio_frame.h"
 #include "api/media_stream_interface.h"
 #include "api/task_queue/task_queue_base.h"
 #include "audio/remix_resample.h"
@@ -87,6 +88,7 @@ NativeAudioSink::NativeAudioSink(rust::Box<AudioSinkWrapper> observer,
       num_channels_(num_channels) {
   frame_.sample_rate_hz_ = sample_rate;
   frame_.num_channels_ = num_channels;
+  frame_.samples_per_channel_ = webrtc::SampleRateToDefaultChannelSize(sample_rate);
 }
 
 void NativeAudioSink::OnData(const void* audio_data,


### PR DESCRIPTION
A change in the resampler API introduced in _libwebrtc_ m137 caused the output frame's `samples_per_channel_`  property to remain uninitialized. As a result, the length of the output slice was always calculated as zero, resulting in `NativeAudioStream` yielding audio frames without any sample data.

Note: This issue only occurs when resampling is required (i.e., when the sample rate or number of channels used to create the `NativeAudioStream` does not match the source).