### PR TITLE
Fix reconnection logic to not exhaust retries prematurely

### DIFF
--- a/livekit/src/rtc_engine/mod.rs
+++ b/livekit/src/rtc_engine/mod.rs
@@ -722,7 +722,7 @@ impl EngineInner {
             )
         };
 
-        for i in 0..RECONNECT_ATTEMPTS {
+        for i in 1..=RECONNECT_ATTEMPTS {
             let (is_closed, full_reconnect) = {
                 let running_handle = self.running_handle.read();
                 (running_handle.closed, running_handle.full_reconnect)
@@ -733,7 +733,7 @@ impl EngineInner {
             }
 
             if full_reconnect {
-                if i == 0 {
+                if i == 1 {
                     let (tx, rx) = oneshot::channel();
                     let _ = self.engine_tx.send(EngineEvent::Restarting(tx));
                     let _ = rx.await;
@@ -757,7 +757,7 @@ impl EngineInner {
                     return Ok(());
                 }
             } else {
-                if i == 0 {
+                if i == 1 {
                     let (tx, rx) = oneshot::channel();
                     let _ = self.engine_tx.send(EngineEvent::Resuming(tx));
                     let _ = rx.await;


### PR DESCRIPTION
This is a fix for: https://github.com/livekit/rust-sdks/issues/481, which was just closed again, likely due to inactivity.

**Problem:**
The reconnection logic doesn't properly honor the reconnection interval. The interval starts counting from engine creation, not from when reconnection begins. If the engine runs for over 50 seconds (RECONNECT_ATTEMPTS × RECONNECT_INTERVAL), the reconnection loop immediately executes all attempts without waiting, causing it to fail after a couple of seconds. That is because we are using Tokio's default interval, which utilizes [MissedTickBehavior::Burst](https://docs.rs/tokio/latest/tokio/time/enum.MissedTickBehavior.html#variant.Burst). Any accumulated ticks will fire immediately.
https://github.com/livekit/rust-sdks/blob/06997356c083b01da766c4c93e8c4e8354d871ce/livekit/src/rtc_engine/mod.rs#L52

**Solution**:
By changing the interval missed tick behavior to [MissedTickBehavior::Delay](https://docs.rs/tokio/latest/tokio/time/enum.MissedTickBehavior.html#variant.Delay), we can achieve the potentially initially desired await before making another reconnection attempt. That way, the reconnection window is significantly larger, thereby increasing the likelihood of reconnection.

**Reproduction steps**:
The problem is quite simple to reproduce. You need to run the `basic_room` example, wait a minute, disconnect the internet, and observe how fast the reconnection attempts are exhausted.