### PR TITLE
Build livekit-api in CI

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -19,11 +19,13 @@ on:
     branches: ["main"]
     paths:
       - livekit/**
+      - livekit-api/**
       - libwebrtc/**
   pull_request:
     branches: ["main"]
     paths:
       - livekit/**
+      - livekit-api/**
       - libwebrtc/**
   workflow_dispatch:
 


### PR DESCRIPTION
Trigger the _build_ workflow when changes are made in _livekit-api_. This is necessary to properly evaluate changes made in this crate, such as in #754.