### PR TITLE
Expose desktop capturer

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -736,6 +736,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-expr"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2c5f3bf25ec225351aa1c8e230d04d880d3bd89dea133537dafad4ae291e5c"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,6 +1798,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "gio-sys"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171ed2f6dd927abbe108cfd9eebff2052c335013f5879d55bab0dc1dee19b706"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1796,6 +1819,50 @@ dependencies = [
  "khronos_api",
  "log",
  "xml-rs",
+]
+
+[[package]]
+name = "glib"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1f2cbc4577536c849335878552f42086bfd25a8dcd6f54a18655cf818b20c8f"
+dependencies = [
+ "bitflags 2.9.4",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "memchr",
+ "smallvec",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55eda916eecdae426d78d274a17b48137acdca6fba89621bd3705f2835bc719f"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d09d3d0fddf7239521674e57b0465dfbd844632fec54f059f7f56112e3f927e1"
+dependencies = [
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -1835,6 +1902,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
 dependencies = [
  "gl_generator",
+]
+
+[[package]]
+name = "gobject-sys"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "538e41d8776173ec107e7b0f2aceced60abc368d7e1d81c1f0e2ecd35f59080d"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -2507,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "libwebrtc"
-version = "0.3.14"
+version = "0.3.16"
 dependencies = [
  "cxx",
  "jni",
@@ -2562,7 +2640,7 @@ checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
 name = "livekit"
-version = "0.7.18"
+version = "0.7.20"
 dependencies = [
  "bmrng",
  "bytes",
@@ -2586,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "livekit-api"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "async-tungstenite",
  "base64 0.21.7",
@@ -2615,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "livekit-protocol"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "futures-util",
  "livekit-runtime",
@@ -3634,7 +3712,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.5",
 ]
 
 [[package]]
@@ -4160,6 +4238,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
+name = "screensharing"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "env_logger",
+ "glib",
+ "livekit",
+ "livekit-api",
+ "log",
+ "tokio",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4252,6 +4343,15 @@ dependencies = [
  "ryu",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4526,6 +4626,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-deps"
+version = "7.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4be53aa0cba896d2dc615bd42bbc130acdcffa239e0a2d965ea5b3b2a86ffdb"
+dependencies = [
+ "cfg-expr",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+
+[[package]]
 name = "tempfile"
 version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4790,6 +4909,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4800,12 +4940,25 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.11.3",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2ad0b7ae9cfeef5605163839cb9221f453399f15cfb5c10be9885fcf56611f9"
 dependencies = [
  "indexmap 2.11.3",
- "toml_datetime",
+ "toml_datetime 0.7.1",
  "toml_parser",
  "winnow",
 ]
@@ -5078,6 +5231,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version-compare"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
 name = "version_check"
@@ -5362,7 +5521,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webrtc-sys"
-version = "0.3.11"
+version = "0.3.13"
 dependencies = [
  "cc",
  "cxx",
@@ -5374,7 +5533,7 @@ dependencies = [
 
 [[package]]
 name = "webrtc-sys-build"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "fs2",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,4 +8,5 @@ members = [
     "webhooks",
     "api",
     "rpc",
+    "screensharing",
 ]

--- a/examples/screensharing/Cargo.toml
+++ b/examples/screensharing/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "screensharing"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+env_logger = "0.10"
+livekit = { path = "../../livekit", features = ["native-tls"]}
+livekit-api = { path = "../../livekit-api"}
+log = "0.4"
+clap = { version = "4.0", features = ["derive"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+glib = "0.21.1"

--- a/examples/screensharing/src/main.rs
+++ b/examples/screensharing/src/main.rs
@@ -1,0 +1,166 @@
+use clap::Parser;
+use livekit::options::{TrackPublishOptions, VideoCodec};
+use livekit::prelude::*;
+use livekit::track::{LocalTrack, LocalVideoTrack, TrackSource};
+use livekit::webrtc::desktop_capturer::{
+    CaptureResult, DesktopCapturer, DesktopCapturerOptions, DesktopFrame,
+};
+use livekit::webrtc::native::yuv_helper;
+use livekit::webrtc::prelude::{
+    I420Buffer, RtcVideoSource, VideoBuffer, VideoFrame, VideoResolution, VideoRotation,
+};
+use livekit::webrtc::video_source::native::NativeVideoSource;
+use livekit_api::access_token;
+use std::env;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Capture the mouse cursor
+    #[arg(long)]
+    capture_cursor: bool,
+
+    /// Capture a specific window (requires window ID)
+    #[arg(long)]
+    capture_window: bool,
+
+    /// Use system screen picker (macOS only)
+    #[cfg(target_os = "macos")]
+    #[arg(long)]
+    use_system_picker: bool,
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let args = Args::parse();
+
+    #[cfg(target_os = "linux")]
+    {
+        /* This is needed for getting the system picker for screen sharing. */
+        use glib::MainLoop;
+        let main_loop = MainLoop::new(None, false);
+        let _handle = std::thread::spawn(move || {
+            main_loop.run();
+        });
+    }
+
+    let url = env::var("LIVEKIT_URL").expect("LIVEKIT_URL is not set");
+    let api_key = env::var("LIVEKIT_API_KEY").expect("LIVEKIT_API_KEY is not set");
+    let api_secret = env::var("LIVEKIT_API_SECRET").expect("LIVEKIT_API_SECRET is not set");
+
+    let token = access_token::AccessToken::with_api_key(&api_key, &api_secret)
+        .with_identity("rust-bot")
+        .with_name("Rust Bot")
+        .with_grants(access_token::VideoGrants {
+            room_join: true,
+            room: "dev_room".to_string(),
+            ..Default::default()
+        })
+        .to_jwt()
+        .unwrap();
+
+    let (room, _) = Room::connect(&url, &token, RoomOptions::default()).await.unwrap();
+    log::info!("Connected to room: {} - {}", room.name(), String::from(room.sid().await));
+
+    let stream_width = 1920;
+    let stream_height = 1080;
+    let buffer_source =
+        NativeVideoSource::new(VideoResolution { width: stream_width, height: stream_height });
+    let track = LocalVideoTrack::create_video_track(
+        "screen_share",
+        RtcVideoSource::Native(buffer_source.clone()),
+    );
+
+    room.local_participant()
+        .publish_track(
+            LocalTrack::Video(track),
+            TrackPublishOptions {
+                source: TrackSource::Screenshare,
+                video_codec: VideoCodec::VP9,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    let buffer_source_clone = buffer_source.clone();
+    let video_frame = Arc::new(Mutex::new(VideoFrame {
+        rotation: VideoRotation::VideoRotation0,
+        buffer: I420Buffer::new(stream_width, stream_height),
+        timestamp_us: 0,
+    }));
+    let capture_buffer = Arc::new(Mutex::new(I420Buffer::new(stream_width, stream_height)));
+    let callback = move |result: CaptureResult, frame: DesktopFrame| {
+        match result {
+            CaptureResult::ErrorTemporary => {
+                log::info!("Error temporary");
+                return;
+            }
+            CaptureResult::ErrorPermanent => {
+                log::info!("Error permanent");
+                return;
+            }
+            _ => {}
+        }
+        let video_frame = video_frame.clone();
+        let height = frame.height();
+        let width = frame.width();
+
+        {
+            let mut capture_buffer = capture_buffer.lock().unwrap();
+            let capture_buffer_width = capture_buffer.width() as i32;
+            let capture_buffer_height = capture_buffer.height() as i32;
+            if height != capture_buffer_height || width != capture_buffer_width {
+                *capture_buffer = I420Buffer::new(width as u32, height as u32);
+            }
+        }
+
+        let stride = frame.stride();
+        let data = frame.data();
+
+        let mut capture_buffer = capture_buffer.lock().unwrap();
+        let (s_y, s_u, s_v) = capture_buffer.strides();
+        let (y, u, v) = capture_buffer.data_mut();
+        yuv_helper::argb_to_i420(data, stride, y, s_y, u, s_u, v, s_v, width, height);
+
+        let scaled_buffer = capture_buffer.scale(stream_width as i32, stream_height as i32);
+        let (scaled_y, scaled_u, scaled_v) = scaled_buffer.data();
+
+        let mut framebuffer = video_frame.lock().unwrap();
+        let buffer = &mut framebuffer.buffer;
+        let (y, u, v) = buffer.data_mut();
+        y.copy_from_slice(scaled_y);
+        u.copy_from_slice(scaled_u);
+        v.copy_from_slice(scaled_v);
+
+        buffer_source_clone.capture_frame(&*framebuffer);
+    };
+    let mut options = DesktopCapturerOptions::new();
+    #[cfg(target_os = "macos")]
+    {
+        options.set_sck_system_picker(args.use_system_picker);
+    }
+    options.set_window_capturer(args.capture_window);
+    options.set_include_cursor(args.capture_cursor);
+    #[cfg(target_os = "linux")]
+    {
+        options.set_pipewire_capturer(true);
+    }
+
+    let mut capturer =
+        DesktopCapturer::new(callback, options).expect("Failed to create desktop capturer");
+    let sources = capturer.get_source_list();
+    log::info!("Found {} sources", sources.len());
+
+    let selected_source = sources.first().cloned();
+    capturer.start_capture(selected_source);
+
+    let now = tokio::time::Instant::now();
+    while now.elapsed() < tokio::time::Duration::from_secs(30) {
+        capturer.capture_frame();
+        tokio::time::sleep(tokio::time::Duration::from_millis(16)).await;
+    }
+}

--- a/libwebrtc/src/desktop_capturer.rs
+++ b/libwebrtc/src/desktop_capturer.rs
@@ -1,0 +1,239 @@
+// Copyright 2025 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::imp::desktop_capturer as imp_dc;
+
+/// Configuration options for creating a desktop capturer.
+///
+/// It contains a subset of libwertc's DesktopCaptureOptions.
+///
+/// By default, it captures the entire screen and does not include the cursor.
+///
+/// # Example
+/// ```no_run
+/// use libwebrtc::desktop_capturer::DesktopCapturerOptions;
+///
+/// let mut options = DesktopCapturerOptions::new();
+/// options.set_include_cursor(true);
+/// ```
+pub struct DesktopCapturerOptions {
+    pub(crate) sys_handle: imp_dc::DesktopCapturerOptions,
+}
+
+impl DesktopCapturerOptions {
+    /// Creates a new `DesktopCapturerOptions` with default values.
+    pub fn new() -> Self {
+        Self { sys_handle: imp_dc::DesktopCapturerOptions::new() }
+    }
+
+    /// Sets whether to include the cursor in captured frames.
+    pub fn set_include_cursor(&mut self, include: bool) {
+        self.sys_handle = self.sys_handle.with_cursor(include);
+    }
+
+    /// Sets whether to capture windows instead of the entire screen.
+    pub fn set_window_capturer(&mut self, window_capturer: bool) {
+        self.sys_handle = self.sys_handle.with_window_capturer(window_capturer);
+    }
+
+    /// Sets whether to allow the ScreenCaptureKit (SCK) capturer on macOS.
+    ///
+    /// This is enabled by default.
+    #[cfg(target_os = "macos")]
+    pub fn set_sck_capturer(&mut self, allow_sck_capturer: bool) {
+        self.sys_handle = self.sys_handle.with_sck_capturer(allow_sck_capturer);
+    }
+
+    /// Sets whether to allow the ScreenCaptureKit system picker on macOS.
+    ///
+    /// This is enabled by default.
+    ///
+    /// When disabled, for capturing displays the client should get the source id
+    /// via a different way as [`DesktopCapturer::get_source_list`] returns an empty vector.
+    #[cfg(target_os = "macos")]
+    pub fn set_sck_system_picker(&mut self, allow_sck_system_picker: bool) {
+        self.sys_handle = self.sys_handle.with_sck_system_picker(allow_sck_system_picker);
+    }
+
+    /// Sets whether to allow the Windows Graphics Capture (WGC) capturer on Windows.
+    ///
+    /// This is enabled by default.
+    #[cfg(target_os = "windows")]
+    pub fn set_wgc_capturer(&mut self, allow_wgc_capturer: bool) {
+        self.sys_handle = self.sys_handle.with_wgc_capturer(allow_wgc_capturer);
+    }
+
+    /// Sets whether to allow the DirectX capturer on Windows.
+    ///
+    /// This is enabled by default.
+    #[cfg(target_os = "windows")]
+    pub fn set_directx_capturer(&mut self, allow_directx_capturer: bool) {
+        self.sys_handle = self.sys_handle.with_directx_capturer(allow_directx_capturer);
+    }
+
+    /// Sets whether to allow the PipeWire capturer on Linux.
+    ///
+    /// It should be enabled when using Wayland.
+    #[cfg(target_os = "linux")]
+    pub fn set_pipewire_capturer(&mut self, allow_pipewire_capturer: bool) {
+        self.sys_handle = self.sys_handle.with_pipewire_capturer(allow_pipewire_capturer);
+    }
+}
+
+/// A desktop capturer for capturing screens or windows.
+pub struct DesktopCapturer {
+    handle: imp_dc::DesktopCapturer,
+}
+
+impl DesktopCapturer {
+    /// Creates a new `DesktopCapturer` with the specified callback and options.
+    ///
+    /// # Arguments
+    ///
+    /// * `callback` - A function that will be called for each captured frame. The callback
+    ///   receives a [`CaptureResult`] indicating success or error, and a [`DesktopFrame`]
+    ///   containing the captured image data.
+    /// * `options` - Configuration options for the capturer
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(DesktopCapturer)` if the capturer was created successfully,
+    /// or `None` if creation failed (e.g., due to platform limitations or permissions).
+    pub fn new<T>(callback: T, options: DesktopCapturerOptions) -> Option<Self>
+    where
+        T: Fn(CaptureResult, DesktopFrame) + Send + 'static,
+    {
+        let inner_callback = move |result: imp_dc::CaptureResult, frame: imp_dc::DesktopFrame| {
+            callback(capture_result_from_sys(result), DesktopFrame::new(frame));
+        };
+        let desktop_capturer = imp_dc::DesktopCapturer::new(inner_callback, options.sys_handle);
+        if desktop_capturer.is_none() {
+            return None;
+        }
+        Some(Self { handle: desktop_capturer.unwrap() })
+    }
+
+    /// Starts capturing from the specified source.
+    ///
+    /// # Arguments
+    ///
+    /// * `source` - The capture source to use. It should be None when the capturer
+    /// is configured to use the system picker (on platforms that support it).
+    ///
+    /// # Note
+    ///
+    /// After calling this method, you must call [`capture_frame`](Self::capture_frame)
+    /// to actually capture frames. This method only initializes the capture session.
+    pub fn start_capture(&mut self, source: Option<CaptureSource>) {
+        if let Some(source) = source {
+            self.handle.select_source(source.sys_handle.id());
+        }
+        self.handle.start();
+    }
+
+    /// Captures a single frame.
+    ///
+    /// You must call [`start_capture`](Self::start_capture) before calling this method.
+    pub fn capture_frame(&mut self) {
+        self.handle.capture_frame();
+    }
+
+    /// Retrieves a list of available capture sources.
+    ///
+    /// Returns a list of screens or windows that can be captured, depending
+    /// on whether the capturer was configured for window or screen capture.
+    ///
+    /// # Returns
+    ///
+    /// A vector of [`CaptureSource`] objects representing available capture sources.
+    pub fn get_source_list(&self) -> Vec<CaptureSource> {
+        let source_list = self.handle.get_source_list();
+        source_list.into_iter().map(|source| CaptureSource { sys_handle: source }).collect()
+    }
+}
+
+pub struct DesktopFrame {
+    pub(crate) sys_handle: imp_dc::DesktopFrame,
+}
+
+impl DesktopFrame {
+    pub fn new(sys_handle: imp_dc::DesktopFrame) -> Self {
+        Self { sys_handle }
+    }
+
+    pub fn width(&self) -> i32 {
+        self.sys_handle.width() as i32
+    }
+
+    pub fn height(&self) -> i32 {
+        self.sys_handle.height() as i32
+    }
+
+    pub fn stride(&self) -> u32 {
+        self.sys_handle.stride() as u32
+    }
+
+    pub fn left(&self) -> i32 {
+        self.sys_handle.left()
+    }
+
+    pub fn top(&self) -> i32 {
+        self.sys_handle.top()
+    }
+
+    pub fn data(&self) -> &[u8] {
+        &self.sys_handle.data()
+    }
+}
+
+#[derive(Clone)]
+pub struct CaptureSource {
+    pub(crate) sys_handle: imp_dc::CaptureSource,
+}
+
+impl CaptureSource {
+    pub fn id(&self) -> u64 {
+        self.sys_handle.id()
+    }
+    pub fn title(&self) -> String {
+        self.sys_handle.title()
+    }
+    pub fn display_id(&self) -> i64 {
+        self.sys_handle.display_id()
+    }
+}
+
+impl std::fmt::Display for CaptureSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CaptureSource")
+            .field("id", &self.id())
+            .field("title", &self.title())
+            .field("display_id", &self.display_id())
+            .finish()
+    }
+}
+
+pub enum CaptureResult {
+    Success,
+    ErrorTemporary,
+    ErrorPermanent,
+}
+
+fn capture_result_from_sys(result: imp_dc::CaptureResult) -> CaptureResult {
+    match result {
+        imp_dc::CaptureResult::Success => CaptureResult::Success,
+        imp_dc::CaptureResult::ErrorTemporary => CaptureResult::ErrorTemporary,
+        imp_dc::CaptureResult::ErrorPermanent => CaptureResult::ErrorPermanent,
+    }
+}

--- a/libwebrtc/src/lib.rs
+++ b/libwebrtc/src/lib.rs
@@ -45,6 +45,7 @@ pub mod audio_source;
 pub mod audio_stream;
 pub mod audio_track;
 pub mod data_channel;
+pub mod desktop_capturer;
 pub mod ice_candidate;
 pub mod media_stream;
 pub mod media_stream_track;

--- a/libwebrtc/src/native/desktop_capturer.rs
+++ b/libwebrtc/src/native/desktop_capturer.rs
@@ -1,0 +1,261 @@
+// Copyright 2025 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cxx::UniquePtr;
+use webrtc_sys::desktop_capturer::{self as sys_dc, ffi::new_desktop_capturer};
+
+#[derive(Copy, Clone, Debug)]
+pub struct DesktopCapturerOptions {
+    pub window_capturer: bool,
+    pub include_cursor: bool,
+    #[cfg(target_os = "macos")]
+    pub allow_sck_capturer: bool,
+    #[cfg(target_os = "macos")]
+    pub allow_sck_system_picker: bool,
+    #[cfg(target_os = "windows")]
+    pub allow_wgc_capturer: bool,
+    #[cfg(target_os = "windows")]
+    pub allow_directx_capturer: bool,
+    #[cfg(target_os = "linux")]
+    pub allow_pipewire_capturer: bool,
+}
+
+impl Default for DesktopCapturerOptions {
+    fn default() -> Self {
+        Self {
+            window_capturer: false,
+            include_cursor: false,
+            #[cfg(target_os = "macos")]
+            allow_sck_capturer: true,
+            #[cfg(target_os = "macos")]
+            allow_sck_system_picker: true,
+            #[cfg(target_os = "windows")]
+            allow_wgc_capturer: true,
+            #[cfg(target_os = "windows")]
+            allow_directx_capturer: true,
+            #[cfg(target_os = "linux")]
+            allow_pipewire_capturer: false,
+        }
+    }
+}
+
+impl DesktopCapturerOptions {
+    pub(crate) fn new() -> Self {
+        Self { window_capturer: false, include_cursor: false, ..Default::default() }
+    }
+
+    pub(crate) fn with_cursor(mut self, include: bool) -> Self {
+        self.include_cursor = include;
+        self
+    }
+
+    pub(crate) fn with_window_capturer(mut self, window_capturer: bool) -> Self {
+        self.window_capturer = window_capturer;
+        self
+    }
+
+    #[cfg(target_os = "macos")]
+    pub(crate) fn with_sck_capturer(mut self, allow_sck_capturer: bool) -> Self {
+        self.allow_sck_capturer = allow_sck_capturer;
+        self
+    }
+
+    #[cfg(target_os = "macos")]
+    pub(crate) fn with_sck_system_picker(mut self, allow_sck_system_picker: bool) -> Self {
+        self.allow_sck_system_picker = allow_sck_system_picker;
+        self
+    }
+
+    #[cfg(target_os = "windows")]
+    pub(crate) fn with_wgc_capturer(mut self, allow_wgc_capturer: bool) -> Self {
+        self.allow_wgc_capturer = allow_wgc_capturer;
+        self
+    }
+
+    #[cfg(target_os = "windows")]
+    pub(crate) fn with_directx_capturer(mut self, allow_directx_capturer: bool) -> Self {
+        self.allow_directx_capturer = allow_directx_capturer;
+        self
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(crate) fn with_pipewire_capturer(mut self, allow_pipewire_capturer: bool) -> Self {
+        self.allow_pipewire_capturer = allow_pipewire_capturer;
+        self
+    }
+
+    pub(crate) fn to_sys_handle(&self) -> sys_dc::ffi::DesktopCapturerOptions {
+        let mut sys_handle = sys_dc::ffi::DesktopCapturerOptions {
+            window_capturer: self.window_capturer,
+            include_cursor: self.include_cursor,
+            allow_sck_capturer: false,
+            allow_sck_system_picker: false,
+            allow_wgc_capturer: false,
+            allow_directx_capturer: false,
+            allow_pipewire_capturer: false,
+        };
+        #[cfg(target_os = "macos")]
+        {
+            sys_handle.allow_sck_capturer = self.allow_sck_capturer;
+            sys_handle.allow_sck_system_picker = self.allow_sck_system_picker;
+        }
+        #[cfg(target_os = "windows")]
+        {
+            sys_handle.allow_wgc_capturer = self.allow_wgc_capturer;
+            sys_handle.allow_directx_capturer = self.allow_directx_capturer;
+        }
+        #[cfg(target_os = "linux")]
+        {
+            sys_handle.allow_pipewire_capturer = self.allow_pipewire_capturer;
+        }
+        sys_handle
+    }
+}
+
+pub struct DesktopCapturer {
+    pub(crate) sys_handle: UniquePtr<sys_dc::ffi::DesktopCapturer>,
+}
+
+impl DesktopCapturer {
+    pub fn new<T>(callback: T, options: DesktopCapturerOptions) -> Option<Self>
+    where
+        T: Fn(CaptureResult, DesktopFrame) + Send + 'static,
+    {
+        let callback = DesktopCallback::new(callback);
+        let callback_wrapper = sys_dc::DesktopCapturerCallbackWrapper::new(Box::new(callback));
+        let sys_handle = new_desktop_capturer(Box::new(callback_wrapper), options.to_sys_handle());
+        if sys_handle.is_null() {
+            None
+        } else {
+            Some(Self { sys_handle })
+        }
+    }
+
+    pub fn capture_frame(&self) {
+        self.sys_handle.capture_frame();
+    }
+
+    pub fn start(&mut self) {
+        let pin_handle = self.sys_handle.pin_mut();
+        pin_handle.start();
+    }
+
+    pub fn select_source(&self, id: u64) -> bool {
+        self.sys_handle.select_source(id)
+    }
+
+    pub fn get_source_list(&self) -> Vec<CaptureSource> {
+        let mut sources = Vec::new();
+        let source_list = self.sys_handle.get_source_list();
+        for source in source_list.iter() {
+            sources.push(CaptureSource { sys_handle: source.clone() });
+        }
+        sources
+    }
+}
+
+pub struct DesktopFrame {
+    pub(crate) sys_handle: UniquePtr<sys_dc::ffi::DesktopFrame>,
+}
+
+impl DesktopFrame {
+    pub fn new(sys_handle: UniquePtr<sys_dc::ffi::DesktopFrame>) -> Self {
+        Self { sys_handle }
+    }
+
+    pub fn width(&self) -> i32 {
+        self.sys_handle.width()
+    }
+
+    pub fn height(&self) -> i32 {
+        self.sys_handle.height()
+    }
+
+    pub fn stride(&self) -> u32 {
+        self.sys_handle.stride() as u32
+    }
+
+    pub fn left(&self) -> i32 {
+        self.sys_handle.left()
+    }
+
+    pub fn top(&self) -> i32 {
+        self.sys_handle.top()
+    }
+
+    pub fn data(&self) -> &[u8] {
+        let data = self.sys_handle.data();
+        unsafe { std::slice::from_raw_parts(data, self.stride() as usize * self.height() as usize) }
+    }
+}
+
+pub struct DesktopCallback<T: Fn(CaptureResult, DesktopFrame) + Send> {
+    callback: T,
+}
+
+impl<T> DesktopCallback<T>
+where
+    T: Fn(CaptureResult, DesktopFrame) + Send,
+{
+    pub fn new(callback: T) -> Self {
+        Self { callback }
+    }
+}
+
+impl<T> sys_dc::DesktopCapturerCallback for DesktopCallback<T>
+where
+    T: Fn(CaptureResult, DesktopFrame) + Send,
+{
+    fn on_capture_result(
+        &self,
+        result: sys_dc::ffi::CaptureResult,
+        frame: UniquePtr<sys_dc::ffi::DesktopFrame>,
+    ) {
+        (self.callback)(capture_result_from_sys(result), DesktopFrame::new(frame));
+    }
+}
+
+#[derive(Clone)]
+pub struct CaptureSource {
+    pub(crate) sys_handle: sys_dc::ffi::Source,
+}
+
+impl CaptureSource {
+    pub fn id(&self) -> u64 {
+        self.sys_handle.id
+    }
+
+    pub fn title(&self) -> String {
+        self.sys_handle.title.clone()
+    }
+
+    pub fn display_id(&self) -> i64 {
+        self.sys_handle.display_id
+    }
+}
+
+pub(crate) enum CaptureResult {
+    Success,
+    ErrorTemporary,
+    ErrorPermanent,
+}
+
+fn capture_result_from_sys(result: sys_dc::ffi::CaptureResult) -> CaptureResult {
+    match result {
+        sys_dc::ffi::CaptureResult::Success => CaptureResult::Success,
+        sys_dc::ffi::CaptureResult::ErrorTemporary => CaptureResult::ErrorTemporary,
+        sys_dc::ffi::CaptureResult::ErrorPermanent => CaptureResult::ErrorPermanent,
+        _ => CaptureResult::ErrorPermanent,
+    }
+}

--- a/libwebrtc/src/native/mod.rs
+++ b/libwebrtc/src/native/mod.rs
@@ -20,6 +20,7 @@ pub mod audio_source;
 pub mod audio_stream;
 pub mod audio_track;
 pub mod data_channel;
+pub mod desktop_capturer;
 pub mod frame_cryptor;
 pub mod ice_candidate;
 pub mod media_stream;

--- a/libwebrtc/src/native/video_frame.rs
+++ b/libwebrtc/src/native/video_frame.rs
@@ -312,6 +312,14 @@ impl I420Buffer {
             )
         }
     }
+
+    pub fn scale(&mut self, scaled_width: i32, scaled_height: i32) -> vf::I420Buffer {
+        vf::I420Buffer {
+            handle: I420Buffer {
+                sys_handle: self.sys_handle.pin_mut().scale(scaled_width, scaled_height),
+            },
+        }
+    }
 }
 
 impl I420ABuffer {
@@ -408,6 +416,14 @@ impl I420ABuffer {
                     (self.stride_a() * self.height()) as usize,
                 )),
             )
+        }
+    }
+
+    pub fn scale(&mut self, scaled_width: i32, scaled_height: i32) -> vf::I420ABuffer {
+        vf::I420ABuffer {
+            handle: I420ABuffer {
+                sys_handle: self.sys_handle.pin_mut().scale(scaled_width, scaled_height),
+            },
         }
     }
 }
@@ -516,6 +532,14 @@ impl I422Buffer {
             )
         }
     }
+
+    pub fn scale(&mut self, scaled_width: i32, scaled_height: i32) -> vf::I422Buffer {
+        vf::I422Buffer {
+            handle: I422Buffer {
+                sys_handle: self.sys_handle.pin_mut().scale(scaled_width, scaled_height),
+            },
+        }
+    }
 }
 impl I444Buffer {
     pub fn new(
@@ -619,6 +643,14 @@ impl I444Buffer {
                 slice::from_raw_parts((*ptr).data_u(), (self.stride_u() * self.height()) as usize),
                 slice::from_raw_parts((*ptr).data_v(), (self.stride_v() * self.height()) as usize),
             )
+        }
+    }
+
+    pub fn scale(&mut self, scaled_width: i32, scaled_height: i32) -> vf::I444Buffer {
+        vf::I444Buffer {
+            handle: I444Buffer {
+                sys_handle: self.sys_handle.pin_mut().scale(scaled_width, scaled_height),
+            },
         }
     }
 }
@@ -738,6 +770,14 @@ impl I010Buffer {
             )
         }
     }
+
+    pub fn scale(&mut self, scaled_width: i32, scaled_height: i32) -> vf::I010Buffer {
+        vf::I010Buffer {
+            handle: I010Buffer {
+                sys_handle: self.sys_handle.pin_mut().scale(scaled_width, scaled_height),
+            },
+        }
+    }
 }
 
 impl NV12Buffer {
@@ -841,6 +881,14 @@ impl NV12Buffer {
                     (self.stride_uv() * chroma_height) as usize,
                 ),
             )
+        }
+    }
+
+    pub fn scale(&mut self, scaled_width: i32, scaled_height: i32) -> vf::NV12Buffer {
+        vf::NV12Buffer {
+            handle: NV12Buffer {
+                sys_handle: self.sys_handle.pin_mut().scale(scaled_width, scaled_height),
+            },
         }
     }
 }

--- a/libwebrtc/src/video_frame.rs
+++ b/libwebrtc/src/video_frame.rs
@@ -235,6 +235,10 @@ impl I420Buffer {
             )
         }
     }
+
+    pub fn scale(&mut self, scaled_width: i32, scaled_height: i32) -> I420Buffer {
+        self.handle.scale(scaled_width, scaled_height)
+    }
 }
 
 impl I420ABuffer {
@@ -273,6 +277,10 @@ impl I420ABuffer {
                 }),
             )
         }
+    }
+
+    pub fn scale(&mut self, scaled_width: i32, scaled_height: i32) -> I420ABuffer {
+        self.handle.scale(scaled_width, scaled_height)
     }
 }
 
@@ -317,6 +325,10 @@ impl I422Buffer {
             )
         }
     }
+
+    pub fn scale(&mut self, scaled_width: i32, scaled_height: i32) -> I422Buffer {
+        self.handle.scale(scaled_width, scaled_height)
+    }
 }
 
 impl I444Buffer {
@@ -359,6 +371,10 @@ impl I444Buffer {
                 std::slice::from_raw_parts_mut(data_v.as_ptr() as *mut u8, data_v.len()),
             )
         }
+    }
+
+    pub fn scale(&mut self, scaled_width: i32, scaled_height: i32) -> I444Buffer {
+        self.handle.scale(scaled_width, scaled_height)
     }
 }
 
@@ -403,6 +419,10 @@ impl I010Buffer {
             )
         }
     }
+
+    pub fn scale(&mut self, scaled_width: i32, scaled_height: i32) -> I010Buffer {
+        self.handle.scale(scaled_width, scaled_height)
+    }
 }
 
 impl NV12Buffer {
@@ -438,6 +458,10 @@ impl NV12Buffer {
                 std::slice::from_raw_parts_mut(data_uv.as_ptr() as *mut u8, data_uv.len()),
             )
         }
+    }
+
+    pub fn scale(&mut self, scaled_width: i32, scaled_height: i32) -> NV12Buffer {
+        self.handle.scale(scaled_width, scaled_height)
     }
 }
 

--- a/webrtc-sys/include/livekit/desktop_capturer.h
+++ b/webrtc-sys/include/livekit/desktop_capturer.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <memory>
+
+#include "modules/desktop_capture/desktop_capture_options.h"
+#include "modules/desktop_capture/desktop_capturer.h"
+#include "rust/cxx.h"
+
+namespace livekit {
+class DesktopFrame;
+class DesktopCapturer;
+class DesktopCapturerOptions;
+class Source;
+}  // namespace livekit
+
+#include "webrtc-sys/src/desktop_capturer.rs.h"
+
+namespace livekit {
+
+class DesktopCapturer : public webrtc::DesktopCapturer::Callback {
+ public:
+  explicit DesktopCapturer(rust::Box<DesktopCapturerCallbackWrapper> callback,
+                           std::unique_ptr<webrtc::DesktopCapturer> capturer);
+
+  void OnCaptureResult(webrtc::DesktopCapturer::Result result,
+                       std::unique_ptr<webrtc::DesktopFrame> frame) final;
+
+  rust::Vec<Source> get_source_list() const;
+  bool select_source(uint64_t id) const { return capturer->SelectSource(id); };
+  void start() { capturer->Start(this); };
+  void capture_frame() const { capturer->CaptureFrame(); };
+
+ private:
+  std::unique_ptr<webrtc::DesktopCapturer> capturer;
+  rust::Box<DesktopCapturerCallbackWrapper> callback;
+};
+
+class DesktopFrame {
+ public:
+  DesktopFrame(std::unique_ptr<webrtc::DesktopFrame> frame)
+      : frame(std::move(frame)) {};
+  int32_t width() const { return frame->size().width(); }
+
+  int32_t height() const { return frame->size().height(); }
+
+  int32_t left() const { return frame->rect().left(); }
+
+  int32_t top() const { return frame->rect().top(); }
+
+  int32_t stride() const { return frame->stride(); }
+
+  const uint8_t* data() const { return frame->data(); }
+
+ private:
+  std::unique_ptr<webrtc::DesktopFrame> frame;
+};
+
+std::unique_ptr<DesktopCapturer> new_desktop_capturer(
+    rust::Box<DesktopCapturerCallbackWrapper> callback,
+    DesktopCapturerOptions options);
+}  // namespace livekit

--- a/webrtc-sys/include/livekit/video_frame_buffer.h
+++ b/webrtc-sys/include/livekit/video_frame_buffer.h
@@ -151,6 +151,11 @@ class BiplanarYuv8Buffer : public BiplanarYuvBuffer {
 class I420Buffer : public PlanarYuv8Buffer {
  public:
   explicit I420Buffer(webrtc::scoped_refptr<webrtc::I420BufferInterface> buffer);
+
+  std::unique_ptr<I420Buffer> scale(int scaled_width, int scaled_height) const;
+
+ private:
+  webrtc::I420BufferInterface* buffer() const;
 };
 
 class I420ABuffer : public I420Buffer {
@@ -160,6 +165,8 @@ class I420ABuffer : public I420Buffer {
   unsigned int stride_a() const;
   const uint8_t* data_a() const;
 
+  std::unique_ptr<I420ABuffer> scale(int scaled_width, int scaled_height) const;
+
  private:
   webrtc::I420ABufferInterface* buffer() const;
 };
@@ -167,21 +174,41 @@ class I420ABuffer : public I420Buffer {
 class I422Buffer : public PlanarYuv8Buffer {
  public:
   explicit I422Buffer(webrtc::scoped_refptr<webrtc::I422BufferInterface> buffer);
+
+  std::unique_ptr<I422Buffer> scale(int scaled_width, int scaled_height) const;
+
+ private:
+  webrtc::I422BufferInterface* buffer() const;
 };
 
 class I444Buffer : public PlanarYuv8Buffer {
  public:
   explicit I444Buffer(webrtc::scoped_refptr<webrtc::I444BufferInterface> buffer);
+
+  std::unique_ptr<I444Buffer> scale(int scaled_width, int scaled_height) const;
+
+ private:
+  webrtc::I444BufferInterface* buffer() const;
 };
 
 class I010Buffer : public PlanarYuv16BBuffer {
  public:
   explicit I010Buffer(webrtc::scoped_refptr<webrtc::I010BufferInterface> buffer);
+
+  std::unique_ptr<I010Buffer> scale(int scaled_width, int scaled_height) const;
+
+ private:
+  webrtc::I010BufferInterface* buffer() const;
 };
 
 class NV12Buffer : public BiplanarYuv8Buffer {
  public:
   explicit NV12Buffer(webrtc::scoped_refptr<webrtc::NV12BufferInterface> buffer);
+
+  std::unique_ptr<NV12Buffer> scale(int scaled_width, int scaled_height) const;
+
+ private:
+  webrtc::NV12BufferInterface* buffer() const;
 };
 
 std::unique_ptr<I420Buffer> copy_i420_buffer(

--- a/webrtc-sys/libwebrtc/build_linux.sh
+++ b/webrtc-sys/libwebrtc/build_linux.sh
@@ -75,7 +75,7 @@ cd build
 
 git apply "$COMMAND_DIR/patches/force_gcc.patch" -v --ignore-space-change --ignore-whitespace --whitespace=nowarn
 
-cd ../.. 
+cd ../..
 
 
 mkdir -p "$ARTIFACTS_DIR/lib"
@@ -106,7 +106,7 @@ args="is_debug=$debug  \
   ffmpeg_branding=\"Chrome\" \
   rtc_use_h264=true \
   rtc_use_h265=true \
-  rtc_use_pipewire=false \
+  rtc_use_pipewire=true \
   symbol_level=0 \
   enable_iterator_debugging=false \
   use_rtti=true \

--- a/webrtc-sys/src/desktop_capturer.cpp
+++ b/webrtc-sys/src/desktop_capturer.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "livekit/desktop_capturer.h"
+
+using SourceList = webrtc::DesktopCapturer::SourceList;
+
+namespace livekit {
+
+std::unique_ptr<DesktopCapturer> new_desktop_capturer(
+    rust::Box<DesktopCapturerCallbackWrapper> callback,
+    DesktopCapturerOptions options) {
+  webrtc::DesktopCaptureOptions webrtc_options =
+      webrtc::DesktopCaptureOptions::CreateDefault();
+#ifdef __APPLE__
+  webrtc_options.set_allow_sck_capturer(options.allow_sck_capturer);
+  webrtc_options.set_allow_sck_system_picker(options.allow_sck_system_picker);
+#endif
+#ifdef _WIN64
+  if (options.window_capturer) {
+    webrtc_options.set_allow_wgc_screen_capturer(options.allow_wgc_capturer);
+  } else {
+    webrtc_options.set_allow_wgc_window_capturer(options.allow_wgc_capturer);
+    // https://github.com/webrtc-sdk/webrtc/blob/m137_release/modules/desktop_capture/desktop_capture_options.h#L133-L142
+    webrtc_options.set_enumerate_current_process_windows(false);
+  }
+  webrtc_options.set_allow_directx_capturer(options.allow_directx_capturer);
+#endif
+#ifdef __linux__
+  webrtc_options.set_allow_pipewire(options.allow_pipewire_capturer);
+#endif
+
+  webrtc_options.set_prefer_cursor_embedded(options.include_cursor);
+
+  std::unique_ptr<webrtc::DesktopCapturer> capturer = nullptr;
+  if (options.window_capturer) {
+    capturer = webrtc::DesktopCapturer::CreateWindowCapturer(webrtc_options);
+  } else {
+    capturer = webrtc::DesktopCapturer::CreateScreenCapturer(webrtc_options);
+  }
+  if (!capturer) {
+    return nullptr;
+  }
+  return std::make_unique<DesktopCapturer>(std::move(callback),
+                                           std::move(capturer));
+}
+
+DesktopCapturer::DesktopCapturer(
+    rust::Box<DesktopCapturerCallbackWrapper> callback,
+    std::unique_ptr<webrtc::DesktopCapturer> capturer)
+    : callback(std::move(callback)), capturer(std::move(capturer)) {}
+
+void DesktopCapturer::OnCaptureResult(
+    webrtc::DesktopCapturer::Result result,
+    std::unique_ptr<webrtc::DesktopFrame> frame) {
+  CaptureResult ret_result = CaptureResult::Success;
+  switch (result) {
+    case webrtc::DesktopCapturer::Result::SUCCESS:
+      ret_result = CaptureResult::Success;
+      break;
+    case webrtc::DesktopCapturer::Result::ERROR_PERMANENT:
+      ret_result = CaptureResult::ErrorPermanent;
+      break;
+    case webrtc::DesktopCapturer::Result::ERROR_TEMPORARY:
+      ret_result = CaptureResult::ErrorTemporary;
+      break;
+    default:
+      break;
+  }
+  callback->on_capture_result(ret_result,
+                              std::make_unique<DesktopFrame>(std::move(frame)));
+}
+
+rust::Vec<Source> DesktopCapturer::get_source_list() const {
+  SourceList list{};
+  bool res = capturer->GetSourceList(&list);
+  rust::Vec<Source> source_list{};
+  if (res) {
+    for (auto& source : list) {
+      source_list.push_back(Source{static_cast<uint64_t>(source.id),
+                                   source.title, source.display_id});
+    }
+  }
+  return source_list;
+}
+}  // namespace livekit

--- a/webrtc-sys/src/desktop_capturer.rs
+++ b/webrtc-sys/src/desktop_capturer.rs
@@ -1,0 +1,98 @@
+// Copyright 2025 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cxx::UniquePtr;
+use ffi::CaptureResult;
+
+use crate::{desktop_capturer::ffi::DesktopFrame, impl_thread_safety};
+
+#[cxx::bridge(namespace = "livekit")]
+pub mod ffi {
+    #[derive(Clone)]
+    struct Source {
+        id: u64,
+        title: String,
+        display_id: i64,
+    }
+
+    #[derive(Clone, Debug)]
+    struct DesktopCapturerOptions {
+        window_capturer: bool,
+        include_cursor: bool,
+        allow_sck_capturer: bool,
+        allow_sck_system_picker: bool,
+        allow_wgc_capturer: bool,
+        allow_directx_capturer: bool,
+        allow_pipewire_capturer: bool,
+    }
+
+    enum CaptureResult {
+        Success,
+        ErrorTemporary,
+        ErrorPermanent,
+    }
+
+    unsafe extern "C++" {
+        include!("livekit/desktop_capturer.h");
+
+        type DesktopCapturer;
+        type DesktopFrame;
+
+        fn new_desktop_capturer(
+            callback: Box<DesktopCapturerCallbackWrapper>,
+            options: DesktopCapturerOptions,
+        ) -> UniquePtr<DesktopCapturer>;
+        fn capture_frame(self: &DesktopCapturer);
+        fn get_source_list(self: &DesktopCapturer) -> Vec<Source>;
+        fn select_source(self: &DesktopCapturer, id: u64) -> bool;
+        fn start(self: Pin<&mut DesktopCapturer>);
+
+        fn width(self: &DesktopFrame) -> i32;
+        fn height(self: &DesktopFrame) -> i32;
+        fn stride(self: &DesktopFrame) -> i32;
+        fn left(self: &DesktopFrame) -> i32;
+        fn top(self: &DesktopFrame) -> i32;
+        fn data(self: &DesktopFrame) -> *const u8;
+    }
+
+    extern "Rust" {
+        type DesktopCapturerCallbackWrapper;
+
+        fn on_capture_result(
+            self: &DesktopCapturerCallbackWrapper,
+            result: CaptureResult,
+            frame: UniquePtr<DesktopFrame>,
+        );
+    }
+}
+
+impl_thread_safety!(ffi::DesktopCapturer, Send + Sync);
+
+pub trait DesktopCapturerCallback: Send {
+    fn on_capture_result(&self, result: CaptureResult, frame: UniquePtr<DesktopFrame>);
+}
+
+pub struct DesktopCapturerCallbackWrapper {
+    callback: Box<dyn DesktopCapturerCallback>,
+}
+
+impl DesktopCapturerCallbackWrapper {
+    pub fn new(callback: Box<dyn DesktopCapturerCallback>) -> Self {
+        Self { callback }
+    }
+
+    fn on_capture_result(&self, result: CaptureResult, frame: UniquePtr<DesktopFrame>) {
+        self.callback.on_capture_result(result, frame);
+    }
+}

--- a/webrtc-sys/src/lib.rs
+++ b/webrtc-sys/src/lib.rs
@@ -19,6 +19,7 @@ pub mod audio_resampler;
 pub mod audio_track;
 pub mod candidate;
 pub mod data_channel;
+pub mod desktop_capturer;
 pub mod frame_cryptor;
 pub mod helper;
 pub mod jsep;

--- a/webrtc-sys/src/video_frame_buffer.cpp
+++ b/webrtc-sys/src/video_frame_buffer.cpp
@@ -192,6 +192,19 @@ webrtc::BiplanarYuv8Buffer* BiplanarYuv8Buffer::buffer() const {
 I420Buffer::I420Buffer(webrtc::scoped_refptr<webrtc::I420BufferInterface> buffer)
     : PlanarYuv8Buffer(buffer) {}
 
+webrtc::I420BufferInterface* I420Buffer::buffer() const {
+  return static_cast<webrtc::I420BufferInterface*>(buffer_.get());
+}
+
+std::unique_ptr<I420Buffer> I420Buffer::scale(int scaled_width,
+                                              int scaled_height) const {
+  rtc::scoped_refptr<webrtc::VideoFrameBuffer> result =
+      buffer()->Scale(scaled_width, scaled_height);
+  return std::make_unique<I420Buffer>(
+      rtc::scoped_refptr<webrtc::I420BufferInterface>(
+          const_cast<webrtc::I420BufferInterface*>(result->GetI420())));
+}
+
 I420ABuffer::I420ABuffer(
     webrtc::scoped_refptr<webrtc::I420ABufferInterface> buffer)
     : I420Buffer(buffer) {}
@@ -208,17 +221,78 @@ webrtc::I420ABufferInterface* I420ABuffer::buffer() const {
   return static_cast<webrtc::I420ABufferInterface*>(buffer_.get());
 }
 
-I422Buffer::I422Buffer(webrtc::scoped_refptr<webrtc::I422BufferInterface> buffer)
+std::unique_ptr<I420ABuffer> I420ABuffer::scale(int scaled_width,
+                                                int scaled_height) const {
+  rtc::scoped_refptr<webrtc::VideoFrameBuffer> result =
+      buffer()->Scale(scaled_width, scaled_height);
+  return std::make_unique<I420ABuffer>(
+      rtc::scoped_refptr<webrtc::I420ABufferInterface>(
+          const_cast<webrtc::I420ABufferInterface*>(result->GetI420A())));
+}
+
+I422Buffer::I422Buffer(rtc::scoped_refptr<webrtc::I422BufferInterface> buffer)
     : PlanarYuv8Buffer(buffer) {}
 
-I444Buffer::I444Buffer(webrtc::scoped_refptr<webrtc::I444BufferInterface> buffer)
+webrtc::I422BufferInterface* I422Buffer::buffer() const {
+  return static_cast<webrtc::I422BufferInterface*>(buffer_.get());
+}
+
+std::unique_ptr<I422Buffer> I422Buffer::scale(int scaled_width,
+                                              int scaled_height) const {
+  rtc::scoped_refptr<webrtc::VideoFrameBuffer> result =
+      buffer()->Scale(scaled_width, scaled_height);
+  return std::make_unique<I422Buffer>(
+      rtc::scoped_refptr<webrtc::I422BufferInterface>(
+          const_cast<webrtc::I422BufferInterface*>(result->GetI422())));
+}
+
+I444Buffer::I444Buffer(rtc::scoped_refptr<webrtc::I444BufferInterface> buffer)
     : PlanarYuv8Buffer(buffer) {}
 
-I010Buffer::I010Buffer(webrtc::scoped_refptr<webrtc::I010BufferInterface> buffer)
+webrtc::I444BufferInterface* I444Buffer::buffer() const {
+  return static_cast<webrtc::I444BufferInterface*>(buffer_.get());
+}
+
+std::unique_ptr<I444Buffer> I444Buffer::scale(int scaled_width,
+                                              int scaled_height) const {
+  rtc::scoped_refptr<webrtc::VideoFrameBuffer> result =
+      buffer()->Scale(scaled_width, scaled_height);
+  return std::make_unique<I444Buffer>(
+      rtc::scoped_refptr<webrtc::I444BufferInterface>(
+          const_cast<webrtc::I444BufferInterface*>(result->GetI444())));
+}
+
+I010Buffer::I010Buffer(rtc::scoped_refptr<webrtc::I010BufferInterface> buffer)
     : PlanarYuv16BBuffer(buffer) {}
 
-NV12Buffer::NV12Buffer(webrtc::scoped_refptr<webrtc::NV12BufferInterface> buffer)
+webrtc::I010BufferInterface* I010Buffer::buffer() const {
+  return static_cast<webrtc::I010BufferInterface*>(buffer_.get());
+}
+
+std::unique_ptr<I010Buffer> I010Buffer::scale(int scaled_width,
+                                              int scaled_height) const {
+  rtc::scoped_refptr<webrtc::VideoFrameBuffer> result =
+      buffer()->Scale(scaled_width, scaled_height);
+  return std::make_unique<I010Buffer>(
+      rtc::scoped_refptr<webrtc::I010BufferInterface>(
+          const_cast<webrtc::I010BufferInterface*>(result->GetI010())));
+}
+
+NV12Buffer::NV12Buffer(rtc::scoped_refptr<webrtc::NV12BufferInterface> buffer)
     : BiplanarYuv8Buffer(buffer) {}
+
+webrtc::NV12BufferInterface* NV12Buffer::buffer() const {
+  return static_cast<webrtc::NV12BufferInterface*>(buffer_.get());
+}
+
+std::unique_ptr<NV12Buffer> NV12Buffer::scale(int scaled_width,
+                                              int scaled_height) const {
+  rtc::scoped_refptr<webrtc::VideoFrameBuffer> result =
+      buffer()->Scale(scaled_width, scaled_height);
+  return std::make_unique<NV12Buffer>(
+      rtc::scoped_refptr<webrtc::NV12BufferInterface>(
+          const_cast<webrtc::NV12BufferInterface*>(result->GetNV12())));
+}
 
 std::unique_ptr<I420Buffer> copy_i420_buffer(
     const std::unique_ptr<I420Buffer>& i420) {

--- a/webrtc-sys/src/video_frame_buffer.rs
+++ b/webrtc-sys/src/video_frame_buffer.rs
@@ -87,6 +87,22 @@ pub mod ffi {
         fn stride_a(self: &I420ABuffer) -> u32;
         fn data_a(self: &I420ABuffer) -> *const u8;
 
+        fn scale(self: &I420Buffer, scaled_width: i32, scaled_height: i32)
+            -> UniquePtr<I420Buffer>;
+        fn scale(
+            self: &I420ABuffer,
+            scaled_width: i32,
+            scaled_height: i32,
+        ) -> UniquePtr<I420ABuffer>;
+        fn scale(self: &I422Buffer, scaled_width: i32, scaled_height: i32)
+            -> UniquePtr<I422Buffer>;
+        fn scale(self: &I444Buffer, scaled_width: i32, scaled_height: i32)
+            -> UniquePtr<I444Buffer>;
+        fn scale(self: &I010Buffer, scaled_width: i32, scaled_height: i32)
+            -> UniquePtr<I010Buffer>;
+        fn scale(self: &NV12Buffer, scaled_width: i32, scaled_height: i32)
+            -> UniquePtr<NV12Buffer>;
+
         fn copy_i420_buffer(i420: &UniquePtr<I420Buffer>) -> UniquePtr<I420Buffer>;
         fn new_i420_buffer(
             width: i32,


### PR DESCRIPTION
Implements screen sharing by exposing libwebrtc's `DesktopCapturer`. 

A few notes:
* I have exposed only a subset of [DesktopCaptureOptions](https://source.chromium.org/chromium/chromium/src/+/main:third_party/webrtc/modules/desktop_capture/desktop_capture_options.h;l=36?q=desktopCaptureOptions&ss=chromium) which have been tested with [Hopp](https://github.com/gethopp/hopp).
* On macos the only way for the user to select a source when sharing a display is via the system picker as libwebrtc hasn't implemented getting the source list. In [our fork](https://github.com/gethopp/webrtc/commit/8948bdab0b2ceeac76c820cb99d50292559179f0#diff-f85e2fba4aa1cf9f0f9310861143acb8afb0f502a36ce2aea55951d64f0100ae) I have extended `GetSourceList` to actually get the available displays without the system picker. I could port my patch to your libwebrtc fork if you want. For selecting windows `GetSourceList` seems to work.
* AFAIK when using pipewire the only way to select a source is via the system picker.
* I have put the commit on top of another open PR I have, which enables buffer scaling. This makes sharing the buffer much easier, because we don't need to know in advance the source dims. If you have another way for scaling buffers I would be happy to use it instead of my patch.

Tested on:
* windows 11
* macOS Tahoe
* ubuntu 25.04 (wayland)

This is related to #92 and https://github.com/zed-industries/zed/issues/28754. 