### PR TITLE
Enable optimizations for release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,11 @@ soxr-sys = { version = "0.1.1", path = "soxr-sys" }
 webrtc-sys = { version = "0.3.20", path = "webrtc-sys" }
 webrtc-sys-build = { version = "0.3.12", path = "webrtc-sys/build" }
 yuv-sys = { version = "0.3.10", path = "yuv-sys" }
+
+[profile.release]
+opt-level = "z"
+lto = true
+codegen-units = 1
+panic = "abort"
+strip = "symbols"
+debug = false


### PR DESCRIPTION
Applies the following optimizations to the release profile with the goal of reducing FFI dylib size:
```toml
[profile.release]
opt-level = "z"
lto = true
codegen-units = 1
panic = "abort"
strip = "symbols"
debug = false
```
Reference: [Profiles](https://doc.rust-lang.org/cargo/reference/profiles.html), The Cargo Book

Initial results: 
- For a local release build on macOS, dylib size shrinks from 33.8MB to 28.1MB.
- Have not evaluated impact on performance yet. Most likely improves, but in some cases enabling optimizations can hurt.

Before merging, we should verify this does not introduce regressions (especially during linking with the C++ SDK).