### PR TITLE
change the livekit-ffi to output a static lib for cpp SDK

### DIFF
--- a/livekit-ffi/Cargo.toml
+++ b/livekit-ffi/Cargo.toml
@@ -50,4 +50,4 @@ webrtc-sys-build = { workspace = true }
 livekit-api = { workspace = true }
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib", "staticlib", "cdylib"]


### PR DESCRIPTION
Otherwise the latest commit can't be linked by the client-sdk-cpp 