### PR TITLE
Fix missing RTC_OBJC_TYPE macros in webrtc-sys .mm files

### DIFF
--- a/.changeset/fix_missing_rtc_objc_type_macros_in_webrtc_sys_mm_files.md
+++ b/.changeset/fix_missing_rtc_objc_type_macros_in_webrtc_sys_mm_files.md
@@ -1,0 +1,7 @@
+---
+webrtc-sys: patch
+---
+
+# Fix missing RTC_OBJC_TYPE macros in webrtc-sys .mm files
+
+Wrap bare ObjC class references in `RTC_OBJC_TYPE()` in `objc_video_factory.mm` and `objc_video_frame_buffer.mm` to support builds with `rtc_objc_prefix` set.

--- a/webrtc-sys/src/objc_video_factory.mm
+++ b/webrtc-sys/src/objc_video_factory.mm
@@ -25,14 +25,14 @@
 namespace livekit_ffi {
 
 std::unique_ptr<webrtc::VideoEncoderFactory> CreateObjCVideoEncoderFactory() {
-  RTCDefaultVideoEncoderFactory* encoderFactory = [[RTCDefaultVideoEncoderFactory alloc] init];
-  RTCVideoEncoderFactorySimulcast* simulcastFactory =
-      [[RTCVideoEncoderFactorySimulcast alloc] initWithPrimary:encoderFactory fallback:encoderFactory];
+  RTC_OBJC_TYPE(RTCDefaultVideoEncoderFactory)* encoderFactory = [[RTC_OBJC_TYPE(RTCDefaultVideoEncoderFactory) alloc] init];
+  RTC_OBJC_TYPE(RTCVideoEncoderFactorySimulcast)* simulcastFactory =
+      [[RTC_OBJC_TYPE(RTCVideoEncoderFactorySimulcast) alloc] initWithPrimary:encoderFactory fallback:encoderFactory];
   return webrtc::ObjCToNativeVideoEncoderFactory(simulcastFactory);
 }
 
 std::unique_ptr<webrtc::VideoDecoderFactory> CreateObjCVideoDecoderFactory() {
-  return webrtc::ObjCToNativeVideoDecoderFactory([[RTCDefaultVideoDecoderFactory alloc] init]);
+  return webrtc::ObjCToNativeVideoDecoderFactory([[RTC_OBJC_TYPE(RTCDefaultVideoDecoderFactory) alloc] init]);
 }
 
 }  // namespace livekit_ffi

--- a/webrtc-sys/src/objc_video_frame_buffer.mm
+++ b/webrtc-sys/src/objc_video_frame_buffer.mm
@@ -25,7 +25,7 @@ namespace livekit_ffi {
 std::unique_ptr<VideoFrameBuffer> new_native_buffer_from_platform_image_buffer(
     CVPixelBufferRef pixelBuffer
 ) {
-    RTCCVPixelBuffer *buffer = [[RTCCVPixelBuffer alloc] initWithPixelBuffer:pixelBuffer];
+    RTC_OBJC_TYPE(RTCCVPixelBuffer) *buffer = [[RTC_OBJC_TYPE(RTCCVPixelBuffer) alloc] initWithPixelBuffer:pixelBuffer];
     webrtc::scoped_refptr<webrtc::VideoFrameBuffer> frame_buffer = webrtc::ObjCToNativeVideoFrameBuffer(buffer);
     [buffer release];
     CVPixelBufferRelease(pixelBuffer);
@@ -37,8 +37,8 @@ CVPixelBufferRef native_buffer_to_platform_image_buffer(
 ) {
     id<RTC_OBJC_TYPE(RTCVideoFrameBuffer)> rtc_pixel_buffer = webrtc::NativeToObjCVideoFrameBuffer(buffer->get());
 
-    if ([rtc_pixel_buffer isKindOfClass:[RTCCVPixelBuffer class]]) {
-        RTCCVPixelBuffer *cv_pixel_buffer = (RTCCVPixelBuffer *)rtc_pixel_buffer;
+    if ([rtc_pixel_buffer isKindOfClass:[RTC_OBJC_TYPE(RTCCVPixelBuffer) class]]) {
+        RTC_OBJC_TYPE(RTCCVPixelBuffer) *cv_pixel_buffer = (RTC_OBJC_TYPE(RTCCVPixelBuffer) *)rtc_pixel_buffer;
         return [cv_pixel_buffer pixelBuffer];
     } else {
         return nullptr;


### PR DESCRIPTION
`objc_video_factory.mm` and `objc_video_frame_buffer.mm` reference ObjC classes using bare names (`RTCDefaultVideoEncoderFactory`, `RTCVideoEncoderFactorySimulcast`, `RTCDefaultVideoDecoderFactory`, `RTCCVPixelBuffer`).

When using a [custom libwebrtc build](https://github.com/livekit/rust-sdks/tree/main/webrtc-sys/libwebrtc) with `rtc_objc_prefix` set (to avoid ObjC class collisions with other WebRTC copies in the same binary), these classes get renamed but the references in webrtc-sys don't, causing compilation errors against the prefixed headers.

For reference:
`objc_video_frame_buffer.mm` already uses `RTC_OBJC_TYPE(RTCVideoFrameBuffer)` [on line 38](https://github.com/livekit/rust-sdks/pull/355/changes#diff-be5bf3cfefc808f5f07e122015fb7eee1c26a961fc805ecc8780893001ac5912R38), but the other references in the same file and all references in `objc_video_factory.mm` were missed.