### PR TITLE
move starting/stopping GLib event loop into libwebrtc crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3012,6 +3012,7 @@ version = "0.3.20"
 dependencies = [
  "cxx",
  "env_logger 0.10.2",
+ "glib",
  "jni",
  "js-sys",
  "lazy_static",
@@ -4935,7 +4936,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "env_logger 0.10.2",
- "glib",
  "livekit",
  "livekit-api",
  "log",

--- a/examples/screensharing/Cargo.toml
+++ b/examples/screensharing/Cargo.toml
@@ -11,6 +11,3 @@ livekit = { workspace = true, features = ["rustls-tls-native-roots"] }
 livekit-api = { workspace = true }
 log = "0.4"
 clap = { version = "4.0", features = ["derive"] }
-
-[target.'cfg(target_os = "linux")'.dependencies]
-glib = "0.21.1"

--- a/examples/screensharing/src/lib.rs
+++ b/examples/screensharing/src/lib.rs
@@ -68,16 +68,6 @@ mod test {
         env_logger::init();
         let args = Args::parse();
 
-        #[cfg(target_os = "linux")]
-        {
-            /* This is needed for getting the system picker for screen sharing. */
-            use glib::MainLoop;
-            let main_loop = MainLoop::new(None, false);
-            let _handle = std::thread::spawn(move || {
-                main_loop.run();
-            });
-        }
-
         let url = env::var("LIVEKIT_URL").expect("LIVEKIT_URL is not set");
         let api_key = env::var("LIVEKIT_API_KEY").expect("LIVEKIT_API_KEY is not set");
         let api_secret = env::var("LIVEKIT_API_SECRET").expect("LIVEKIT_API_SECRET is not set");

--- a/libwebrtc/Cargo.toml
+++ b/libwebrtc/Cargo.toml
@@ -7,12 +7,23 @@ license = "Apache-2.0"
 description = "Livekit safe bindings to libwebrtc"
 repository = "https://github.com/livekit/rust-sdks"
 
+[features]
+default = [ "glib-main-loop" ]
+# On Wayland, libwebrtc uses GDBus to communicate with the XDG Desktop Portal.
+# GDBus requires a GLib event loop to be running. If you already have a GLib
+# event loop running in your application, for example if you are using the
+# GTK or GStreamer Rust bindings, disable this feature.
+glib-main-loop = [ "dep:glib" ]
+
 [dependencies]
 livekit-protocol = { workspace = true }
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
+
+[target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
+glib = { version = "0.21.3", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.21"


### PR DESCRIPTION
instead of the screensharing example. This is an implementation detail that users of the library should not need to be concerned about. It is likely this library will be used in cross platform applications where the developers might not be very familiar with Linux and could overlook the need to run a GLib event loop if they have to handle it on their own.