### PR TITLE
Use unwind panic for tier III Apple platforms

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,3 +15,23 @@ rustflags = ["-C", "link-args=-ObjC"]
 
 [target.aarch64-apple-ios-sim]
 rustflags = ["-C", "link-args=-ObjC"]
+
+# Settings for building livekit-uniffi
+
+# Use unwind panic for tier III Apple platforms until they
+# become tier II (see rust-lang/rust#151705).
+
+[target.aarch64-apple-tvos]
+rustflags = ["-C", "panic=unwind"]
+
+[target.aarch64-apple-tvos-sim]
+rustflags = ["-C", "panic=unwind"]
+
+[target.x86_64-apple-tvos]
+rustflags = ["-C", "panic=unwind"]
+
+[target.aarch64-apple-visionos]
+rustflags = ["-C", "panic=unwind"]
+
+[target.aarch64-apple-visionos-sim]
+rustflags = ["-C", "panic=unwind"]

--- a/livekit-uniffi/Cargo.toml
+++ b/livekit-uniffi/Cargo.toml
@@ -25,11 +25,3 @@ uniffi = { version = "0.30.0", features = ["build", "scaffolding-ffi-buffer-fns"
 [[bin]]
 name = "uniffi-bindgen"
 path = "bindgen.rs"
-
-[profile.release]
-opt-level = "z"
-lto = true
-codegen-units = 1
-panic = "abort"
-strip = "symbols"
-debug = false


### PR DESCRIPTION
Use unwind panic for tier III Apple platforms when building _livekit-uniffi_. This will no longer be necessary once these platforms become tier II (see rust-lang/rust#151705).