### PR TITLE
Remove build_node job from ffi-builds workflow

### DIFF
--- a/.github/workflows/ffi-builds.yml
+++ b/.github/workflows/ffi-builds.yml
@@ -209,11 +209,6 @@ jobs:
           name: ffi-builds-${{ matrix.target }}
           path: ${{ matrix.name }}.zip
 
-  build_node:
-    name: Build node bindings
-    runs-on: ubuntu-latest
-    steps:
-
   release:
     name: Release to GH (Draft)
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixed a minor issue introduced in this [commit](https://github.com/livekit/rust-sdks/commit/5c204981fc5bdc59873dec842d2bfab6b27ffbd7) in the release-plz workflow.
This issue resulted in the release version update and logs not being generated for the PR during this period.