### PR TITLE
fix: ensure Room.creation_time is ms

### DIFF
--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -760,7 +760,7 @@ impl Room {
     pub fn max_participants(&self) -> u32 {
         self.inner.info.read().max_participants
     }
-
+    /// Returns the room creation time in milliseconds since Unix epoch.
     pub fn creation_time(&self) -> i64 {
         self.inner.info.read().creation_time
     }

--- a/livekit/tests/room_test.rs
+++ b/livekit/tests/room_test.rs
@@ -33,7 +33,7 @@ async fn test_connect() -> Result<()> {
     assert!(room.name().starts_with("test_room_"));
     assert!(room.remote_participants().is_empty());
 
-    let creation_time = Utc.timestamp_opt(room.creation_time(), 0).unwrap();
+    let creation_time = Utc.timestamp_millis_opt(room.creation_time()).unwrap();
     assert!(creation_time.signed_duration_since(Utc::now()).abs() <= TimeDelta::seconds(10));
 
     let local_participant = room.local_participant();


### PR DESCRIPTION
when we initially connect to the room, we are parsing the creation_time incorrectly. it gets updated later with the correct ms values, but will remain wrong immediately after connect.