### PR TITLE
webrtc-sys: copy desktop_capture.ninja into C++ library archive

### DIFF
--- a/webrtc-sys/libwebrtc/build_android.sh
+++ b/webrtc-sys/libwebrtc/build_android.sh
@@ -125,6 +125,7 @@ python3 "./src/tools_webrtc/libs/generate_licenses.py" \
   --target :default "$OUTPUT_DIR" "$OUTPUT_DIR"
 
 cp "$OUTPUT_DIR/obj/webrtc.ninja" "$ARTIFACTS_DIR"
+cp "$OUTPUT_DIR/obj/modules/desktop_capture/desktop_capture.ninja" "$ARTIFACTS_DIR"
 cp "$OUTPUT_DIR/libjingle_peerconnection_so.so" "$ARTIFACTS_DIR/lib"
 cp "$OUTPUT_DIR/args.gn" "$ARTIFACTS_DIR"
 cp "$OUTPUT_DIR/LICENSE.md" "$ARTIFACTS_DIR"

--- a/webrtc-sys/libwebrtc/build_ios.sh
+++ b/webrtc-sys/libwebrtc/build_ios.sh
@@ -133,6 +133,7 @@ python3 "./src/tools_webrtc/libs/generate_licenses.py" \
   --target :webrtc "$OUTPUT_DIR" "$OUTPUT_DIR"
 
 cp "$OUTPUT_DIR/obj/webrtc.ninja" "$ARTIFACTS_DIR"
+cp "$OUTPUT_DIR/obj/modules/desktop_capture/desktop_capture.ninja" "$ARTIFACTS_DIR"
 cp "$OUTPUT_DIR/args.gn" "$ARTIFACTS_DIR"
 cp "$OUTPUT_DIR/LICENSE.md" "$ARTIFACTS_DIR"
 

--- a/webrtc-sys/libwebrtc/build_linux.sh
+++ b/webrtc-sys/libwebrtc/build_linux.sh
@@ -137,6 +137,7 @@ python3 "./src/tools_webrtc/libs/generate_licenses.py" \
   --target :default "$OUTPUT_DIR" "$OUTPUT_DIR"
 
 cp "$OUTPUT_DIR/obj/webrtc.ninja" "$ARTIFACTS_DIR"
+cp "$OUTPUT_DIR/obj/modules/desktop_capture/desktop_capture.ninja" "$ARTIFACTS_DIR"
 cp "$OUTPUT_DIR/args.gn" "$ARTIFACTS_DIR"
 cp "$OUTPUT_DIR/LICENSE.md" "$ARTIFACTS_DIR"
 

--- a/webrtc-sys/libwebrtc/build_macos.sh
+++ b/webrtc-sys/libwebrtc/build_macos.sh
@@ -125,6 +125,7 @@ python3 "./src/tools_webrtc/libs/generate_licenses.py" \
   --target :webrtc "$OUTPUT_DIR" "$OUTPUT_DIR"
 
 cp "$OUTPUT_DIR/obj/webrtc.ninja" "$ARTIFACTS_DIR"
+cp "$OUTPUT_DIR/obj/modules/desktop_capture/desktop_capture.ninja" "$ARTIFACTS_DIR"
 cp "$OUTPUT_DIR/args.gn" "$ARTIFACTS_DIR"
 cp "$OUTPUT_DIR/LICENSE.md" "$ARTIFACTS_DIR"
 

--- a/webrtc-sys/libwebrtc/build_windows.cmd
+++ b/webrtc-sys/libwebrtc/build_windows.cmd
@@ -79,6 +79,7 @@ call python3 "%cd%\src\tools_webrtc\libs\generate_licenses.py" ^
   --target :default %OUTPUT_DIR% %OUTPUT_DIR%
 
 copy "%OUTPUT_DIR%\obj\webrtc.ninja" "%ARTIFACTS_DIR%"
+copy "%OUTPUT_DIR%\obj\modules\desktop_capture\desktop_capture.ninja" "%ARTIFACTS_DIR%"
 copy "%OUTPUT_DIR%\args.gn" "%ARTIFACTS_DIR%"
 copy "%OUTPUT_DIR%\LICENSE.md" "%ARTIFACTS_DIR%"
 


### PR DESCRIPTION
Parsing this is required for building with desktop capture support.