### PR TITLE
Install protoc in main build workflow

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -70,6 +70,12 @@ jobs:
         with:
           submodules: true
 
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          version: "25.2"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install linux dependencies
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm'}}
         run: |


### PR DESCRIPTION
This PR fixes the main build workflow by installing _protoc_. This was introduced by #734; the build workflow wasn’t triggered by that PR since it only touched the FFI crate, so the error wasn't detected. Since the build workflow builds the entire workspace, we should probably remove the path condition. However, I will limit the scope of this PR just to the fix.