### PR TITLE
fix: do not log 'signal client closed: "stream closed"' on disconnect

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -70,17 +70,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Cache apt packages
-        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm' }}
-        uses: actions/cache@v4
-        with:
-          path: |
-            /var/lib/apt/lists
-            /var/cache/apt/archives
-          key: ${{ matrix.os }}-apt-${{ hashFiles('**/builds.yml') }}
-          restore-keys: |
-            ${{ matrix.os }}-apt-
-
       - name: Install linux dependencies
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm'}}
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,15 +47,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Cache APT packages
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: actions/cache@v3
-        with:
-          path: /var/cache/apt/archives
-          key: ${{ runner.os }}-apt-${{ hashFiles('**/apt-packages.list') }}
-          restore-keys: |
-            ${{ runner.os }}-apt-
-
       - name: Install Rust toolchain
         run: |
           rustup update --no-self-update nightly


### PR DESCRIPTION
when server sends an explicit LeaveRequest, we would still end up logging

```
livekit::rtc_engine:453:livekit::rtc_engine - received session close: "signal client closed: \"stream closed\"" UnknownReason Resume
```

that's due to the signal client being closed after an explicit Leave is sent