### PR TITLE
chore: Rename namespace for ffi bridge code.

### DIFF
--- a/webrtc-sys/include/livekit/android.h
+++ b/webrtc-sys/include/livekit/android.h
@@ -23,15 +23,15 @@
 #include "api/video_codecs/video_decoder_factory.h"
 #include "api/video_codecs/video_encoder_factory.h"
 
-namespace livekit {
+namespace livekit_ffi {
 typedef JavaVM JavaVM;
-}  // namespace livekit
+}  // namespace livekit_ffi
 #include "webrtc-sys/src/android.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 void init_android(JavaVM* jvm);
 
 std::unique_ptr<webrtc::VideoEncoderFactory> CreateAndroidVideoEncoderFactory();
 std::unique_ptr<webrtc::VideoDecoderFactory> CreateAndroidVideoDecoderFactory();
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/apm.h
+++ b/webrtc-sys/include/livekit/apm.h
@@ -24,7 +24,7 @@
 #include "modules/audio_processing/aec3/echo_canceller3.h"
 #include "modules/audio_processing/audio_buffer.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 struct AudioProcessingConfig {
   bool echo_canceller_enabled;
@@ -72,4 +72,4 @@ std::unique_ptr<AudioProcessingModule> create_apm(
     bool high_pass_filter_enabled,
     bool noise_suppression_enabled);
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/audio_device.h
+++ b/webrtc-sys/include/livekit/audio_device.h
@@ -24,7 +24,7 @@
 #include "rtc_base/synchronization/mutex.h"
 #include "rtc_base/task_utils/repeating_task.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 class AudioDevice : public webrtc::AudioDeviceModule {
  public:
@@ -126,4 +126,4 @@ class AudioDevice : public webrtc::AudioDeviceModule {
   bool playing_{false};
   bool initialized_{false};
 };
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/audio_mixer.h
+++ b/webrtc-sys/include/livekit/audio_mixer.h
@@ -25,14 +25,14 @@
 #include "rtc_base/synchronization/mutex.h"
 #include "rust/cxx.h"
 
-namespace livekit {
+namespace livekit_ffi {
 class AudioMixer;
 class NativeAudioFrame;
-}  // namespace livekit
+}  // namespace livekit_ffi
 
 #include "webrtc-sys/src/audio_mixer.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 class NativeAudioFrame {
  public:
@@ -85,4 +85,4 @@ class AudioMixer {
 
 std::unique_ptr<AudioMixer> create_audio_mixer();
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/audio_resampler.h
+++ b/webrtc-sys/include/livekit/audio_resampler.h
@@ -24,7 +24,7 @@
 #include "livekit/webrtc.h"
 #include "rust/cxx.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 class AudioResampler {
  public:
@@ -44,4 +44,4 @@ class AudioResampler {
 
 std::unique_ptr<AudioResampler> create_audio_resampler();
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/audio_track.h
+++ b/webrtc-sys/include/livekit/audio_track.h
@@ -33,17 +33,17 @@
 #include "rtc_base/thread_annotations.h"
 #include "rust/cxx.h"
 
-namespace livekit {
+namespace livekit_ffi {
 class AudioTrack;
 class NativeAudioSink;
 class AudioTrackSource;
 class SourceContext;
 
-using CompleteCallback = void (*)(const livekit::SourceContext*);
-}  // namespace livekit
+using CompleteCallback = void (*)(const livekit_ffi::SourceContext*);
+}  // namespace livekit_ffi
 #include "webrtc-sys/src/audio_track.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 class AudioTrack : public MediaStreamTrack {
  private:
@@ -198,4 +198,4 @@ static std::shared_ptr<AudioTrackSource> _shared_audio_track_source() {
   return nullptr;  // Ignore
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/candidate.h
+++ b/webrtc-sys/include/livekit/candidate.h
@@ -20,13 +20,13 @@
 
 #include "api/candidate.h"
 
-namespace livekit {
+namespace livekit_ffi {
 class Candidate;
 }
 #include "webrtc-sys/src/candidate.rs.h"
 
 // cricket::Candidate
-namespace livekit {
+namespace livekit_ffi {
 
 class Candidate {
  public:
@@ -40,4 +40,4 @@ static std::shared_ptr<Candidate> _shared_candidate() {
   return nullptr;
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/data_channel.h
+++ b/webrtc-sys/include/livekit/data_channel.h
@@ -24,12 +24,12 @@
 #include "rtc_base/synchronization/mutex.h"
 #include "rust/cxx.h"
 
-namespace livekit {
+namespace livekit_ffi {
 class DataChannel;
-}  // namespace livekit
+}  // namespace livekit_ffi
 #include "webrtc-sys/src/data_channel.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 class NativeDataChannelObserver;
 
@@ -76,4 +76,4 @@ class NativeDataChannelObserver : public webrtc::DataChannelObserver {
   const DataChannel* dc_;
 };
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/desktop_capturer.h
+++ b/webrtc-sys/include/livekit/desktop_capturer.h
@@ -20,16 +20,16 @@
 #include "modules/desktop_capture/desktop_capturer.h"
 #include "rust/cxx.h"
 
-namespace livekit {
+namespace livekit_ffi {
 class DesktopFrame;
 class DesktopCapturer;
 class DesktopCapturerOptions;
 class Source;
-}  // namespace livekit
+}  // namespace livekit_ffi
 
 #include "webrtc-sys/src/desktop_capturer.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 class DesktopCapturer : public webrtc::DesktopCapturer::Callback {
  public:
@@ -69,4 +69,4 @@ class DesktopFrame {
 };
 
 std::unique_ptr<DesktopCapturer> new_desktop_capturer(DesktopCapturerOptions options);
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/frame_cryptor.h
+++ b/webrtc-sys/include/livekit/frame_cryptor.h
@@ -32,7 +32,7 @@
 #include "rtc_base/synchronization/mutex.h"
 #include "rust/cxx.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 struct KeyProviderOptions;
 struct EncryptedPacket;
@@ -222,4 +222,4 @@ std::shared_ptr<DataPacketCryptor> new_data_packet_cryptor(
     Algorithm algorithm,
     std::shared_ptr<KeyProvider> key_provider);
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/global_task_queue.h
+++ b/webrtc-sys/include/livekit/global_task_queue.h
@@ -18,8 +18,8 @@
 
 #include "api/task_queue/task_queue_factory.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 webrtc::TaskQueueFactory* GetGlobalTaskQueueFactory();
 
-} // namespace livekit
+} // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/helper.h
+++ b/webrtc-sys/include/livekit/helper.h
@@ -18,7 +18,7 @@
 
 #include "rust/cxx.h"
 
-namespace livekit {
+namespace livekit_ffi {
 class MediaStream;
 class AudioTrack;
 class VideoTrack;
@@ -26,10 +26,10 @@ class Candidate;
 class RtpSender;
 class RtpReceiver;
 class RtpTransceiver;
-}  // namespace livekit
+}  // namespace livekit_ffi
 #include "webrtc-sys/src/helper.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 // Impl not needed
 static rust::Vec<MediaStreamPtr> _vec_media_stream_ptr() {
@@ -54,4 +54,4 @@ static rust::Vec<RtpTransceiverPtr> _vec_rtp_transceiver_ptr() {
   throw;
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/jsep.h
+++ b/webrtc-sys/include/livekit/jsep.h
@@ -27,13 +27,13 @@
 #include "rtc_base/ref_count.h"
 #include "rust/cxx.h"
 
-namespace livekit {
+namespace livekit_ffi {
 class IceCandidate;
 class SessionDescription;
-};  // namespace livekit
+};  // namespace livekit_ffi
 #include "webrtc-sys/src/jsep.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 class PeerContext;
 
@@ -44,7 +44,7 @@ class IceCandidate {
 
   rust::String sdp_mid() const;
   int sdp_mline_index() const;
-  rust::String candidate() const;  // TODO(theomonnom) Return livekit::Candidate
+  rust::String candidate() const;  // TODO(theomonnom) Return livekit_ffi::Candidate
                                    // instead of rust::String
 
   rust::String stringify() const;
@@ -148,4 +148,4 @@ class NativeRtcStatsCollector : public webrtc::RTCStatsCollectorCallback {
   rust::Fn<void(rust::Box<T>, rust::String)> on_stats_;
 };
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/media_stream.h
+++ b/webrtc-sys/include/livekit/media_stream.h
@@ -23,12 +23,12 @@
 #include "livekit/webrtc.h"
 #include "rust/cxx.h"
 
-namespace livekit {
+namespace livekit_ffi {
 class MediaStream;
-}  // namespace livekit
+}  // namespace livekit_ffi
 #include "webrtc-sys/src/media_stream.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 class MediaStream {
  public:
@@ -54,4 +54,4 @@ static std::shared_ptr<MediaStream> _shared_media_stream() {
   return nullptr;  // Ignore
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/media_stream_track.h
+++ b/webrtc-sys/include/livekit/media_stream_track.h
@@ -23,12 +23,12 @@
 #include "livekit/webrtc.h"
 #include "rust/cxx.h"
 
-namespace livekit {
+namespace livekit_ffi {
 class MediaStreamTrack;
-}  // namespace livekit
+}  // namespace livekit_ffi
 #include "webrtc-sys/src/media_stream_track.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 class MediaStreamTrack {
  protected:
@@ -57,4 +57,4 @@ static std::shared_ptr<MediaStreamTrack> _shared_media_stream_track() {
   return nullptr;  // Ignore
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/objc_video_factory.h
+++ b/webrtc-sys/include/livekit/objc_video_factory.h
@@ -21,9 +21,9 @@
 #include "api/video_codecs/video_decoder_factory.h"
 #include "api/video_codecs/video_encoder_factory.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 std::unique_ptr<webrtc::VideoEncoderFactory> CreateObjCVideoEncoderFactory();
 std::unique_ptr<webrtc::VideoDecoderFactory> CreateObjCVideoDecoderFactory();
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/peer_connection.h
+++ b/webrtc-sys/include/livekit/peer_connection.h
@@ -32,12 +32,12 @@
 #include "rust/cxx.h"
 #include "webrtc-sys/src/data_channel.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 class PeerConnection;
-}  // namespace livekit
+}  // namespace livekit_ffi
 #include "webrtc-sys/src/peer_connection.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 webrtc::PeerConnectionInterface::RTCConfiguration to_native_rtc_configuration(
     RtcConfiguration config);
@@ -205,4 +205,4 @@ static std::shared_ptr<PeerConnection> _shared_peer_connection() {
   return nullptr;  // Ignore
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/peer_connection_factory.h
+++ b/webrtc-sys/include/livekit/peer_connection_factory.h
@@ -25,13 +25,13 @@
 #include "rust/cxx.h"
 #include "webrtc.h"
 
-namespace livekit {
+namespace livekit_ffi {
 class PeerConnectionFactory;
 class PeerConnectionObserverWrapper;
-}  // namespace livekit
+}  // namespace livekit_ffi
 #include "webrtc-sys/src/peer_connection_factory.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 class PeerConnection;
 struct RtcConfiguration;
@@ -70,4 +70,4 @@ class PeerConnectionFactory {
 };
 
 std::shared_ptr<PeerConnectionFactory> create_peer_connection_factory();
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/prohibit_libsrtp_initialization.h
+++ b/webrtc-sys/include/livekit/prohibit_libsrtp_initialization.h
@@ -16,6 +16,6 @@
 
 #pragma once
 
-namespace livekit {
+namespace livekit_ffi {
 void ProhibitLibsrtpInitialization();
 }

--- a/webrtc-sys/include/livekit/rtc_error.h
+++ b/webrtc-sys/include/livekit/rtc_error.h
@@ -20,7 +20,7 @@
 #include "rust/cxx.h"
 #include "webrtc-sys/src/rtc_error.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 RtcError to_error(const webrtc::RTCError& error);
 std::string serialize_error(
@@ -31,4 +31,4 @@ rust::String serialize_deserialize();
 void throw_error();
 #endif
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/rtp_parameters.h
+++ b/webrtc-sys/include/livekit/rtp_parameters.h
@@ -24,7 +24,7 @@
 #include "api/rtp_transceiver_direction.h"
 #include "webrtc-sys/src/rtp_parameters.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 webrtc::RtcpFeedback to_native_rtcp_feedback(RtcpFeedback feedback);
 webrtc::RtpCodecCapability to_native_rtp_codec_capability(
@@ -58,4 +58,4 @@ RtpCapabilities to_rust_rtp_capabilities(webrtc::RtpCapabilities capabilities);
 RtcpParameters to_rust_rtcp_parameters(webrtc::RtcpParameters params);
 RtpParameters to_rust_rtp_parameters(webrtc::RtpParameters params);
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/rtp_receiver.h
+++ b/webrtc-sys/include/livekit/rtp_receiver.h
@@ -27,11 +27,11 @@
 #include "livekit/webrtc.h"
 #include "rust/cxx.h"
 
-namespace livekit {
+namespace livekit_ffi {
 class RtpReceiver;
 }
 #include "webrtc-sys/src/rtp_receiver.rs.h"
-namespace livekit {
+namespace livekit_ffi {
 
 // TODO(theomonnom): Implement RtpReceiverObserverInterface?
 // TODO(theomonnom): RtpSource
@@ -76,4 +76,4 @@ static std::shared_ptr<RtpReceiver> _shared_rtp_receiver() {
   return nullptr;
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/rtp_sender.h
+++ b/webrtc-sys/include/livekit/rtp_sender.h
@@ -26,12 +26,12 @@
 #include "livekit/rtp_parameters.h"
 #include "rust/cxx.h"
 
-namespace livekit {
+namespace livekit_ffi {
 class RtpSender;
 }
 #include "webrtc-sys/src/rtp_sender.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 // TODO(theomonnom): FrameTransformer & FrameEncryptor interface
 class RtpSender {
@@ -78,4 +78,4 @@ class RtpSender {
 static std::shared_ptr<RtpSender> _shared_rtp_sender() {
   return nullptr;  // Ignore
 }
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/rtp_transceiver.h
+++ b/webrtc-sys/include/livekit/rtp_transceiver.h
@@ -29,12 +29,12 @@
 #include "livekit/rtp_sender.h"
 #include "rust/cxx.h"
 
-namespace livekit {
+namespace livekit_ffi {
 class RtpTransceiver;
 }
 #include "webrtc-sys/src/rtp_transceiver.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 webrtc::RtpTransceiverInit to_native_rtp_transceiver_init(
     RtpTransceiverInit init);
@@ -90,4 +90,4 @@ static std::shared_ptr<RtpTransceiver> _shared_rtp_transceiver() {
   return nullptr;
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/video_decoder_factory.h
+++ b/webrtc-sys/include/livekit/video_decoder_factory.h
@@ -20,7 +20,7 @@
 #include "api/video_codecs/video_decoder_factory.h"
 #include "absl/strings/match.h"
 
-namespace livekit {
+namespace livekit_ffi {
 class VideoDecoderFactory : public webrtc::VideoDecoderFactory {
  public:
   VideoDecoderFactory();
@@ -36,4 +36,4 @@ class VideoDecoderFactory : public webrtc::VideoDecoderFactory {
  private:
   std::vector<std::unique_ptr<webrtc::VideoDecoderFactory>> factories_;
 };
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/video_encoder_factory.h
+++ b/webrtc-sys/include/livekit/video_encoder_factory.h
@@ -19,7 +19,7 @@
 #include "api/video_codecs/video_encoder.h"
 #include "api/video_codecs/video_encoder_factory.h"
 
-namespace livekit {
+namespace livekit_ffi {
 class VideoEncoderFactory : public webrtc::VideoEncoderFactory {
   class InternalFactory : public webrtc::VideoEncoderFactory {
    public:
@@ -53,4 +53,4 @@ class VideoEncoderFactory : public webrtc::VideoEncoderFactory {
  private:
   std::unique_ptr<InternalFactory> internal_factory_;
 };
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/video_frame.h
+++ b/webrtc-sys/include/livekit/video_frame.h
@@ -20,13 +20,13 @@
 #include "livekit/video_frame_buffer.h"
 #include "rtc_base/checks.h"
 
-namespace livekit {
+namespace livekit_ffi {
 class VideoFrame;
 class VideoFrameBuilder;
-}  // namespace livekit
+}  // namespace livekit_ffi
 #include "webrtc-sys/src/video_frame.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 class VideoFrame {
  public:
@@ -68,4 +68,4 @@ class VideoFrameBuilder {
 
 std::unique_ptr<VideoFrameBuilder> new_video_frame_builder();
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/video_frame_buffer.h
+++ b/webrtc-sys/include/livekit/video_frame_buffer.h
@@ -25,7 +25,7 @@
 #include "api/video/nv12_buffer.h"
 #include "api/video/video_frame_buffer.h"
 
-namespace livekit {
+namespace livekit_ffi {
 class VideoFrameBuffer;
 class PlanarYuvBuffer;
 class PlanarYuv8Buffer;
@@ -38,22 +38,22 @@ class I422Buffer;
 class I444Buffer;
 class I010Buffer;
 class NV12Buffer;
-}  // namespace livekit
+}  // namespace livekit_ffi
 
 #ifdef __APPLE__
 #include <CoreVideo/CoreVideo.h>
-namespace livekit {
+namespace livekit_ffi {
 typedef __CVBuffer PlatformImageBuffer;
-}  // namespace livekit
+}  // namespace livekit_ffi
 #else
-namespace livekit {
+namespace livekit_ffi {
 typedef void PlatformImageBuffer;
-}  // namespace livekit
+}  // namespace livekit_ffi
 #endif
 
 #include "webrtc-sys/src/video_frame_buffer.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 class VideoFrameBuffer {
  public:
@@ -271,4 +271,4 @@ static std::unique_ptr<VideoFrameBuffer> _unique_video_frame_buffer() {
   return nullptr;
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/video_track.h
+++ b/webrtc-sys/include/livekit/video_track.h
@@ -29,14 +29,14 @@
 #include "rtc_base/timestamp_aligner.h"
 #include "rust/cxx.h"
 
-namespace livekit {
+namespace livekit_ffi {
 class VideoTrack;
 class NativeVideoSink;
 class VideoTrackSource;
-}  // namespace livekit
+}  // namespace livekit_ffi
 #include "webrtc-sys/src/video_track.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 class VideoTrack : public MediaStreamTrack {
  private:
@@ -137,4 +137,4 @@ static std::shared_ptr<VideoTrack> _shared_video_track() {
   return nullptr;  // Ignore
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/webrtc.h
+++ b/webrtc-sys/include/livekit/webrtc.h
@@ -32,13 +32,13 @@
 #include "rtc_base/win32_socket_init.h"
 #endif
 
-namespace livekit {
+namespace livekit_ffi {
 class RtcRuntime;
 class LogSink;
-}  // namespace livekit
+}  // namespace livekit_ffi
 #include "webrtc-sys/src/webrtc.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 class MediaStreamTrack;
 class RtpReceiver;
@@ -78,7 +78,7 @@ class RtcRuntime : public std::enable_shared_from_this<RtcRuntime> {
 
   // Lists used to make sure we don't create multiple wrappers for one
   // underlying webrtc object. (e.g: webrtc::VideoTrackInterface should only
-  // have one livekit::VideoTrack associated with it).
+  // have one livekit_ffi::VideoTrack associated with it).
   // The only reason we to do that is to allow to add states inside our
   // wrappers (e.g: the sinks_ member inside AudioTrack)
   // DataChannel and the PeerConnectionFactory don't need to do this (There's no
@@ -115,4 +115,4 @@ std::unique_ptr<LogSink> new_log_sink(
 
 rust::String create_random_uuid();
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/yuv_helper.h
+++ b/webrtc-sys/include/livekit/yuv_helper.h
@@ -23,7 +23,7 @@
 #include "api/video/yuv_helper.h"
 #include "webrtc-sys/src/yuv_helper.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 #define THROW_ON_ERROR(ret)                                           \
   if (ret != 0) {                                                     \
@@ -378,4 +378,4 @@ static void argb_to_nv12(const uint8_t* src_argb,
                                     height));
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/android.cpp
+++ b/webrtc-sys/src/android.cpp
@@ -27,7 +27,7 @@
 #include "sdk/android/native_api/jni/scoped_java_ref.h"
 #include "sdk/android/src/jni/jni_helpers.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 void init_android(JavaVM* jvm) {
   webrtc::InitAndroid(jvm);
@@ -62,4 +62,4 @@ CreateAndroidVideoDecoderFactory() {
   return webrtc::JavaToNativeVideoDecoderFactory(env, decoder_factory);
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/android.rs
+++ b/webrtc-sys/src/android.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #[cfg(target_os = "android")]
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
     unsafe extern "C++" {
         include!("livekit/android.h");

--- a/webrtc-sys/src/apm.cpp
+++ b/webrtc-sys/src/apm.cpp
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <memory>
 
-namespace livekit {
+namespace livekit_ffi {
 
 AudioProcessingModule::AudioProcessingModule(
     const AudioProcessingConfig& config) {
@@ -70,4 +70,4 @@ std::unique_ptr<AudioProcessingModule> create_apm(
   return std::make_unique<AudioProcessingModule>(config);
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/apm.rs
+++ b/webrtc-sys/src/apm.rs
@@ -14,7 +14,7 @@
 
 use crate::impl_thread_safety;
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
     unsafe extern "C++" {
         include!("livekit/apm.h");

--- a/webrtc-sys/src/audio_device.cpp
+++ b/webrtc-sys/src/audio_device.cpp
@@ -21,7 +21,7 @@ const int kChannels = 2;
 const int kBytesPerSample = kChannels * sizeof(int16_t);
 const int kSamplesPer10Ms = kSampleRate / 100;
 
-namespace livekit {
+namespace livekit_ffi {
 
 AudioDevice::AudioDevice(webrtc::TaskQueueFactory* task_queue_factory)
     : task_queue_factory_(task_queue_factory),
@@ -332,4 +332,4 @@ int32_t AudioDevice::SetObserver(webrtc::AudioDeviceObserver* observer) {
   return 0;
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/audio_mixer.cpp
+++ b/webrtc-sys/src/audio_mixer.cpp
@@ -24,7 +24,7 @@
 #include "modules/audio_mixer/audio_mixer_impl.h"
 #include "webrtc-sys/src/audio_mixer.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 AudioMixer::AudioMixer() {
   audio_mixer_ = webrtc::AudioMixerImpl::Create();
@@ -79,12 +79,12 @@ AudioMixerSource::GetAudioFrameWithInfo(int sample_rate,
                                         webrtc::AudioFrame* audio_frame) {
   NativeAudioFrame frame(audio_frame);
 
-  livekit::AudioFrameInfo result =
+  livekit_ffi::AudioFrameInfo result =
       source_->get_audio_frame_with_info(sample_rate, frame);
 
-  if (result == livekit::AudioFrameInfo::Normal) {
+  if (result == livekit_ffi::AudioFrameInfo::Normal) {
     return webrtc::AudioMixer::Source::AudioFrameInfo::kNormal;
-  } else if (result == livekit::AudioFrameInfo::Muted) {
+  } else if (result == livekit_ffi::AudioFrameInfo::Muted) {
     return webrtc::AudioMixer::Source::AudioFrameInfo::kMuted;
   } else {
     return webrtc::AudioMixer::Source::AudioFrameInfo::kError;
@@ -102,4 +102,4 @@ void NativeAudioFrame::update_frame(uint32_t timestamp,
                       num_channels);
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/audio_mixer.rs
+++ b/webrtc-sys/src/audio_mixer.rs
@@ -18,7 +18,7 @@ use ffi::AudioFrameInfo;
 
 use crate::impl_thread_safety;
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
     unsafe extern "C++" {
         include!("livekit/audio_mixer.h");

--- a/webrtc-sys/src/audio_resampler.cpp
+++ b/webrtc-sys/src/audio_resampler.cpp
@@ -22,7 +22,7 @@
 #include "api/audio/audio_view.h"
 #include "api/audio/audio_frame.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 size_t AudioResampler::remix_and_resample(const int16_t* src,
                                           size_t samples_per_channel,
@@ -49,4 +49,4 @@ std::unique_ptr<AudioResampler> create_audio_resampler() {
   return std::make_unique<AudioResampler>();
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/audio_resampler.rs
+++ b/webrtc-sys/src/audio_resampler.rs
@@ -14,7 +14,7 @@
 
 use crate::impl_thread_safety;
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
     unsafe extern "C++" {
         include!("livekit/audio_resampler.h");

--- a/webrtc-sys/src/audio_track.cpp
+++ b/webrtc-sys/src/audio_track.cpp
@@ -36,7 +36,7 @@
 #include "rust/cxx.h"
 #include "webrtc-sys/src/audio_track.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 inline cricket::AudioOptions to_native_audio_options(
     const AudioSourceOptions& options) {
@@ -323,4 +323,4 @@ webrtc::scoped_refptr<AudioTrackSource::InternalSource> AudioTrackSource::get()
   return source_;
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/audio_track.rs
+++ b/webrtc-sys/src/audio_track.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use crate::impl_thread_safety;
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
 
     pub struct AudioSourceOptions {
@@ -101,7 +101,7 @@ pub struct SourceContext(pub Box<dyn Any + Send>);
 pub struct CompleteCallback(pub extern "C" fn(ctx: *const SourceContext));
 
 unsafe impl ExternType for CompleteCallback {
-    type Id = type_id!("livekit::CompleteCallback");
+    type Id = type_id!("livekit_ffi::CompleteCallback");
     type Kind = cxx::kind::Trivial;
 }
 

--- a/webrtc-sys/src/candidate.cpp
+++ b/webrtc-sys/src/candidate.cpp
@@ -16,7 +16,7 @@
 
 #include "livekit/candidate.h"
 
-namespace livekit {
+namespace livekit_ffi {
 Candidate::Candidate(const cricket::Candidate& candidate)
     : candidate_(candidate) {}
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/candidate.rs
+++ b/webrtc-sys/src/candidate.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
     unsafe extern "C++" {
         include!("livekit/candidate.h");

--- a/webrtc-sys/src/data_channel.cpp
+++ b/webrtc-sys/src/data_channel.cpp
@@ -21,7 +21,7 @@
 #include "rtc_base/synchronization/mutex.h"
 #include "webrtc-sys/src/data_channel.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 webrtc::DataChannelInit to_native_data_channel_init(DataChannelInit init) {
   webrtc::DataChannelInit rtc_init{};
@@ -118,4 +118,4 @@ void NativeDataChannelObserver::OnBufferedAmountChange(
   observer_->on_buffered_amount_change(sent_data_size);
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/data_channel.rs
+++ b/webrtc-sys/src/data_channel.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use crate::impl_thread_safety;
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
     #[derive(Debug)]
     #[repr(i32)]

--- a/webrtc-sys/src/desktop_capturer.cpp
+++ b/webrtc-sys/src/desktop_capturer.cpp
@@ -20,7 +20,7 @@
 
 using SourceList = webrtc::DesktopCapturer::SourceList;
 
-namespace livekit {
+namespace livekit_ffi {
 
 std::unique_ptr<DesktopCapturer> new_desktop_capturer(
     DesktopCapturerOptions options) {
@@ -115,4 +115,4 @@ rust::Vec<Source> DesktopCapturer::get_source_list() const {
   }
   return source_list;
 }
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/desktop_capturer.rs
+++ b/webrtc-sys/src/desktop_capturer.rs
@@ -17,7 +17,7 @@ use ffi::CaptureResult;
 
 use crate::{desktop_capturer::ffi::DesktopFrame, impl_thread_safety};
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
     #[derive(Clone)]
     struct Source {

--- a/webrtc-sys/src/frame_cryptor.cpp
+++ b/webrtc-sys/src/frame_cryptor.cpp
@@ -26,7 +26,7 @@
 #include "rtc_base/thread.h"
 #include "webrtc-sys/src/frame_cryptor.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 webrtc::FrameCryptorTransformer::Algorithm AlgorithmToFrameCryptorAlgorithm(
     Algorithm algorithm) {
@@ -257,4 +257,4 @@ std::shared_ptr<DataPacketCryptor> new_data_packet_cryptor(
       key_provider->rtc_key_provider());
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/frame_cryptor.rs
+++ b/webrtc-sys/src/frame_cryptor.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use crate::impl_thread_safety;
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
 
     #[derive(Debug)]
@@ -167,7 +167,7 @@ pub mod ffi {
             state: FrameCryptionState,
         );
     }
-} // namespace livekit
+} // namespace livekit_ffi
 
 impl_thread_safety!(ffi::FrameCryptor, Send + Sync);
 impl_thread_safety!(ffi::KeyProvider, Send + Sync);

--- a/webrtc-sys/src/global_task_queue.cpp
+++ b/webrtc-sys/src/global_task_queue.cpp
@@ -19,7 +19,7 @@
 #include "api/task_queue/default_task_queue_factory.h"
 #include "api/task_queue/task_queue_factory.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 webrtc::TaskQueueFactory* GetGlobalTaskQueueFactory() {
   static std::unique_ptr<webrtc::TaskQueueFactory> global_task_queue_factory =
@@ -27,4 +27,4 @@ webrtc::TaskQueueFactory* GetGlobalTaskQueueFactory() {
   return global_task_queue_factory.get();
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/helper.rs
+++ b/webrtc-sys/src/helper.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
     // Wrapper to opaque C++ objects
     // https://github.com/dtolnay/cxx/issues/741

--- a/webrtc-sys/src/jsep.cpp
+++ b/webrtc-sys/src/jsep.cpp
@@ -23,7 +23,7 @@
 #include "rtc_base/ref_counted_object.h"
 #include "rust/cxx.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 std::string serialize_sdp_error(webrtc::SdpParseError error) {
   std::stringstream ss;
@@ -148,4 +148,4 @@ void NativeSetRemoteSdpObserver::OnSetRemoteDescriptionComplete(
     webrtc::RTCError error) {
   on_complete_(std::move(ctx_), to_error(error));
 }
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/jsep.rs
+++ b/webrtc-sys/src/jsep.rs
@@ -19,7 +19,7 @@ use std::{
 
 use crate::impl_thread_safety;
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
     #[derive(Debug)]
     #[repr(i32)]

--- a/webrtc-sys/src/media_stream.cpp
+++ b/webrtc-sys/src/media_stream.cpp
@@ -29,7 +29,7 @@
 #include "rtc_base/ref_counted_object.h"
 #include "rtc_base/time_utils.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 MediaStream::MediaStream(
     std::shared_ptr<RtcRuntime> rtc_runtime,
@@ -98,4 +98,4 @@ bool MediaStream::remove_track(std::shared_ptr<MediaStreamTrack> track) const {
   }
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/media_stream.rs
+++ b/webrtc-sys/src/media_stream.rs
@@ -14,7 +14,7 @@
 
 use crate::impl_thread_safety;
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
     extern "C++" {
         include!("livekit/helper.h");

--- a/webrtc-sys/src/media_stream_track.cpp
+++ b/webrtc-sys/src/media_stream_track.cpp
@@ -28,7 +28,7 @@
 #include "rtc_base/ref_counted_object.h"
 #include "rtc_base/time_utils.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 MediaStreamTrack::MediaStreamTrack(
     std::shared_ptr<RtcRuntime> rtc_runtime,
@@ -55,4 +55,4 @@ TrackState MediaStreamTrack::state() const {
   return static_cast<TrackState>(track_->state());
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/media_stream_track.rs
+++ b/webrtc-sys/src/media_stream_track.rs
@@ -14,7 +14,7 @@
 
 use crate::impl_thread_safety;
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
     #[repr(i32)]
     pub enum TrackState {

--- a/webrtc-sys/src/nvidia/cuda_context.cpp
+++ b/webrtc-sys/src/nvidia/cuda_context.cpp
@@ -17,7 +17,7 @@ static const char CUDA_DYNAMIC_LIBRARY[] = "nvcuda.dll";
 static const char CUDA_DYNAMIC_LIBRARY[] = "libcuda.so.1";
 #endif
 
-namespace livekit {
+namespace livekit_ffi {
 
 #define __CUCTX_CUDA_CALL(call, ret)                        \
   CUresult err__ = call;                                    \
@@ -198,4 +198,4 @@ void CudaContext::Shutdown() {
   }
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/nvidia/cuda_context.h
+++ b/webrtc-sys/src/nvidia/cuda_context.h
@@ -3,7 +3,7 @@
 
 #include <cuda.h>
 
-namespace livekit {
+namespace livekit_ffi {
 
 class CudaContext {
  public:
@@ -24,6 +24,6 @@ class CudaContext {
   CUcontext cu_context_ = nullptr;
 };
 
-}  // namespace livekit
+}  // namespace livekit_ffi
 
 #endif  // WEBRTC_SYS_NVIDIA_CUDA_CONTEXT_H

--- a/webrtc-sys/src/nvidia/nvidia_decoder_factory.cpp
+++ b/webrtc-sys/src/nvidia/nvidia_decoder_factory.cpp
@@ -67,7 +67,7 @@ std::vector<SdpVideoFormat> SupportedNvDecoderCodecs(CUcontext context) {
 }
 
 NvidiaVideoDecoderFactory::NvidiaVideoDecoderFactory()
-    : cu_context_(livekit::CudaContext::GetInstance()) {
+    : cu_context_(livekit_ffi::CudaContext::GetInstance()) {
   if (cu_context_->Initialize()) {
     supported_formats_ = SupportedNvDecoderCodecs(cu_context_->GetContext());
   } else {
@@ -80,7 +80,7 @@ NvidiaVideoDecoderFactory::NvidiaVideoDecoderFactory()
 NvidiaVideoDecoderFactory::~NvidiaVideoDecoderFactory() {}
 
 bool NvidiaVideoDecoderFactory::IsSupported() {
-  if (!livekit::CudaContext::IsAvailable()) {
+  if (!livekit_ffi::CudaContext::IsAvailable()) {
     RTC_LOG(LS_WARNING) << "Cuda Context is not available.";
     return false;
   }
@@ -97,7 +97,7 @@ std::unique_ptr<VideoDecoder> NvidiaVideoDecoderFactory::Create(
     if (format.IsSameCodec(supported_format)) {
       // If the format is supported, create and return the decoder.
       if (!cu_context_) {
-        cu_context_ = livekit::CudaContext::GetInstance();
+        cu_context_ = livekit_ffi::CudaContext::GetInstance();
         if (!cu_context_->Initialize()) {
           RTC_LOG(LS_ERROR) << "Failed to initialize CUDA context.";
           return nullptr;

--- a/webrtc-sys/src/nvidia/nvidia_decoder_factory.h
+++ b/webrtc-sys/src/nvidia/nvidia_decoder_factory.h
@@ -26,7 +26,7 @@ class NvidiaVideoDecoderFactory : public VideoDecoderFactory {
 
  private:
   std::vector<SdpVideoFormat> supported_formats_;
-  livekit::CudaContext* cu_context_;
+  livekit_ffi::CudaContext* cu_context_;
 };
 
 }  // namespace webrtc

--- a/webrtc-sys/src/nvidia/nvidia_encoder_factory.cpp
+++ b/webrtc-sys/src/nvidia/nvidia_encoder_factory.cpp
@@ -35,7 +35,7 @@ NvidiaVideoEncoderFactory::NvidiaVideoEncoderFactory() {
 NvidiaVideoEncoderFactory::~NvidiaVideoEncoderFactory() {}
 
 bool NvidiaVideoEncoderFactory::IsSupported() {
-  if (!livekit::CudaContext::IsAvailable()) {
+  if (!livekit_ffi::CudaContext::IsAvailable()) {
     RTC_LOG(LS_WARNING) << "Cuda Context is not available.";
     return false;
   }
@@ -51,7 +51,7 @@ std::unique_ptr<VideoEncoder> NvidiaVideoEncoderFactory::Create(
   for (const auto& supported_format : supported_formats_) {
     if (format.IsSameCodec(supported_format)) {
       if (!cu_context_) {
-        cu_context_ = livekit::CudaContext::GetInstance();
+        cu_context_ = livekit_ffi::CudaContext::GetInstance();
         if (!cu_context_->Initialize()) {
           RTC_LOG(LS_ERROR) << "Failed to initialize CUDA context.";
           return nullptr;

--- a/webrtc-sys/src/nvidia/nvidia_encoder_factory.h
+++ b/webrtc-sys/src/nvidia/nvidia_encoder_factory.h
@@ -34,7 +34,7 @@ class NvidiaVideoEncoderFactory : public VideoEncoderFactory {
 
  private:
   std::vector<SdpVideoFormat> supported_formats_;
-  livekit::CudaContext* cu_context_ = nullptr;
+  livekit_ffi::CudaContext* cu_context_ = nullptr;
 };
 
 }  // namespace webrtc

--- a/webrtc-sys/src/objc_video_factory.mm
+++ b/webrtc-sys/src/objc_video_factory.mm
@@ -22,7 +22,7 @@
 #include "sdk/objc/native/api/video_decoder_factory.h"
 #include "sdk/objc/native/api/video_encoder_factory.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 std::unique_ptr<webrtc::VideoEncoderFactory> CreateObjCVideoEncoderFactory() {
   RTCDefaultVideoEncoderFactory* encoderFactory = [[RTCDefaultVideoEncoderFactory alloc] init];
@@ -35,4 +35,4 @@ std::unique_ptr<webrtc::VideoDecoderFactory> CreateObjCVideoDecoderFactory() {
   return webrtc::ObjCToNativeVideoDecoderFactory([[RTCDefaultVideoDecoderFactory alloc] init]);
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/objc_video_frame_buffer.mm
+++ b/webrtc-sys/src/objc_video_frame_buffer.mm
@@ -20,7 +20,7 @@
 #import <sdk/objc/components/video_frame_buffer/RTCCVPixelBuffer.h>
 #include "sdk/objc/native/api/video_frame_buffer.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 std::unique_ptr<VideoFrameBuffer> new_native_buffer_from_platform_image_buffer(
     CVPixelBufferRef pixelBuffer
@@ -45,4 +45,4 @@ CVPixelBufferRef native_buffer_to_platform_image_buffer(
     }
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/peer_connection.cpp
+++ b/webrtc-sys/src/peer_connection.cpp
@@ -29,7 +29,7 @@
 #include "livekit/rtp_transceiver.h"
 #include "rtc_base/logging.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 webrtc::PeerConnectionInterface::RTCConfiguration to_native_rtc_configuration(
     RtcConfiguration config) {
@@ -475,4 +475,4 @@ void PeerConnection::OnInterestingUsage(int usage_pattern) {
   observer_->on_interesting_usage(usage_pattern);
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/peer_connection.rs
+++ b/webrtc-sys/src/peer_connection.rs
@@ -16,7 +16,7 @@ use std::any::Any;
 
 use crate::impl_thread_safety;
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
     #[repr(i32)]
     pub enum PeerConnectionState {

--- a/webrtc-sys/src/peer_connection_factory.cpp
+++ b/webrtc-sys/src/peer_connection_factory.cpp
@@ -43,7 +43,7 @@
 #include "webrtc-sys/src/peer_connection.rs.h"
 #include "webrtc-sys/src/peer_connection_factory.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 class PeerConnectionObserver;
 
@@ -62,16 +62,16 @@ PeerConnectionFactory::PeerConnectionFactory(
   dependencies.trials = std::make_unique<webrtc::FieldTrialBasedConfig>();
 
   audio_device_ = rtc_runtime_->worker_thread()->BlockingCall([&] {
-    return webrtc::make_ref_counted<livekit::AudioDevice>(
+    return webrtc::make_ref_counted<livekit_ffi::AudioDevice>(
         dependencies.task_queue_factory.get());
   });
 
   dependencies.adm = audio_device_;
 
   dependencies.video_encoder_factory =
-      std::move(std::make_unique<livekit::VideoEncoderFactory>());
+      std::move(std::make_unique<livekit_ffi::VideoEncoderFactory>());
   dependencies.video_decoder_factory =
-      std::move(std::make_unique<livekit::VideoDecoderFactory>());
+      std::move(std::make_unique<livekit_ffi::VideoDecoderFactory>());
   dependencies.audio_encoder_factory = webrtc::CreateBuiltinAudioEncoderFactory();
   dependencies.audio_decoder_factory = webrtc::CreateBuiltinAudioDecoderFactory();
   dependencies.audio_processing = webrtc::BuiltinAudioProcessingBuilder()
@@ -144,4 +144,4 @@ std::shared_ptr<PeerConnectionFactory> create_peer_connection_factory() {
   return std::make_shared<PeerConnectionFactory>(RtcRuntime::create());
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/peer_connection_factory.rs
+++ b/webrtc-sys/src/peer_connection_factory.rs
@@ -22,7 +22,7 @@ use crate::{
     rtp_transceiver::ffi::RtpTransceiver,
 };
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
     pub struct CandidatePair {
         local: SharedPtr<Candidate>,

--- a/webrtc-sys/src/prohibit_libsrtp_initialization.cpp
+++ b/webrtc-sys/src/prohibit_libsrtp_initialization.cpp
@@ -16,7 +16,7 @@
 
 #include "pc/srtp_session.h"
 
-namespace livekit {
+namespace livekit_ffi {
 void ProhibitLibsrtpInitialization() {
     cricket::ProhibitLibsrtpInitialization();
 }

--- a/webrtc-sys/src/prohibit_libsrtp_initialization.rs
+++ b/webrtc-sys/src/prohibit_libsrtp_initialization.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
     unsafe extern "C++" {
         include!("livekit/prohibit_libsrtp_initialization.h");

--- a/webrtc-sys/src/rtc_error.cpp
+++ b/webrtc-sys/src/rtc_error.cpp
@@ -20,7 +20,7 @@
 #include <sstream>
 #include <string>
 
-namespace livekit {
+namespace livekit_ffi {
 
 RtcError to_error(const webrtc::RTCError& error) {
   RtcError lk_error;
@@ -65,4 +65,4 @@ void throw_error() {
 }
 #endif
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/rtc_error.rs
+++ b/webrtc-sys/src/rtc_error.rs
@@ -20,7 +20,7 @@ use std::{
 // cxx doesn't support custom Exception type, so we serialize RtcError inside the cxx::Exception
 // "what" string
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
     #[derive(Debug)]
     #[repr(i32)]
@@ -100,7 +100,7 @@ impl Display for ffi::RtcError {
 mod tests {
     use crate::rtc_error::ffi::{RtcError, RtcErrorDetailType, RtcErrorType};
 
-    #[cxx::bridge(namespace = "livekit")]
+    #[cxx::bridge(namespace = "livekit_ffi")]
     pub mod ffi {
         unsafe extern "C++" {
             include!("livekit/rtc_error.h");

--- a/webrtc-sys/src/rtp_parameters.cpp
+++ b/webrtc-sys/src/rtp_parameters.cpp
@@ -16,7 +16,7 @@
 
 #include "livekit/rtp_parameters.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 webrtc::RtcpFeedback to_native_rtcp_feedback(RtcpFeedback feedback) {
   webrtc::RtcpFeedback native{};
@@ -411,4 +411,4 @@ RtpParameters to_rust_rtp_parameters(webrtc::RtpParameters params) {
   return rust;
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/rtp_parameters.rs
+++ b/webrtc-sys/src/rtp_parameters.rs
@@ -14,7 +14,7 @@
 
 pub const DEFAULT_BITRATE_PRIORITY: f64 = 1.0;
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
 
     // Used to replace std::map

--- a/webrtc-sys/src/rtp_receiver.cpp
+++ b/webrtc-sys/src/rtp_receiver.cpp
@@ -23,7 +23,7 @@
 #include "api/peer_connection_interface.h"
 #include "api/scoped_refptr.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 RtpReceiver::RtpReceiver(
     std::shared_ptr<RtcRuntime> rtc_runtime,
@@ -78,4 +78,4 @@ void RtpReceiver::set_jitter_buffer_minimum_delay(bool is_some,
       is_some ? absl::make_optional(delay_seconds) : absl::nullopt);
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/rtp_receiver.rs
+++ b/webrtc-sys/src/rtp_receiver.rs
@@ -16,7 +16,7 @@ use std::any::Any;
 
 use crate::impl_thread_safety;
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
 
     extern "C++" {

--- a/webrtc-sys/src/rtp_sender.cpp
+++ b/webrtc-sys/src/rtp_sender.cpp
@@ -20,7 +20,7 @@
 #include "rust/cxx.h"
 #include "webrtc-sys/src/rtp_sender.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 
 
@@ -90,4 +90,4 @@ void RtpSender::set_parameters(RtpParameters params) const {
     throw std::runtime_error(serialize_error(to_error(error)));
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/rtp_sender.rs
+++ b/webrtc-sys/src/rtp_sender.rs
@@ -16,7 +16,7 @@ use std::any::Any;
 
 use crate::impl_thread_safety;
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
 
     extern "C++" {

--- a/webrtc-sys/src/rtp_transceiver.cpp
+++ b/webrtc-sys/src/rtp_transceiver.cpp
@@ -19,7 +19,7 @@
 #include "api/peer_connection_interface.h"
 #include "api/scoped_refptr.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 webrtc::RtpTransceiverInit to_native_rtp_transceiver_init(
     RtpTransceiverInit init) {
@@ -151,4 +151,4 @@ void RtpTransceiver::set_header_extensions_to_negotiate(
     throw std::runtime_error(serialize_error(to_error(error)));
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/rtp_transceiver.rs
+++ b/webrtc-sys/src/rtp_transceiver.rs
@@ -14,7 +14,7 @@
 
 use crate::impl_thread_safety;
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
 
     #[derive(Debug)]

--- a/webrtc-sys/src/vaapi/h264_encoder_impl.cpp
+++ b/webrtc-sys/src/vaapi/h264_encoder_impl.cpp
@@ -35,7 +35,7 @@ enum H264EncoderImplEvent {
 VAAPIH264EncoderWrapper::VAAPIH264EncoderWrapper(const webrtc::Environment& env,
                                                  const SdpVideoFormat& format)
     : env_(env),
-      encoder_(new livekit::VaapiH264EncoderWrapper()),
+      encoder_(new livekit_ffi::VaapiH264EncoderWrapper()),
       packetization_mode_(
           H264EncoderSettings::Parse(format).packetization_mode),
       format_(format) {

--- a/webrtc-sys/src/vaapi/h264_encoder_impl.h
+++ b/webrtc-sys/src/vaapi/h264_encoder_impl.h
@@ -63,7 +63,7 @@ class VAAPIH264EncoderWrapper : public VideoEncoder {
  private:
   const webrtc::Environment& env_;
   EncodedImageCallback* encoded_image_callback_ = nullptr;
-  std::unique_ptr<livekit::VaapiH264EncoderWrapper> encoder_;
+  std::unique_ptr<livekit_ffi::VaapiH264EncoderWrapper> encoder_;
   LayerConfig configuration_;
   EncodedImage encoded_image_;
   H264PacketizationMode packetization_mode_;

--- a/webrtc-sys/src/vaapi/vaapi_display_drm.cpp
+++ b/webrtc-sys/src/vaapi/vaapi_display_drm.cpp
@@ -105,7 +105,7 @@ static VADisplay va_open_display_drm(int* drm_fd) {
   return NULL;
 }
 
-namespace livekit {
+namespace livekit_ffi {
 
 bool VaapiDisplayDrm::Open() {
   va_display_ = va_open_display_drm(&drm_fd_);
@@ -132,4 +132,4 @@ void VaapiDisplayDrm::Close() {
   }
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/vaapi/vaapi_display_drm.h
+++ b/webrtc-sys/src/vaapi/vaapi_display_drm.h
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <va/va.h>
 
-namespace livekit {
+namespace livekit_ffi {
 
 // VAAPI drm display wrapper class
 class VaapiDisplayDrm {
@@ -30,6 +30,6 @@ class VaapiDisplayDrm {
   int drm_fd_;
 };
 
-}  // namespace livekit
+}  // namespace livekit_ffi
 
 #endif  // VAAPI_DISPLAY_DRM_H_

--- a/webrtc-sys/src/vaapi/vaapi_display_win32.cpp
+++ b/webrtc-sys/src/vaapi/vaapi_display_win32.cpp
@@ -162,7 +162,7 @@ static VADisplay va_open_display_win32(void) {
 
 static void va_close_display_win32(VADisplay va_dpy) {}
 
-namespace livekit {
+namespace livekit_ffi {
 
 VaapiDisplayWin32::VaapiDisplayWin32() : va_display_(nullptr) {
   putenv("LIBVA_DRIVER_NAME=vaon12");
@@ -189,4 +189,4 @@ void VaapiDisplayWin32::Close() {
   }
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/vaapi/vaapi_display_win32.h
+++ b/webrtc-sys/src/vaapi/vaapi_display_win32.h
@@ -4,7 +4,7 @@
 #include <va/va.h>
 #include <va/va_win32.h>
 
-namespace livekit {
+namespace livekit_ffi {
 
 // VAAPI win32 display wrapper class
 class VaapiDisplayWin32 {
@@ -28,6 +28,6 @@ class VaapiDisplayWin32 {
   VADisplay va_display_ = nullptr;
 };
 
-}  // namespace livekit
+}  // namespace livekit_ffi
 
 #endif  // VAAPI_DISPLAY_WIN32_H_

--- a/webrtc-sys/src/vaapi/vaapi_encoder_factory.cpp
+++ b/webrtc-sys/src/vaapi/vaapi_encoder_factory.cpp
@@ -8,10 +8,10 @@
 
 #if defined(WIN32)
 #include "vaapi_display_win32.h"
-using VaapiDisplay = livekit::VaapiDisplayWin32;
+using VaapiDisplay = livekit_ffi::VaapiDisplayWin32;
 #elif defined(__linux__)
 #include "vaapi_display_drm.h"
-using VaapiDisplay = livekit::VaapiDisplayDrm;
+using VaapiDisplay = livekit_ffi::VaapiDisplayDrm;
 #endif
 
 namespace webrtc {

--- a/webrtc-sys/src/vaapi/vaapi_h264_encoder_wrapper.cpp
+++ b/webrtc-sys/src/vaapi/vaapi_h264_encoder_wrapper.cpp
@@ -1646,7 +1646,7 @@ static int render_slice(VA264Context* context) {
   return 0;
 }
 
-namespace livekit {
+namespace livekit_ffi {
 
 VaapiH264EncoderWrapper::VaapiH264EncoderWrapper()
     : va_display_(std::make_unique<VaapiDisplay>()) {
@@ -1877,4 +1877,4 @@ bool VaapiH264EncoderWrapper::Encode(int fourcc,
   return true;
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/vaapi/vaapi_h264_encoder_wrapper.h
+++ b/webrtc-sys/src/vaapi/vaapi_h264_encoder_wrapper.h
@@ -11,10 +11,10 @@
 
 #if defined(WIN32)
 #include "vaapi_display_win32.h"
-using VaapiDisplay = livekit::VaapiDisplayWin32;
+using VaapiDisplay = livekit_ffi::VaapiDisplayWin32;
 #elif defined(__linux__)
 #include "vaapi_display_drm.h"
-using VaapiDisplay = livekit::VaapiDisplayDrm ;
+using VaapiDisplay = livekit_ffi::VaapiDisplayDrm ;
 #endif
 #define SURFACE_NUM 16 /* 16 surfaces for reference */
 
@@ -76,7 +76,7 @@ typedef struct {
   VA264Config config;
 } VA264Context;
 
-namespace livekit {
+namespace livekit_ffi {
 
 class VaapiH264EncoderWrapper {
  public:
@@ -122,6 +122,6 @@ class VaapiH264EncoderWrapper {
   bool initialized_ = false;
 };
 
-}  // namespace livekit
+}  // namespace livekit_ffi
 
 #endif  // VAAPI_H264_ENCODER_WRAPPER_H_

--- a/webrtc-sys/src/video_decoder_factory.cpp
+++ b/webrtc-sys/src/video_decoder_factory.cpp
@@ -39,11 +39,11 @@
 #include "nvidia/nvidia_decoder_factory.h"
 #endif
 
-namespace livekit {
+namespace livekit_ffi {
 
 VideoDecoderFactory::VideoDecoderFactory() {
 #ifdef __APPLE__
-  factories_.push_back(livekit::CreateObjCVideoDecoderFactory());
+  factories_.push_back(livekit_ffi::CreateObjCVideoDecoderFactory());
 #endif
 
 #ifdef WEBRTC_ANDROID
@@ -125,4 +125,4 @@ std::unique_ptr<webrtc::VideoDecoder> VideoDecoderFactory::Create(
   return nullptr;
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/video_encoder_factory.cpp
+++ b/webrtc-sys/src/video_encoder_factory.cpp
@@ -45,7 +45,7 @@
 #include "vaapi/vaapi_encoder_factory.h"
 #endif
 
-namespace livekit {
+namespace livekit_ffi {
 
 using Factory = webrtc::VideoEncoderFactoryTemplate<
     webrtc::LibvpxVp8EncoderTemplateAdapter,
@@ -59,7 +59,7 @@ using Factory = webrtc::VideoEncoderFactoryTemplate<
 
 VideoEncoderFactory::InternalFactory::InternalFactory() {
 #ifdef __APPLE__
-  factories_.push_back(livekit::CreateObjCVideoEncoderFactory());
+  factories_.push_back(livekit_ffi::CreateObjCVideoEncoderFactory());
 #endif
 
 #ifdef WEBRTC_ANDROID
@@ -155,4 +155,4 @@ std::unique_ptr<webrtc::VideoEncoder> VideoEncoderFactory::Create(
   return encoder;
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/video_frame.cpp
+++ b/webrtc-sys/src/video_frame.cpp
@@ -20,7 +20,7 @@
 
 #include "api/video/video_frame.h"
 
-namespace livekit {
+namespace livekit_ffi {
 VideoFrame::VideoFrame(const webrtc::VideoFrame& frame)
     : frame_(std::move(frame)) {}
 
@@ -83,4 +83,4 @@ std::unique_ptr<VideoFrameBuilder> new_video_frame_builder() {
   return std::make_unique<VideoFrameBuilder>();
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/video_frame.rs
+++ b/webrtc-sys/src/video_frame.rs
@@ -14,7 +14,7 @@
 
 use crate::impl_thread_safety;
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
     #[derive(Debug)]
     #[repr(i32)]

--- a/webrtc-sys/src/video_frame_buffer.cpp
+++ b/webrtc-sys/src/video_frame_buffer.cpp
@@ -18,7 +18,7 @@
 
 #include "api/make_ref_counted.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 VideoFrameBuffer::VideoFrameBuffer(
     webrtc::scoped_refptr<webrtc::VideoFrameBuffer> buffer)
@@ -359,4 +359,4 @@ PlatformImageBuffer* native_buffer_to_platform_image_buffer(
 
 #endif
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/video_frame_buffer.rs
+++ b/webrtc-sys/src/video_frame_buffer.rs
@@ -14,7 +14,7 @@
 
 use crate::impl_thread_safety;
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
     #[derive(Debug)]
     #[repr(i32)]

--- a/webrtc-sys/src/video_track.cpp
+++ b/webrtc-sys/src/video_track.cpp
@@ -33,7 +33,7 @@
 #include "rtc_base/time_utils.h"
 #include "webrtc-sys/src/video_track.rs.h"
 
-namespace livekit {
+namespace livekit_ffi {
 
 VideoTrack::VideoTrack(std::shared_ptr<RtcRuntime> rtc_runtime,
                        webrtc::scoped_refptr<webrtc::VideoTrackInterface> track)
@@ -199,4 +199,4 @@ std::shared_ptr<VideoTrackSource> new_video_track_source(
   return std::make_shared<VideoTrackSource>(resolution);
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/video_track.rs
+++ b/webrtc-sys/src/video_track.rs
@@ -18,7 +18,7 @@ use cxx::UniquePtr;
 
 use crate::{impl_thread_safety, video_frame::ffi::VideoFrame};
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
     #[repr(i32)]
     pub enum ContentHint {

--- a/webrtc-sys/src/webrtc.cpp
+++ b/webrtc-sys/src/webrtc.cpp
@@ -34,7 +34,7 @@
 #include "rtc_base/win32.h"
 #endif
 
-namespace livekit {
+namespace livekit_ffi {
 
 static webrtc::Mutex g_mutex{};
 // Can't be atomic, we're using a Mutex because we need to wait for the
@@ -173,4 +173,4 @@ rust::String create_random_uuid() {
   return webrtc::CreateRandomUuid();
 }
 
-}  // namespace livekit
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/webrtc.rs
+++ b/webrtc-sys/src/webrtc.rs
@@ -14,7 +14,7 @@
 
 use crate::impl_thread_safety;
 
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
     #[derive(Debug)]
     #[repr(i32)]

--- a/webrtc-sys/src/yuv_helper.rs
+++ b/webrtc-sys/src/yuv_helper.rs
@@ -14,7 +14,7 @@
 
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::missing_safety_doc)]
-#[cxx::bridge(namespace = "livekit")]
+#[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
     unsafe extern "C++" {
         include!("livekit/yuv_helper.h");


### PR DESCRIPTION
The static library symbols compiled by the internal `livekit::XXXX` namespace will conflict with the link symbols of the public API in the cpp-sdk.  So we need to rename `livekit::` to `livekit_ffi::`.

Since we don't need to expose the FFI bridge (CPP) code and API, renaming it will not cause any side effects.