### PR TITLE
Remove participant check for data packets

### DIFF
--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -1429,11 +1429,6 @@ impl RoomSession {
                 .unwrap_or(None);
         }
 
-        if participant.is_none() && (participant_identity.is_some() || participant_sid.is_some()) {
-            // We received a data packet from a participant that is not in the participants list
-            return;
-        }
-
         // Update participant's data encryption status for regular data messages
         if let Some(ref p) = participant {
             use crate::e2ee::EncryptionType;


### PR DESCRIPTION
This check ends up dropping packets when `send_data` is called, and when a data packet is published on a project with livestream mode. The former fails because [this](https://github.com/livekit/rust-sdks/blob/4d3b5ac60dd3670f7b7c00a999205865445b8ea8/livekit/src/rtc_engine/rtc_session.rs#L1127) line returns Some(ParticipantIdentity("")) and not None, as user.participant_identity.try_into().ok() converts none to string. The latter fails because in livestream mode, participant list is not populated. Other SDKs (for eg. JS) are not doing this check. Removing this check should address both issues. 