### PR TITLE
Add Clone derive to Room struct

### DIFF
--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -388,6 +388,7 @@ impl Default for RoomOptions {
     }
 }
 
+#[derive(Clone)]
 pub struct Room {
     inner: Arc<RoomSession>,
 }


### PR DESCRIPTION
I have no idea why, but somehow Clone is not derived for livekit::Room. In general, livekit::Room contains only an Arc, and by default this should safely implement Clone without any issue. If the design is to only let livekit::Room own RoomInner, perhaps using a Box is the better way. 