### PR TITLE
build_linux.sh: enable Pipewire (Wayland) and X11 desktop capture

### DIFF
--- a/webrtc-sys/libwebrtc/build_linux.sh
+++ b/webrtc-sys/libwebrtc/build_linux.sh
@@ -115,12 +115,12 @@ args="is_debug=$debug  \
   ffmpeg_branding=\"Chrome\" \
   rtc_use_h264=true \
   rtc_use_h265=true \
-  rtc_use_pipewire=false \
+  rtc_use_pipewire=true \
   symbol_level=0 \
   enable_iterator_debugging=false \
   use_rtti=true \
   is_clang=false \
-  rtc_use_x11=false"
+  rtc_use_x11=true"
 
 # generate ninja files
 gn gen "$OUTPUT_DIR" --root="src" --args="${args}"


### PR DESCRIPTION
I split this off from https://github.com/livekit/rust-sdks/pull/725 to make this prerequisite build change trivial to review. This will allow releasing a new version of the prebuilt libwebrtc that will work with the changes in #725.