### PR TITLE
added rust latency measurement example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "examples/basic_room",
     "examples/basic_text_stream",
     "examples/encrypted_text_stream",
+    "examples/agent_audio_latency",
     "examples/local_audio",
     "examples/local_video",
     "examples/mobile",

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ match event {
 ![](https://github.com/livekit/rust-sdks/blob/main/examples/images/simple-room-demo.gif)
 
 - [basic room](https://github.com/livekit/rust-sdks/tree/main/examples/basic_room): simple example connecting to a room.
+- [agent_audio_latency](https://github.com/livekit/rust-sdks/tree/main/examples/agent_audio_latency): audio-only mic/speaker example for talking to an agent and estimating response latency.
 - [wgpu_room](https://github.com/livekit/rust-sdks/tree/main/examples/wgpu_room): complete example app with video rendering using wgpu and egui.
 - [mobile](https://github.com/livekit/rust-sdks/tree/main/examples/mobile): mobile app targeting iOS and Android
 - [play_from_disk](https://github.com/livekit/rust-sdks/tree/main/examples/play_from_disk): publish audio from a wav file

--- a/examples/agent_audio_latency/Cargo.toml
+++ b/examples/agent_audio_latency/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "agent_audio_latency"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+cpal = "0.15"
+env_logger = { workspace = true }
+futures-util = { workspace = true }
+livekit = { workspace = true, features = ["rustls-tls-native-roots"] }
+livekit-api = { workspace = true, features = ["rustls-tls-native-roots"] }
+log = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/examples/agent_audio_latency/README.md
+++ b/examples/agent_audio_latency/README.md
@@ -1,0 +1,55 @@
+# Agent Audio Latency Example
+
+This example connects to a LiveKit room, publishes microphone audio with `cpal`, plays remote audio back to the default speaker, and optionally injects a short probe tone to estimate agent response latency.
+
+It is audio-only. No video tracks are created.
+
+## What the latency metric means
+
+When `--benchmark` is enabled, the app waits for remote audio to be quiet, injects a short tone burst into the outgoing audio, and measures how long it takes before remote audio becomes active again.
+
+That metric works well for:
+
+- echo / loopback agents
+- agents that immediately answer with speech or audio
+
+It is not a codec-level mouth-to-ear measurement. It is an application-level "probe sent to first remote audio response" estimate.
+
+## Usage
+
+With a pre-minted participant token:
+
+```bash
+cargo run -p agent_audio_latency -- \
+  --url "$LIVEKIT_URL" \
+  --token "$LIVEKIT_TOKEN"
+```
+
+Or mint a token locally:
+
+```bash
+cargo run -p agent_audio_latency -- \
+  --url "$LIVEKIT_URL" \
+  --api-key "$LIVEKIT_API_KEY" \
+  --api-secret "$LIVEKIT_API_SECRET" \
+  --room-name my-room \
+  --identity rust-agent-client
+```
+
+Enable the latency benchmark:
+
+```bash
+cargo run -p agent_audio_latency -- \
+  --url "$LIVEKIT_URL" \
+  --token "$LIVEKIT_TOKEN" \
+  --benchmark
+```
+
+If you only want to listen to a specific agent participant:
+
+```bash
+cargo run -p agent_audio_latency -- \
+  --url "$LIVEKIT_URL" \
+  --token "$LIVEKIT_TOKEN" \
+  --agent-identity my-agent
+```

--- a/examples/agent_audio_latency/src/audio_capture.rs
+++ b/examples/agent_audio_latency/src/audio_capture.rs
@@ -1,0 +1,137 @@
+use crate::latency::TurnLatencyBench;
+use anyhow::{anyhow, Result};
+use cpal::traits::{DeviceTrait, StreamTrait};
+use cpal::{Device, SampleFormat, SizedSample, Stream, StreamConfig};
+use log::{error, info, warn};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+use tokio::sync::mpsc;
+
+pub struct AudioCapture {
+    _stream: Stream,
+    is_running: Arc<AtomicBool>,
+}
+
+impl AudioCapture {
+    pub fn new(
+        device: Device,
+        config: StreamConfig,
+        sample_format: SampleFormat,
+        audio_tx: mpsc::UnboundedSender<Vec<i16>>,
+        channel_index: u32,
+        num_input_channels: u32,
+        benchmark: Option<Arc<Mutex<TurnLatencyBench>>>,
+    ) -> Result<Self> {
+        let is_running = Arc::new(AtomicBool::new(true));
+        let stream = match sample_format {
+            SampleFormat::F32 => Self::create_input_stream::<f32>(
+                device,
+                config,
+                audio_tx,
+                is_running.clone(),
+                channel_index,
+                num_input_channels,
+                benchmark.clone(),
+            )?,
+            SampleFormat::I16 => Self::create_input_stream::<i16>(
+                device,
+                config,
+                audio_tx,
+                is_running.clone(),
+                channel_index,
+                num_input_channels,
+                benchmark.clone(),
+            )?,
+            SampleFormat::U16 => Self::create_input_stream::<u16>(
+                device,
+                config,
+                audio_tx,
+                is_running.clone(),
+                channel_index,
+                num_input_channels,
+                benchmark,
+            )?,
+            other => return Err(anyhow!("unsupported input sample format: {other:?}")),
+        };
+
+        stream.play()?;
+        info!("audio capture stream started");
+
+        Ok(Self { _stream: stream, is_running })
+    }
+
+    fn create_input_stream<T>(
+        device: Device,
+        config: StreamConfig,
+        audio_tx: mpsc::UnboundedSender<Vec<i16>>,
+        is_running: Arc<AtomicBool>,
+        channel_index: u32,
+        num_input_channels: u32,
+        benchmark: Option<Arc<Mutex<TurnLatencyBench>>>,
+    ) -> Result<Stream>
+    where
+        T: SizedSample + Send + 'static,
+    {
+        // cpal runs the microphone callback on the platform's real-time audio thread.
+        // Keep this callback short and non-blocking: push samples into a channel and let
+        // the dedicated uplink runtime handle framing and SDK calls.
+        let stream = device.build_input_stream(
+            &config,
+            move |data: &[T], _: &cpal::InputCallbackInfo| {
+                if !is_running.load(Ordering::Relaxed) {
+                    return;
+                }
+
+                let converted: Vec<i16> = data
+                    .iter()
+                    .skip(channel_index as usize)
+                    .step_by(num_input_channels as usize)
+                    .map(|&sample| convert_sample_to_i16(sample))
+                    .collect();
+
+                if let Some(benchmark) = &benchmark {
+                    // Detect turn-end directly on the capture callback thread. For this
+                    // benchmark, the audio callback timing is more meaningful than a later
+                    // async task wakeup in the networking pipeline.
+                    benchmark.lock().unwrap().observe_user_audio(&converted, config.sample_rate.0);
+                }
+
+                if let Err(err) = audio_tx.send(converted) {
+                    warn!("failed to forward captured audio: {err}");
+                }
+            },
+            move |err| {
+                error!("audio input stream error: {err}");
+            },
+            None,
+        )?;
+
+        Ok(stream)
+    }
+
+    pub fn stop(&self) {
+        self.is_running.store(false, Ordering::Relaxed);
+    }
+}
+
+impl Drop for AudioCapture {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn convert_sample_to_i16<T: SizedSample>(sample: T) -> i16 {
+    if std::mem::size_of::<T>() == std::mem::size_of::<f32>() {
+        let sample_f32 = unsafe { std::mem::transmute_copy::<T, f32>(&sample) };
+        (sample_f32.clamp(-1.0, 1.0) * i16::MAX as f32) as i16
+    } else if std::mem::size_of::<T>() == std::mem::size_of::<i16>() {
+        unsafe { std::mem::transmute_copy::<T, i16>(&sample) }
+    } else if std::mem::size_of::<T>() == std::mem::size_of::<u16>() {
+        let sample_u16 = unsafe { std::mem::transmute_copy::<T, u16>(&sample) };
+        ((sample_u16 as i32) - (u16::MAX as i32 / 2)) as i16
+    } else {
+        0
+    }
+}

--- a/examples/agent_audio_latency/src/audio_mixer.rs
+++ b/examples/agent_audio_latency/src/audio_mixer.rs
@@ -1,0 +1,42 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+pub struct AudioMixer {
+    buffer: Arc<Mutex<VecDeque<i16>>>,
+    volume: f32,
+    max_buffer_size: usize,
+}
+
+impl AudioMixer {
+    pub fn new(sample_rate: u32, channels: u32, volume: f32) -> Self {
+        Self {
+            buffer: Arc::new(Mutex::new(VecDeque::with_capacity(
+                sample_rate as usize * channels as usize,
+            ))),
+            volume: volume.clamp(0.0, 1.0),
+            max_buffer_size: sample_rate as usize * channels as usize,
+        }
+    }
+
+    pub fn add_audio_data(&self, data: &[i16]) {
+        let mut buffer = self.buffer.lock().unwrap();
+        for &sample in data {
+            buffer.push_back((sample as f32 * self.volume) as i16);
+            if buffer.len() > self.max_buffer_size {
+                buffer.pop_front();
+            }
+        }
+    }
+
+    pub fn get_samples(&self, requested_samples: usize) -> Vec<i16> {
+        let mut buffer = self.buffer.lock().unwrap();
+        let mut result = Vec::with_capacity(requested_samples);
+
+        for _ in 0..requested_samples {
+            result.push(buffer.pop_front().unwrap_or(0));
+        }
+
+        result
+    }
+}

--- a/examples/agent_audio_latency/src/audio_playback.rs
+++ b/examples/agent_audio_latency/src/audio_playback.rs
@@ -1,0 +1,122 @@
+use crate::audio_mixer::AudioMixer;
+use crate::latency::TurnLatencyBench;
+use anyhow::{anyhow, Result};
+use cpal::traits::{DeviceTrait, StreamTrait};
+use cpal::{Device, FromSample, Sample, SampleFormat, SizedSample, Stream, StreamConfig};
+use log::{error, info};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+
+pub struct AudioPlayback {
+    _stream: Stream,
+    is_running: Arc<AtomicBool>,
+}
+
+impl AudioPlayback {
+    pub fn new(
+        device: Device,
+        config: StreamConfig,
+        sample_format: SampleFormat,
+        mixer: AudioMixer,
+        benchmark: Option<Arc<Mutex<TurnLatencyBench>>>,
+    ) -> Result<Self> {
+        let is_running = Arc::new(AtomicBool::new(true));
+        let stream = match sample_format {
+            SampleFormat::F32 => Self::create_output_stream::<f32>(
+                device,
+                config,
+                mixer,
+                is_running.clone(),
+                benchmark.clone(),
+            )?,
+            SampleFormat::I16 => Self::create_output_stream::<i16>(
+                device,
+                config,
+                mixer,
+                is_running.clone(),
+                benchmark.clone(),
+            )?,
+            SampleFormat::U16 => Self::create_output_stream::<u16>(
+                device,
+                config,
+                mixer,
+                is_running.clone(),
+                benchmark,
+            )?,
+            other => return Err(anyhow!("unsupported output sample format: {other:?}")),
+        };
+
+        stream.play()?;
+        info!("audio playback stream started");
+
+        Ok(Self { _stream: stream, is_running })
+    }
+
+    fn create_output_stream<T>(
+        device: Device,
+        config: StreamConfig,
+        mixer: AudioMixer,
+        is_running: Arc<AtomicBool>,
+        benchmark: Option<Arc<Mutex<TurnLatencyBench>>>,
+    ) -> Result<Stream>
+    where
+        T: SizedSample + Sample + Send + 'static + FromSample<f32>,
+    {
+        // Speaker rendering also runs on a separate real-time audio thread managed by cpal.
+        // It must not be blocked by network or room-event work, which is why playback pulls
+        // already-mixed samples from shared state instead of awaiting Tokio work here.
+        let stream = device.build_output_stream(
+            &config,
+            move |data: &mut [T], _: &cpal::OutputCallbackInfo| {
+                if !is_running.load(Ordering::Relaxed) {
+                    for sample in data.iter_mut() {
+                        *sample = Sample::from_sample(0.0f32);
+                    }
+                    return;
+                }
+
+                let samples = mixer.get_samples(data.len());
+                if let Some(benchmark) = &benchmark {
+                    // Detect speaker response on the render callback thread so the benchmark
+                    // measures when audio is actually handed to the output device path.
+                    benchmark.lock().unwrap().observe_speaker_audio(&samples, config.sample_rate.0);
+                }
+                for (slot, sample) in data.iter_mut().zip(samples.into_iter()) {
+                    *slot = convert_i16_to_sample::<T>(sample);
+                }
+            },
+            move |err| {
+                error!("audio output stream error: {err}");
+            },
+            None,
+        )?;
+
+        Ok(stream)
+    }
+
+    pub fn stop(&self) {
+        self.is_running.store(false, Ordering::Relaxed);
+    }
+}
+
+impl Drop for AudioPlayback {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn convert_i16_to_sample<T: SizedSample + Sample + FromSample<f32>>(sample: i16) -> T {
+    if std::mem::size_of::<T>() == std::mem::size_of::<f32>() {
+        let sample_f32 = sample as f32 / i16::MAX as f32;
+        unsafe { std::mem::transmute_copy::<f32, T>(&sample_f32) }
+    } else if std::mem::size_of::<T>() == std::mem::size_of::<i16>() {
+        unsafe { std::mem::transmute_copy::<i16, T>(&sample) }
+    } else if std::mem::size_of::<T>() == std::mem::size_of::<u16>() {
+        let sample_u16 = ((sample as i32) + (u16::MAX as i32 / 2)) as u16;
+        unsafe { std::mem::transmute_copy::<u16, T>(&sample_u16) }
+    } else {
+        Sample::from_sample(0.0f32)
+    }
+}

--- a/examples/agent_audio_latency/src/latency.rs
+++ b/examples/agent_audio_latency/src/latency.rs
@@ -1,0 +1,226 @@
+use log::info;
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Debug)]
+pub struct TurnLatencyBenchConfig {
+    pub enabled: bool,
+    pub user_speech_threshold_dbfs: f32,
+    pub user_silence_hold: Duration,
+    pub speaker_speech_threshold_dbfs: f32,
+    pub speaker_confirm_duration: Duration,
+    pub min_user_speech_duration: Duration,
+    pub speaker_gap_tolerance: Duration,
+    pub wait_for_speaker_timeout: Duration,
+}
+
+impl Default for TurnLatencyBenchConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            user_speech_threshold_dbfs: -42.0,
+            user_silence_hold: Duration::from_millis(250),
+            speaker_speech_threshold_dbfs: -38.0,
+            speaker_confirm_duration: Duration::from_millis(300),
+            min_user_speech_duration: Duration::from_millis(350),
+            speaker_gap_tolerance: Duration::from_millis(120),
+            wait_for_speaker_timeout: Duration::from_secs(8),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TurnLatencyBench {
+    config: TurnLatencyBenchConfig,
+    user_is_speaking: bool,
+    user_speech_accum: Duration,
+    user_silence_accum: Duration,
+    waiting_for_speaker: bool,
+    user_speech_end_at: Option<Instant>,
+    speaker_loud_accum: Duration,
+    speaker_quiet_accum: Duration,
+    speaker_segment_start: Option<Instant>,
+    latencies: Vec<Duration>,
+}
+
+impl TurnLatencyBench {
+    pub fn new(config: TurnLatencyBenchConfig) -> Self {
+        Self {
+            config,
+            user_is_speaking: false,
+            user_speech_accum: Duration::ZERO,
+            user_silence_accum: Duration::ZERO,
+            waiting_for_speaker: false,
+            user_speech_end_at: None,
+            speaker_loud_accum: Duration::ZERO,
+            speaker_quiet_accum: Duration::ZERO,
+            speaker_segment_start: None,
+            latencies: Vec::new(),
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.config.enabled
+    }
+
+    pub fn observe_user_audio(&mut self, samples: &[i16], sample_rate: u32) {
+        if !self.config.enabled || samples.is_empty() {
+            return;
+        }
+
+        let level_dbfs = rms_dbfs(samples);
+        let chunk_duration = chunk_duration(samples.len(), sample_rate);
+        let now = Instant::now();
+
+        if level_dbfs >= self.config.user_speech_threshold_dbfs {
+            if self.waiting_for_speaker {
+                // Cancel the pending turn if the user starts speaking again before the
+                // participant responds. This avoids printing repeated false "speech ended"
+                // events while the user is still in the same turn.
+                self.waiting_for_speaker = false;
+                self.user_speech_end_at = None;
+                self.reset_speaker_tracking();
+            }
+
+            self.user_is_speaking = true;
+            self.user_speech_accum += chunk_duration;
+            self.user_silence_accum = Duration::ZERO;
+            return;
+        }
+
+        if !self.user_is_speaking {
+            return;
+        }
+
+        self.user_silence_accum += chunk_duration;
+        if self.user_silence_accum < self.config.user_silence_hold {
+            return;
+        }
+
+        if self.user_speech_accum < self.config.min_user_speech_duration {
+            self.user_is_speaking = false;
+            self.user_speech_accum = Duration::ZERO;
+            self.user_silence_accum = Duration::ZERO;
+            return;
+        }
+
+        self.user_is_speaking = false;
+        self.user_speech_accum = Duration::ZERO;
+        self.user_silence_accum = Duration::ZERO;
+        self.waiting_for_speaker = true;
+        self.user_speech_end_at = Some(now);
+        self.reset_speaker_tracking();
+        info!("benchmark: detected end of user speech");
+    }
+
+    pub fn observe_speaker_audio(&mut self, samples: &[i16], sample_rate: u32) {
+        if !self.config.enabled || !self.waiting_for_speaker || samples.is_empty() {
+            return;
+        }
+
+        let level_dbfs = rms_dbfs(samples);
+        let chunk_duration = chunk_duration(samples.len(), sample_rate);
+        let now = Instant::now();
+        let chunk_start = now.checked_sub(chunk_duration).unwrap_or(now);
+
+        if let Some(user_end) = self.user_speech_end_at {
+            if now.duration_since(user_end) > self.config.wait_for_speaker_timeout {
+                self.waiting_for_speaker = false;
+                self.user_speech_end_at = None;
+                self.reset_speaker_tracking();
+                return;
+            }
+        }
+
+        if level_dbfs < self.config.speaker_speech_threshold_dbfs {
+            if self.speaker_segment_start.is_some() {
+                self.speaker_quiet_accum += chunk_duration;
+                if self.speaker_quiet_accum > self.config.speaker_gap_tolerance {
+                    self.reset_speaker_tracking();
+                }
+            }
+            return;
+        }
+
+        if self.speaker_segment_start.is_none() {
+            self.speaker_segment_start = Some(chunk_start);
+        }
+        self.speaker_quiet_accum = Duration::ZERO;
+        self.speaker_loud_accum += chunk_duration;
+
+        if self.speaker_loud_accum < self.config.speaker_confirm_duration {
+            return;
+        }
+
+        let Some(user_end) = self.user_speech_end_at.take() else {
+            return;
+        };
+        let speaker_start = self.speaker_segment_start.unwrap_or(chunk_start);
+        let latency = speaker_start.saturating_duration_since(user_end);
+        self.latencies.push(latency);
+        self.waiting_for_speaker = false;
+        self.reset_speaker_tracking();
+
+        info!(
+            "benchmark: detected start of speaker audio after user speech end, latency={:.1} ms | {}",
+            latency.as_secs_f64() * 1000.0,
+            self.summary()
+        );
+    }
+
+    fn reset_speaker_tracking(&mut self) {
+        self.speaker_loud_accum = Duration::ZERO;
+        self.speaker_quiet_accum = Duration::ZERO;
+        self.speaker_segment_start = None;
+    }
+
+    fn summary(&self) -> String {
+        if self.latencies.is_empty() {
+            return "n=0".to_string();
+        }
+
+        let mut sorted = self.latencies.clone();
+        sorted.sort_unstable();
+        let min = sorted[0];
+        let max = sorted[sorted.len() - 1];
+        let avg = self.latencies.iter().map(Duration::as_secs_f64).sum::<f64>()
+            / self.latencies.len() as f64;
+        let p50 = percentile(&sorted, 0.50);
+        let p95 = percentile(&sorted, 0.95);
+
+        format!(
+            "n={} avg={:.1}ms p50={:.1}ms p95={:.1}ms min={:.1}ms max={:.1}ms",
+            self.latencies.len(),
+            avg * 1000.0,
+            p50.as_secs_f64() * 1000.0,
+            p95.as_secs_f64() * 1000.0,
+            min.as_secs_f64() * 1000.0,
+            max.as_secs_f64() * 1000.0
+        )
+    }
+}
+
+fn chunk_duration(num_samples: usize, sample_rate: u32) -> Duration {
+    Duration::from_secs_f64(num_samples as f64 / sample_rate as f64)
+}
+
+fn rms_dbfs(samples: &[i16]) -> f32 {
+    let mean_square = samples
+        .iter()
+        .map(|sample| {
+            let normalized = *sample as f32 / i16::MAX as f32;
+            normalized * normalized
+        })
+        .sum::<f32>()
+        / samples.len() as f32;
+
+    if mean_square <= 0.0 {
+        -96.0
+    } else {
+        10.0 * mean_square.log10()
+    }
+}
+
+fn percentile(sorted: &[Duration], q: f64) -> Duration {
+    let index = ((sorted.len().saturating_sub(1)) as f64 * q).round() as usize;
+    sorted[index]
+}

--- a/examples/agent_audio_latency/src/main.rs
+++ b/examples/agent_audio_latency/src/main.rs
@@ -1,0 +1,463 @@
+mod audio_capture;
+mod audio_mixer;
+mod audio_playback;
+mod latency;
+
+use anyhow::{anyhow, Result};
+use audio_capture::AudioCapture;
+use audio_mixer::AudioMixer;
+use audio_playback::AudioPlayback;
+use clap::Parser;
+use cpal::traits::{DeviceTrait, HostTrait};
+use cpal::{Device, SampleRate, StreamConfig};
+use futures_util::StreamExt;
+use latency::{TurnLatencyBench, TurnLatencyBenchConfig};
+use livekit::{
+    options::TrackPublishOptions,
+    track::{LocalAudioTrack, LocalTrack, RemoteTrack, TrackSource},
+    webrtc::{
+        audio_frame::AudioFrame,
+        audio_source::native::NativeAudioSource,
+        audio_stream::native::NativeAudioStream,
+        prelude::{AudioSourceOptions, RtcAudioSource},
+    },
+    Room, RoomEvent, RoomOptions,
+};
+use livekit_api::access_token;
+use log::{debug, info};
+use std::env;
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+
+const SAMPLE_RATE_HZ: u32 = 48_000;
+const CPAL_BUFFER_FRAMES_10MS: u32 = SAMPLE_RATE_HZ / 100;
+
+#[derive(Parser, Debug)]
+#[command(
+    author,
+    version,
+    about = "Audio-only LiveKit client with optional agent latency benchmark"
+)]
+struct Args {
+    #[arg(long)]
+    list_devices: bool,
+
+    #[arg(long)]
+    url: Option<String>,
+
+    #[arg(long)]
+    token: Option<String>,
+
+    #[arg(long)]
+    api_key: Option<String>,
+
+    #[arg(long)]
+    api_secret: Option<String>,
+
+    #[arg(long, default_value = "audio-room")]
+    room_name: String,
+
+    #[arg(long, default_value = "rust-agent-client")]
+    identity: String,
+
+    #[arg(long)]
+    input_device: Option<String>,
+
+    #[arg(long)]
+    output_device: Option<String>,
+
+    #[arg(long, default_value_t = SAMPLE_RATE_HZ)]
+    sample_rate: u32,
+
+    #[arg(long, default_value_t = 0)]
+    channel: u32,
+
+    #[arg(long, default_value_t = 1.0)]
+    volume: f32,
+
+    #[arg(long)]
+    agent_identity: Option<String>,
+
+    #[arg(long)]
+    benchmark: bool,
+
+    #[arg(long, default_value_t = -42.0)]
+    user_speech_threshold_dbfs: f32,
+
+    #[arg(long, default_value_t = 250)]
+    user_silence_hold_ms: u64,
+
+    #[arg(long, default_value_t = -38.0)]
+    speaker_speech_threshold_dbfs: f32,
+
+    #[arg(long, default_value_t = 300)]
+    speaker_confirm_ms: u64,
+}
+
+struct DedicatedRuntime {
+    name: &'static str,
+    handle: tokio::runtime::Handle,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl DedicatedRuntime {
+    fn new(name: &'static str) -> Result<Self> {
+        let (handle_tx, handle_rx) = std::sync::mpsc::sync_channel(1);
+        let thread =
+            thread::Builder::new().name(format!("agent-audio-{name}")).spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("failed to build dedicated tokio runtime");
+                let handle = runtime.handle().clone();
+                let (shutdown_tx, shutdown_rx) = oneshot::channel();
+                handle_tx
+                    .send((handle, shutdown_tx))
+                    .expect("failed to send runtime handle to main thread");
+                runtime.block_on(async move {
+                    let _ = shutdown_rx.await;
+                });
+            })?;
+
+        let (handle, shutdown_tx) = handle_rx
+            .recv()
+            .map_err(|_| anyhow!("failed to receive dedicated runtime handle for {name}"))?;
+
+        Ok(Self { name, handle, shutdown_tx: Some(shutdown_tx), thread: Some(thread) })
+    }
+
+    fn spawn<F>(&self, future: F) -> tokio::task::JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        self.handle.spawn(future)
+    }
+
+    fn shutdown(&mut self) {
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(());
+        }
+        if let Some(thread) = self.thread.take() {
+            if let Err(err) = thread.join() {
+                info!("dedicated runtime thread '{}' exited with error: {:?}", self.name, err);
+            }
+        }
+    }
+}
+
+impl Drop for DedicatedRuntime {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    env_logger::init();
+    let args = Args::parse();
+
+    if args.list_devices {
+        return list_audio_devices();
+    }
+    if !(0.0..=1.0).contains(&args.volume) {
+        return Err(anyhow!("volume must be between 0.0 and 1.0"));
+    }
+
+    let url = args
+        .url
+        .clone()
+        .or_else(|| env::var("LIVEKIT_URL").ok())
+        .ok_or_else(|| anyhow!("missing LiveKit URL, set --url or LIVEKIT_URL"))?;
+    let token = resolve_token(&args)?;
+
+    let host = cpal::default_host();
+    let input_device = select_input_device(&host, args.input_device.as_deref())?;
+    let output_device = select_output_device(&host, args.output_device.as_deref())?;
+    let input_supported_config = input_device.default_input_config()?;
+    let output_supported_config = output_device.default_output_config()?;
+
+    if args.sample_rate != SAMPLE_RATE_HZ {
+        return Err(anyhow!(
+            "this example is tuned for {} Hz real-time audio; got {}",
+            SAMPLE_RATE_HZ,
+            args.sample_rate
+        ));
+    }
+
+    let available_channels = input_supported_config.channels() as u32;
+    if args.channel >= available_channels {
+        return Err(anyhow!(
+            "input channel {} is out of range for device with {} channels",
+            args.channel,
+            available_channels
+        ));
+    }
+
+    let input_name = input_device.name().unwrap_or_else(|_| "unknown".to_string());
+    let output_name = output_device.name().unwrap_or_else(|_| "unknown".to_string());
+    info!("input device: {input_name}");
+    info!("output device: {output_name}");
+
+    let mut room_options = RoomOptions::default();
+    room_options.auto_subscribe = true;
+    let (room, _) = Room::connect(&url, &token, room_options).await?;
+    let room = Arc::new(room);
+    info!("connected to room: {} ({})", room.name(), room.sid().await);
+
+    let latency_bench = Arc::new(Mutex::new(TurnLatencyBench::new(TurnLatencyBenchConfig {
+        enabled: args.benchmark,
+        user_speech_threshold_dbfs: args.user_speech_threshold_dbfs,
+        user_silence_hold: Duration::from_millis(args.user_silence_hold_ms),
+        speaker_speech_threshold_dbfs: args.speaker_speech_threshold_dbfs,
+        speaker_confirm_duration: Duration::from_millis(args.speaker_confirm_ms),
+        ..Default::default()
+    })));
+
+    if latency_bench.lock().unwrap().enabled() {
+        info!(
+            "turn benchmark enabled: user_threshold={}dBFS user_silence={}ms speaker_threshold={}dBFS speaker_confirm={}ms",
+            args.user_speech_threshold_dbfs,
+            args.user_silence_hold_ms,
+            args.speaker_speech_threshold_dbfs,
+            args.speaker_confirm_ms
+        );
+    }
+
+    let livekit_source = NativeAudioSource::new(
+        AudioSourceOptions {
+            echo_cancellation: false,
+            noise_suppression: false,
+            auto_gain_control: false,
+        },
+        args.sample_rate,
+        1,
+        // Fast path for real-time audio: disable the SDK-side queue and push exact 10 ms frames
+        // directly into WebRTC. The uplink loop below already slices microphone data to 10 ms.
+        0,
+    );
+
+    let local_track = LocalAudioTrack::create_audio_track(
+        "microphone",
+        RtcAudioSource::Native(livekit_source.clone()),
+    );
+
+    room.local_participant()
+        .publish_track(
+            LocalTrack::Audio(local_track),
+            TrackPublishOptions { source: TrackSource::Microphone, ..Default::default() },
+        )
+        .await?;
+    info!("published local audio track");
+
+    let mixer = AudioMixer::new(args.sample_rate, 1, args.volume);
+    let (audio_tx, audio_rx) = mpsc::unbounded_channel();
+
+    // Real-time audio is sensitive to scheduler stalls. The microphone uplink path and
+    // the room downlink/playback path each get a dedicated Tokio runtime thread so that
+    // control-plane work or remote-audio processing on one side does not delay the other.
+    let mut uplink_runtime = DedicatedRuntime::new("uplink")?;
+    let mut downlink_runtime = DedicatedRuntime::new("downlink")?;
+
+    let _capture = AudioCapture::new(
+        input_device,
+        StreamConfig {
+            channels: input_supported_config.channels(),
+            sample_rate: SampleRate(args.sample_rate),
+            // Request a 10 ms device buffer to keep capture latency predictable.
+            buffer_size: cpal::BufferSize::Fixed(CPAL_BUFFER_FRAMES_10MS),
+        },
+        input_supported_config.sample_format(),
+        audio_tx,
+        args.channel,
+        available_channels,
+        if args.benchmark { Some(latency_bench.clone()) } else { None },
+    )?;
+
+    let _playback = AudioPlayback::new(
+        output_device,
+        StreamConfig {
+            channels: 1,
+            sample_rate: SampleRate(args.sample_rate),
+            // Match speaker output to the same 10 ms pacing used by capture and WebRTC.
+            buffer_size: cpal::BufferSize::Fixed(CPAL_BUFFER_FRAMES_10MS),
+        },
+        output_supported_config.sample_format(),
+        mixer.clone(),
+        if args.benchmark { Some(latency_bench.clone()) } else { None },
+    )?;
+
+    let uplink_task =
+        uplink_runtime.spawn(stream_audio_to_livekit(audio_rx, livekit_source, args.sample_rate));
+
+    let remote_audio_task = downlink_runtime.spawn(handle_remote_audio(
+        room.clone(),
+        mixer,
+        args.sample_rate,
+        args.agent_identity.clone(),
+    ));
+
+    info!("audio app is running, press Ctrl+C to stop");
+    tokio::signal::ctrl_c().await?;
+    info!("shutting down");
+
+    uplink_task.abort();
+    remote_audio_task.abort();
+    room.close().await?;
+    uplink_runtime.shutdown();
+    downlink_runtime.shutdown();
+    Ok(())
+}
+
+async fn stream_audio_to_livekit(
+    mut audio_rx: mpsc::UnboundedReceiver<Vec<i16>>,
+    livekit_source: NativeAudioSource,
+    sample_rate: u32,
+) -> Result<()> {
+    let mut buffer = Vec::new();
+    let samples_per_10ms = (sample_rate / 100) as usize;
+
+    while let Some(audio_data) = audio_rx.recv().await {
+        buffer.extend_from_slice(&audio_data);
+
+        while buffer.len() >= samples_per_10ms {
+            let chunk: Vec<i16> = buffer.drain(..samples_per_10ms).collect();
+
+            let frame = AudioFrame {
+                data: chunk.into(),
+                sample_rate,
+                num_channels: 1,
+                samples_per_channel: samples_per_10ms as u32,
+            };
+
+            livekit_source.capture_frame(&frame).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn handle_remote_audio(
+    room: Arc<Room>,
+    mixer: AudioMixer,
+    sample_rate: u32,
+    agent_identity: Option<String>,
+) -> Result<()> {
+    let mut room_events = room.subscribe();
+
+    while let Some(event) = room_events.recv().await {
+        match event {
+            RoomEvent::ParticipantConnected(participant) => {
+                info!("participant connected: {}", participant.identity());
+            }
+            RoomEvent::ParticipantDisconnected(participant) => {
+                info!("participant disconnected: {}", participant.identity());
+            }
+            RoomEvent::TrackSubscribed { track, participant, .. } => {
+                if let Some(expected) = agent_identity.as_deref() {
+                    if participant.identity().to_string() != expected {
+                        debug!(
+                            "ignoring remote audio from non-agent participant {}",
+                            participant.identity()
+                        );
+                        continue;
+                    }
+                }
+
+                if let RemoteTrack::Audio(audio_track) = track {
+                    let identity = participant.identity().to_string();
+                    info!("subscribed to remote audio track from {identity}");
+                    let mixer = mixer.clone();
+
+                    tokio::spawn(async move {
+                        let mut stream =
+                            NativeAudioStream::new(audio_track.rtc_track(), sample_rate as i32, 1);
+
+                        while let Some(frame) = stream.next().await {
+                            mixer.add_audio_data(frame.data.as_ref());
+                        }
+
+                        info!("remote audio stream ended for {identity}");
+                    });
+                }
+            }
+            other => {
+                debug!("room event: {other:?}");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn resolve_token(args: &Args) -> Result<String> {
+    if let Some(token) = args.token.clone().or_else(|| env::var("LIVEKIT_TOKEN").ok()) {
+        return Ok(token);
+    }
+
+    let api_key = args
+        .api_key
+        .clone()
+        .or_else(|| env::var("LIVEKIT_API_KEY").ok())
+        .ok_or_else(|| anyhow!("missing token and API key; set --token or --api-key"))?;
+    let api_secret = args
+        .api_secret
+        .clone()
+        .or_else(|| env::var("LIVEKIT_API_SECRET").ok())
+        .ok_or_else(|| anyhow!("missing token and API secret; set --token or --api-secret"))?;
+
+    Ok(access_token::AccessToken::with_api_key(&api_key, &api_secret)
+        .with_identity(&args.identity)
+        .with_name(&args.identity)
+        .with_grants(access_token::VideoGrants {
+            room_join: true,
+            room: args.room_name.clone(),
+            ..Default::default()
+        })
+        .to_jwt()?)
+}
+
+fn list_audio_devices() -> Result<()> {
+    let host = cpal::default_host();
+    println!("Input devices:");
+    for device in host.input_devices()? {
+        let name = device.name().unwrap_or_else(|_| "unknown".to_string());
+        println!("  {name}");
+    }
+    println!("Output devices:");
+    for device in host.output_devices()? {
+        let name = device.name().unwrap_or_else(|_| "unknown".to_string());
+        println!("  {name}");
+    }
+    Ok(())
+}
+
+fn select_input_device(host: &cpal::Host, requested_name: Option<&str>) -> Result<Device> {
+    if let Some(name) = requested_name {
+        return find_device(host.input_devices()?, name, "input");
+    }
+    host.default_input_device().ok_or_else(|| anyhow!("no default input device available"))
+}
+
+fn select_output_device(host: &cpal::Host, requested_name: Option<&str>) -> Result<Device> {
+    if let Some(name) = requested_name {
+        return find_device(host.output_devices()?, name, "output");
+    }
+    host.default_output_device().ok_or_else(|| anyhow!("no default output device available"))
+}
+
+fn find_device(devices: impl Iterator<Item = Device>, needle: &str, kind: &str) -> Result<Device> {
+    for device in devices {
+        if let Ok(name) = device.name() {
+            if name.contains(needle) {
+                return Ok(device);
+            }
+        }
+    }
+    Err(anyhow!("{kind} device containing '{needle}' was not found"))
+}


### PR DESCRIPTION


Setup (Note, replace with your own endpoint and token from "lk token create"  cmd)
export LIVEKIT_URL=wss://xianstaging-hixkk74p.staging.livekit.cloud # Note, change to your own endpoint
export LIVEKIT_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NzYzMjcyMDQsImlkZW50aXR5Ijoic3hpYW4iLCJpc3MiOiJBUElHejJLUXU0UGJ6YkEiLCJuYW1lIjoic3hpYW4iLCJuYmYiOjE3NzAzMjcyMDQsInN1YiI6InN4aWFuIiwidmlkZW8iOnsicm9vbSI6ImNwcCIsInJvb21Kb2luIjp0cnVlfX0.oI0DCLyCMK-y6yxyQ3cFPArGJa03XHeeUrC_t2LUCgU



Rust the test with benchmark and logging:
RUST_LOG=info cargo run -p agent_audio_latency -- \                  
    --url "$LIVEKIT_URL" \
    --token "$LIVEKIT_TOKEN" \
    --benchmark \
    --user-speech-threshold-dbfs=-50 \
    --speaker-speech-threshold-dbfs=-55 \
    --speaker-confirm-ms=120



Run the pure tests without speech latency detection (this will reduce the unnecessary test processing overhead):
RUST_LOG=info cargo run -p agent_audio_latency -- \                  
    --url "$LIVEKIT_URL" \
    --token "$LIVEKIT_TOKEN"