### PR TITLE
Install protoc for Linux FFI build

### DIFF
--- a/.github/workflows/ffi-builds.yml
+++ b/.github/workflows/ffi-builds.yml
@@ -157,6 +157,7 @@ jobs:
             export PATH=/root/.cargo/bin:\$PATH; \
             yum install llvm llvm-libs -y; \
             yum install clang -y; \
+            yum install protobuf-compiler -y; \
             yum groupinstall 'Development Tools' -y; \
             clang --version; \
             yum install openssl-devel libX11-devel mesa-libGL-devel libXext-devel libva-devel libdrm-devel -y; \


### PR DESCRIPTION
Builder image must have protoc installed to build as of #734.