### PR TITLE
fix(twirp): URL path construction causing bad_route errors

### DIFF
--- a/livekit-api/src/services/twirp_client.rs
+++ b/livekit-api/src/services/twirp_client.rs
@@ -103,9 +103,8 @@ impl TwirpClient {
     ) -> TwirpResult<R> {
         let mut url = url::Url::parse(&self.host)?;
 
-        if let Ok(mut segs) = url.path_segments_mut() {
-            segs.push(&format!("{}/{}.{}/{}", self.prefix, self.pkg, service, method));
-        }
+        // Fix: Use set_path instead of path_segments_mut().push() to avoid URL-encoding slashes
+        url.set_path(&format!("{}/{}.{}/{}", self.prefix, self.pkg, service, method));
 
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/protobuf"));
 


### PR DESCRIPTION
In `twirp_client.rs` line 107, `url.path_segments_mut().push()` was used to construct the Twirp endpoint URL. This method URL-encodes forward slashes as `%2F`, resulting in malformed URLs that LiveKit server couldn't parse.

Before:
**Expected**: `http://localhost:7890/twirp/livekit.RoomService/CreateRoom`  
**Actual**: `http://localhost:7890/%2Ftwirp%2Flivekit.RoomService%2FCreateRoom`

PR Solution:
Use `url.set_path()` instead, which correctly sets the entire path without encoding forward slashes.
