### PR TITLE
clamp connection timeout and fixed the comment

### DIFF
--- a/livekit/src/room/participant/local_participant.rs
+++ b/livekit/src/room/participant/local_participant.rs
@@ -763,7 +763,8 @@ impl LocalParticipant {
         let (response_tx, response_rx) = oneshot::channel();
         let effective_timeout = std::cmp::max(
             data.response_timeout.saturating_sub(max_round_trip_latency),
-            min_effective_timeout);
+            min_effective_timeout,
+        );
 
         match self
             .publish_rpc_request(RpcRequest {


### PR DESCRIPTION
So the problem is that the performRpc is a public function, and we never sanity check if users provide values larger than the connection_timeout, which might cause unexpected behavior.

This PR fixes the comment and also clamp the connection response timeout if needed.