### PR TITLE
Mike/rust latency measurement example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "agent_audio_latency"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "cpal",
+ "env_logger 0.11.8",
+ "futures-util",
+ "livekit",
+ "livekit-api",
+ "log",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "agent_dispatch"
 version = "0.1.0"
 dependencies = [
@@ -633,6 +649,12 @@ dependencies = [
  "rustc-demangle",
  "windows-link",
 ]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -1254,6 +1276,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,6 +1521,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,6 +1593,33 @@ name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "cxx"
@@ -1677,6 +1744,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,6 +1770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1769,6 +1848,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "ecolor"
 version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1777,6 +1870,30 @@ dependencies = [
  "bytemuck",
  "emath",
  "serde",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1882,6 +1999,27 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "emath"
@@ -2110,6 +2248,22 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -2385,6 +2539,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2635,6 +2790,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2733,6 +2899,15 @@ name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -3346,15 +3521,23 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
  "base64 0.22.1",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac",
  "js-sys",
- "ring",
+ "p256",
+ "p384",
+ "rand 0.8.5",
+ "rsa",
  "serde",
  "serde_json",
+ "sha2",
+ "signature",
 ]
 
 [[package]]
@@ -3388,6 +3571,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
@@ -4203,6 +4389,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4225,6 +4427,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -4693,6 +4906,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4802,6 +5039,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4869,6 +5115,27 @@ dependencies = [
  "atomic-waker",
  "fastrand 2.3.0",
  "futures-io",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -4996,6 +5263,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -5522,6 +5798,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5568,6 +5854,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rtc-node-ffi-bindings"
 version = "0.0.1"
 dependencies = [
@@ -5598,6 +5904,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -5829,6 +6144,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5996,6 +6325,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -6173,6 +6512,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "examples/basic_room",
     "examples/basic_text_stream",
     "examples/encrypted_text_stream",
+    "examples/agent_audio_latency",
     "examples/local_audio",
     "examples/local_video",
     "examples/mobile",

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ match event {
 ![](https://github.com/livekit/rust-sdks/blob/main/examples/images/simple-room-demo.gif)
 
 - [basic room](https://github.com/livekit/rust-sdks/tree/main/examples/basic_room): simple example connecting to a room.
+- [agent_audio_latency](https://github.com/livekit/rust-sdks/tree/main/examples/agent_audio_latency): audio-only mic/speaker example for talking to an agent and estimating response latency.
 - [wgpu_room](https://github.com/livekit/rust-sdks/tree/main/examples/wgpu_room): complete example app with video rendering using wgpu and egui.
 - [mobile](https://github.com/livekit/rust-sdks/tree/main/examples/mobile): mobile app targeting iOS and Android
 - [play_from_disk](https://github.com/livekit/rust-sdks/tree/main/examples/play_from_disk): publish audio from a wav file

--- a/examples/agent_audio_latency/Cargo.toml
+++ b/examples/agent_audio_latency/Cargo.toml
@@ -13,4 +13,5 @@ futures-util = { workspace = true }
 livekit = { workspace = true, features = ["rustls-tls-native-roots"] }
 livekit-api = { workspace = true, features = ["rustls-tls-native-roots"] }
 log = { workspace = true }
+rand = "0.8"
 tokio = { workspace = true, features = ["full"] }

--- a/examples/agent_audio_latency/Cargo.toml
+++ b/examples/agent_audio_latency/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "agent_audio_latency"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+cpal = "0.15"
+env_logger = { workspace = true }
+futures-util = { workspace = true }
+livekit = { workspace = true, features = ["rustls-tls-native-roots"] }
+livekit-api = { workspace = true, features = ["rustls-tls-native-roots"] }
+log = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/examples/agent_audio_latency/README.md
+++ b/examples/agent_audio_latency/README.md
@@ -1,0 +1,55 @@
+# Agent Audio Latency Example
+
+This example connects to a LiveKit room, publishes microphone audio with `cpal`, plays remote audio back to the default speaker, and optionally injects a short probe tone to estimate agent response latency.
+
+It is audio-only. No video tracks are created.
+
+## What the latency metric means
+
+When `--benchmark` is enabled, the app waits for remote audio to be quiet, injects a short tone burst into the outgoing audio, and measures how long it takes before remote audio becomes active again.
+
+That metric works well for:
+
+- echo / loopback agents
+- agents that immediately answer with speech or audio
+
+It is not a codec-level mouth-to-ear measurement. It is an application-level "probe sent to first remote audio response" estimate.
+
+## Usage
+
+With a pre-minted participant token:
+
+```bash
+cargo run -p agent_audio_latency -- \
+  --url "$LIVEKIT_URL" \
+  --token "$LIVEKIT_TOKEN"
+```
+
+Or mint a token locally:
+
+```bash
+cargo run -p agent_audio_latency -- \
+  --url "$LIVEKIT_URL" \
+  --api-key "$LIVEKIT_API_KEY" \
+  --api-secret "$LIVEKIT_API_SECRET" \
+  --room-name my-room \
+  --identity rust-agent-client
+```
+
+Enable the latency benchmark:
+
+```bash
+cargo run -p agent_audio_latency -- \
+  --url "$LIVEKIT_URL" \
+  --token "$LIVEKIT_TOKEN" \
+  --benchmark
+```
+
+If you only want to listen to a specific agent participant:
+
+```bash
+cargo run -p agent_audio_latency -- \
+  --url "$LIVEKIT_URL" \
+  --token "$LIVEKIT_TOKEN" \
+  --agent-identity my-agent
+```

--- a/examples/agent_audio_latency/src/audio_capture.rs
+++ b/examples/agent_audio_latency/src/audio_capture.rs
@@ -1,0 +1,137 @@
+use crate::latency::TurnLatencyBench;
+use anyhow::{anyhow, Result};
+use cpal::traits::{DeviceTrait, StreamTrait};
+use cpal::{Device, SampleFormat, SizedSample, Stream, StreamConfig};
+use log::{error, info, warn};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+use tokio::sync::mpsc;
+
+pub struct AudioCapture {
+    _stream: Stream,
+    is_running: Arc<AtomicBool>,
+}
+
+impl AudioCapture {
+    pub fn new(
+        device: Device,
+        config: StreamConfig,
+        sample_format: SampleFormat,
+        audio_tx: mpsc::UnboundedSender<Vec<i16>>,
+        channel_index: u32,
+        num_input_channels: u32,
+        benchmark: Option<Arc<Mutex<TurnLatencyBench>>>,
+    ) -> Result<Self> {
+        let is_running = Arc::new(AtomicBool::new(true));
+        let stream = match sample_format {
+            SampleFormat::F32 => Self::create_input_stream::<f32>(
+                device,
+                config,
+                audio_tx,
+                is_running.clone(),
+                channel_index,
+                num_input_channels,
+                benchmark.clone(),
+            )?,
+            SampleFormat::I16 => Self::create_input_stream::<i16>(
+                device,
+                config,
+                audio_tx,
+                is_running.clone(),
+                channel_index,
+                num_input_channels,
+                benchmark.clone(),
+            )?,
+            SampleFormat::U16 => Self::create_input_stream::<u16>(
+                device,
+                config,
+                audio_tx,
+                is_running.clone(),
+                channel_index,
+                num_input_channels,
+                benchmark,
+            )?,
+            other => return Err(anyhow!("unsupported input sample format: {other:?}")),
+        };
+
+        stream.play()?;
+        info!("audio capture stream started");
+
+        Ok(Self { _stream: stream, is_running })
+    }
+
+    fn create_input_stream<T>(
+        device: Device,
+        config: StreamConfig,
+        audio_tx: mpsc::UnboundedSender<Vec<i16>>,
+        is_running: Arc<AtomicBool>,
+        channel_index: u32,
+        num_input_channels: u32,
+        benchmark: Option<Arc<Mutex<TurnLatencyBench>>>,
+    ) -> Result<Stream>
+    where
+        T: SizedSample + Send + 'static,
+    {
+        // cpal runs the microphone callback on the platform's real-time audio thread.
+        // Keep this callback short and non-blocking: push samples into a channel and let
+        // the dedicated uplink runtime handle framing and SDK calls.
+        let stream = device.build_input_stream(
+            &config,
+            move |data: &[T], _: &cpal::InputCallbackInfo| {
+                if !is_running.load(Ordering::Relaxed) {
+                    return;
+                }
+
+                let converted: Vec<i16> = data
+                    .iter()
+                    .skip(channel_index as usize)
+                    .step_by(num_input_channels as usize)
+                    .map(|&sample| convert_sample_to_i16(sample))
+                    .collect();
+
+                if let Some(benchmark) = &benchmark {
+                    // Detect turn-end directly on the capture callback thread. For this
+                    // benchmark, the audio callback timing is more meaningful than a later
+                    // async task wakeup in the networking pipeline.
+                    benchmark.lock().unwrap().observe_user_audio(&converted, config.sample_rate.0);
+                }
+
+                if let Err(err) = audio_tx.send(converted) {
+                    warn!("failed to forward captured audio: {err}");
+                }
+            },
+            move |err| {
+                error!("audio input stream error: {err}");
+            },
+            None,
+        )?;
+
+        Ok(stream)
+    }
+
+    pub fn stop(&self) {
+        self.is_running.store(false, Ordering::Relaxed);
+    }
+}
+
+impl Drop for AudioCapture {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn convert_sample_to_i16<T: SizedSample>(sample: T) -> i16 {
+    if std::mem::size_of::<T>() == std::mem::size_of::<f32>() {
+        let sample_f32 = unsafe { std::mem::transmute_copy::<T, f32>(&sample) };
+        (sample_f32.clamp(-1.0, 1.0) * i16::MAX as f32) as i16
+    } else if std::mem::size_of::<T>() == std::mem::size_of::<i16>() {
+        unsafe { std::mem::transmute_copy::<T, i16>(&sample) }
+    } else if std::mem::size_of::<T>() == std::mem::size_of::<u16>() {
+        let sample_u16 = unsafe { std::mem::transmute_copy::<T, u16>(&sample) };
+        ((sample_u16 as i32) - (u16::MAX as i32 / 2)) as i16
+    } else {
+        0
+    }
+}

--- a/examples/agent_audio_latency/src/audio_capture.rs
+++ b/examples/agent_audio_latency/src/audio_capture.rs
@@ -1,3 +1,4 @@
+use crate::audio_processing::SharedAudioProcessing;
 use crate::latency::TurnLatencyBench;
 use anyhow::{anyhow, Result};
 use cpal::traits::{DeviceTrait, StreamTrait};
@@ -22,6 +23,7 @@ impl AudioCapture {
         audio_tx: mpsc::UnboundedSender<Vec<i16>>,
         channel_index: u32,
         num_input_channels: u32,
+        apm: Option<Arc<SharedAudioProcessing>>,
         benchmark: Option<Arc<Mutex<TurnLatencyBench>>>,
     ) -> Result<Self> {
         info!("creating audio capture stream");
@@ -35,6 +37,7 @@ impl AudioCapture {
                 is_running.clone(),
                 channel_index,
                 num_input_channels,
+                apm.clone(),
                 benchmark.clone(),
             )?,
             SampleFormat::I16 => Self::create_input_stream::<i16>(
@@ -44,6 +47,7 @@ impl AudioCapture {
                 is_running.clone(),
                 channel_index,
                 num_input_channels,
+                apm.clone(),
                 benchmark.clone(),
             )?,
             SampleFormat::U16 => Self::create_input_stream::<u16>(
@@ -53,6 +57,7 @@ impl AudioCapture {
                 is_running.clone(),
                 channel_index,
                 num_input_channels,
+                apm,
                 benchmark,
             )?,
             other => return Err(anyhow!("unsupported input sample format: {other:?}")),
@@ -72,6 +77,7 @@ impl AudioCapture {
         is_running: Arc<AtomicBool>,
         channel_index: u32,
         num_input_channels: u32,
+        apm: Option<Arc<SharedAudioProcessing>>,
         benchmark: Option<Arc<Mutex<TurnLatencyBench>>>,
     ) -> Result<Stream>
     where
@@ -87,12 +93,18 @@ impl AudioCapture {
                     return;
                 }
 
-                let converted: Vec<i16> = data
+                let mut converted: Vec<i16> = data
                     .iter()
                     .skip(channel_index as usize)
                     .step_by(num_input_channels as usize)
                     .map(|&sample| convert_sample_to_i16(sample))
                     .collect();
+
+                if let Some(apm) = &apm {
+                    // APM forward processing belongs on the capture thread so the mic signal
+                    // is cleaned up before it enters the app's async/network pipeline.
+                    apm.process_capture(&mut converted);
+                }
 
                 if let Some(benchmark) = &benchmark {
                     // Detect turn-end directly on the capture callback thread. For this

--- a/examples/agent_audio_latency/src/audio_capture.rs
+++ b/examples/agent_audio_latency/src/audio_capture.rs
@@ -24,7 +24,9 @@ impl AudioCapture {
         num_input_channels: u32,
         benchmark: Option<Arc<Mutex<TurnLatencyBench>>>,
     ) -> Result<Self> {
+        info!("creating audio capture stream");
         let is_running = Arc::new(AtomicBool::new(true));
+        info!("selected audio input device: {} with config: {:?}, channel: {}, num_input_channels: {}", device.name()?, config, channel_index, num_input_channels);
         let stream = match sample_format {
             SampleFormat::F32 => Self::create_input_stream::<f32>(
                 device,
@@ -56,6 +58,7 @@ impl AudioCapture {
             other => return Err(anyhow!("unsupported input sample format: {other:?}")),
         };
 
+        info!("stream.play()");
         stream.play()?;
         info!("audio capture stream started");
 

--- a/examples/agent_audio_latency/src/audio_mixer.rs
+++ b/examples/agent_audio_latency/src/audio_mixer.rs
@@ -1,0 +1,42 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+pub struct AudioMixer {
+    buffer: Arc<Mutex<VecDeque<i16>>>,
+    volume: f32,
+    max_buffer_size: usize,
+}
+
+impl AudioMixer {
+    pub fn new(sample_rate: u32, channels: u32, volume: f32) -> Self {
+        Self {
+            buffer: Arc::new(Mutex::new(VecDeque::with_capacity(
+                sample_rate as usize * channels as usize,
+            ))),
+            volume: volume.clamp(0.0, 1.0),
+            max_buffer_size: sample_rate as usize * channels as usize,
+        }
+    }
+
+    pub fn add_audio_data(&self, data: &[i16]) {
+        let mut buffer = self.buffer.lock().unwrap();
+        for &sample in data {
+            buffer.push_back((sample as f32 * self.volume) as i16);
+            if buffer.len() > self.max_buffer_size {
+                buffer.pop_front();
+            }
+        }
+    }
+
+    pub fn get_samples(&self, requested_samples: usize) -> Vec<i16> {
+        let mut buffer = self.buffer.lock().unwrap();
+        let mut result = Vec::with_capacity(requested_samples);
+
+        for _ in 0..requested_samples {
+            result.push(buffer.pop_front().unwrap_or(0));
+        }
+
+        result
+    }
+}

--- a/examples/agent_audio_latency/src/audio_playback.rs
+++ b/examples/agent_audio_latency/src/audio_playback.rs
@@ -1,4 +1,5 @@
 use crate::audio_mixer::AudioMixer;
+use crate::audio_processing::SharedAudioProcessing;
 use crate::latency::TurnLatencyBench;
 use anyhow::{anyhow, Result};
 use cpal::traits::{DeviceTrait, StreamTrait};
@@ -20,6 +21,7 @@ impl AudioPlayback {
         config: StreamConfig,
         sample_format: SampleFormat,
         mixer: AudioMixer,
+        apm: Option<Arc<SharedAudioProcessing>>,
         benchmark: Option<Arc<Mutex<TurnLatencyBench>>>,
     ) -> Result<Self> {
         let is_running = Arc::new(AtomicBool::new(true));
@@ -29,6 +31,7 @@ impl AudioPlayback {
                 config,
                 mixer,
                 is_running.clone(),
+                apm.clone(),
                 benchmark.clone(),
             )?,
             SampleFormat::I16 => Self::create_output_stream::<i16>(
@@ -36,6 +39,7 @@ impl AudioPlayback {
                 config,
                 mixer,
                 is_running.clone(),
+                apm.clone(),
                 benchmark.clone(),
             )?,
             SampleFormat::U16 => Self::create_output_stream::<u16>(
@@ -43,6 +47,7 @@ impl AudioPlayback {
                 config,
                 mixer,
                 is_running.clone(),
+                apm,
                 benchmark,
             )?,
             other => return Err(anyhow!("unsupported output sample format: {other:?}")),
@@ -59,6 +64,7 @@ impl AudioPlayback {
         config: StreamConfig,
         mixer: AudioMixer,
         is_running: Arc<AtomicBool>,
+        apm: Option<Arc<SharedAudioProcessing>>,
         benchmark: Option<Arc<Mutex<TurnLatencyBench>>>,
     ) -> Result<Stream>
     where
@@ -77,7 +83,12 @@ impl AudioPlayback {
                     return;
                 }
 
-                let samples = mixer.get_samples(data.len());
+                let mut samples = mixer.get_samples(data.len());
+                if let Some(apm) = &apm {
+                    // APM reverse processing must see the render-side audio so the echo
+                    // canceller can correlate future mic input against what we played.
+                    apm.process_render(&mut samples);
+                }
                 if let Some(benchmark) = &benchmark {
                     // Detect speaker response on the render callback thread so the benchmark
                     // measures when audio is actually handed to the output device path.

--- a/examples/agent_audio_latency/src/audio_playback.rs
+++ b/examples/agent_audio_latency/src/audio_playback.rs
@@ -1,0 +1,122 @@
+use crate::audio_mixer::AudioMixer;
+use crate::latency::TurnLatencyBench;
+use anyhow::{anyhow, Result};
+use cpal::traits::{DeviceTrait, StreamTrait};
+use cpal::{Device, FromSample, Sample, SampleFormat, SizedSample, Stream, StreamConfig};
+use log::{error, info};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+
+pub struct AudioPlayback {
+    _stream: Stream,
+    is_running: Arc<AtomicBool>,
+}
+
+impl AudioPlayback {
+    pub fn new(
+        device: Device,
+        config: StreamConfig,
+        sample_format: SampleFormat,
+        mixer: AudioMixer,
+        benchmark: Option<Arc<Mutex<TurnLatencyBench>>>,
+    ) -> Result<Self> {
+        let is_running = Arc::new(AtomicBool::new(true));
+        let stream = match sample_format {
+            SampleFormat::F32 => Self::create_output_stream::<f32>(
+                device,
+                config,
+                mixer,
+                is_running.clone(),
+                benchmark.clone(),
+            )?,
+            SampleFormat::I16 => Self::create_output_stream::<i16>(
+                device,
+                config,
+                mixer,
+                is_running.clone(),
+                benchmark.clone(),
+            )?,
+            SampleFormat::U16 => Self::create_output_stream::<u16>(
+                device,
+                config,
+                mixer,
+                is_running.clone(),
+                benchmark,
+            )?,
+            other => return Err(anyhow!("unsupported output sample format: {other:?}")),
+        };
+
+        stream.play()?;
+        info!("audio playback stream started");
+
+        Ok(Self { _stream: stream, is_running })
+    }
+
+    fn create_output_stream<T>(
+        device: Device,
+        config: StreamConfig,
+        mixer: AudioMixer,
+        is_running: Arc<AtomicBool>,
+        benchmark: Option<Arc<Mutex<TurnLatencyBench>>>,
+    ) -> Result<Stream>
+    where
+        T: SizedSample + Sample + Send + 'static + FromSample<f32>,
+    {
+        // Speaker rendering also runs on a separate real-time audio thread managed by cpal.
+        // It must not be blocked by network or room-event work, which is why playback pulls
+        // already-mixed samples from shared state instead of awaiting Tokio work here.
+        let stream = device.build_output_stream(
+            &config,
+            move |data: &mut [T], _: &cpal::OutputCallbackInfo| {
+                if !is_running.load(Ordering::Relaxed) {
+                    for sample in data.iter_mut() {
+                        *sample = Sample::from_sample(0.0f32);
+                    }
+                    return;
+                }
+
+                let samples = mixer.get_samples(data.len());
+                if let Some(benchmark) = &benchmark {
+                    // Detect speaker response on the render callback thread so the benchmark
+                    // measures when audio is actually handed to the output device path.
+                    benchmark.lock().unwrap().observe_speaker_audio(&samples, config.sample_rate.0);
+                }
+                for (slot, sample) in data.iter_mut().zip(samples.into_iter()) {
+                    *slot = convert_i16_to_sample::<T>(sample);
+                }
+            },
+            move |err| {
+                error!("audio output stream error: {err}");
+            },
+            None,
+        )?;
+
+        Ok(stream)
+    }
+
+    pub fn stop(&self) {
+        self.is_running.store(false, Ordering::Relaxed);
+    }
+}
+
+impl Drop for AudioPlayback {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn convert_i16_to_sample<T: SizedSample + Sample + FromSample<f32>>(sample: i16) -> T {
+    if std::mem::size_of::<T>() == std::mem::size_of::<f32>() {
+        let sample_f32 = sample as f32 / i16::MAX as f32;
+        unsafe { std::mem::transmute_copy::<f32, T>(&sample_f32) }
+    } else if std::mem::size_of::<T>() == std::mem::size_of::<i16>() {
+        unsafe { std::mem::transmute_copy::<i16, T>(&sample) }
+    } else if std::mem::size_of::<T>() == std::mem::size_of::<u16>() {
+        let sample_u16 = ((sample as i32) + (u16::MAX as i32 / 2)) as u16;
+        unsafe { std::mem::transmute_copy::<u16, T>(&sample_u16) }
+    } else {
+        Sample::from_sample(0.0f32)
+    }
+}

--- a/examples/agent_audio_latency/src/audio_processing.rs
+++ b/examples/agent_audio_latency/src/audio_processing.rs
@@ -1,0 +1,55 @@
+use livekit::webrtc::native::apm::AudioProcessingModule;
+use log::warn;
+use std::sync::Mutex;
+
+const APM_STREAM_DELAY_MS: i32 = 50;
+
+pub struct SharedAudioProcessing {
+    apm: Mutex<AudioProcessingModule>,
+    sample_rate: u32,
+    num_channels: i32,
+}
+
+impl SharedAudioProcessing {
+    pub fn new(sample_rate: u32, num_channels: i32) -> Self {
+        let mut apm = AudioProcessingModule::new(
+            true,  // echo cancellation
+            false, // AGC disabled by request
+            true,  // high-pass filter
+            true,  // noise suppression
+        );
+        if let Err(err) = apm.set_stream_delay_ms(APM_STREAM_DELAY_MS) {
+            warn!("APM set_stream_delay_ms failed: {err}");
+        }
+
+        Self { apm: Mutex::new(apm), sample_rate, num_channels }
+    }
+
+    pub fn process_capture(&self, data: &mut [i16]) {
+        if data.is_empty() {
+            return;
+        }
+
+        if let Err(err) = self.apm.lock().unwrap().process_stream(
+            data,
+            self.sample_rate as i32,
+            self.num_channels,
+        ) {
+            warn!("APM process_stream failed: {err}");
+        }
+    }
+
+    pub fn process_render(&self, data: &mut [i16]) {
+        if data.is_empty() {
+            return;
+        }
+
+        if let Err(err) = self.apm.lock().unwrap().process_reverse_stream(
+            data,
+            self.sample_rate as i32,
+            self.num_channels,
+        ) {
+            warn!("APM process_reverse_stream failed: {err}");
+        }
+    }
+}

--- a/examples/agent_audio_latency/src/latency.rs
+++ b/examples/agent_audio_latency/src/latency.rs
@@ -1,0 +1,226 @@
+use log::info;
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Debug)]
+pub struct TurnLatencyBenchConfig {
+    pub enabled: bool,
+    pub user_speech_threshold_dbfs: f32,
+    pub user_silence_hold: Duration,
+    pub speaker_speech_threshold_dbfs: f32,
+    pub speaker_confirm_duration: Duration,
+    pub min_user_speech_duration: Duration,
+    pub speaker_gap_tolerance: Duration,
+    pub wait_for_speaker_timeout: Duration,
+}
+
+impl Default for TurnLatencyBenchConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            user_speech_threshold_dbfs: -42.0,
+            user_silence_hold: Duration::from_millis(250),
+            speaker_speech_threshold_dbfs: -38.0,
+            speaker_confirm_duration: Duration::from_millis(300),
+            min_user_speech_duration: Duration::from_millis(350),
+            speaker_gap_tolerance: Duration::from_millis(120),
+            wait_for_speaker_timeout: Duration::from_secs(8),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TurnLatencyBench {
+    config: TurnLatencyBenchConfig,
+    user_is_speaking: bool,
+    user_speech_accum: Duration,
+    user_silence_accum: Duration,
+    waiting_for_speaker: bool,
+    user_speech_end_at: Option<Instant>,
+    speaker_loud_accum: Duration,
+    speaker_quiet_accum: Duration,
+    speaker_segment_start: Option<Instant>,
+    latencies: Vec<Duration>,
+}
+
+impl TurnLatencyBench {
+    pub fn new(config: TurnLatencyBenchConfig) -> Self {
+        Self {
+            config,
+            user_is_speaking: false,
+            user_speech_accum: Duration::ZERO,
+            user_silence_accum: Duration::ZERO,
+            waiting_for_speaker: false,
+            user_speech_end_at: None,
+            speaker_loud_accum: Duration::ZERO,
+            speaker_quiet_accum: Duration::ZERO,
+            speaker_segment_start: None,
+            latencies: Vec::new(),
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.config.enabled
+    }
+
+    pub fn observe_user_audio(&mut self, samples: &[i16], sample_rate: u32) {
+        if !self.config.enabled || samples.is_empty() {
+            return;
+        }
+
+        let level_dbfs = rms_dbfs(samples);
+        let chunk_duration = chunk_duration(samples.len(), sample_rate);
+        let now = Instant::now();
+
+        if level_dbfs >= self.config.user_speech_threshold_dbfs {
+            if self.waiting_for_speaker {
+                // Cancel the pending turn if the user starts speaking again before the
+                // participant responds. This avoids printing repeated false "speech ended"
+                // events while the user is still in the same turn.
+                self.waiting_for_speaker = false;
+                self.user_speech_end_at = None;
+                self.reset_speaker_tracking();
+            }
+
+            self.user_is_speaking = true;
+            self.user_speech_accum += chunk_duration;
+            self.user_silence_accum = Duration::ZERO;
+            return;
+        }
+
+        if !self.user_is_speaking {
+            return;
+        }
+
+        self.user_silence_accum += chunk_duration;
+        if self.user_silence_accum < self.config.user_silence_hold {
+            return;
+        }
+
+        if self.user_speech_accum < self.config.min_user_speech_duration {
+            self.user_is_speaking = false;
+            self.user_speech_accum = Duration::ZERO;
+            self.user_silence_accum = Duration::ZERO;
+            return;
+        }
+
+        self.user_is_speaking = false;
+        self.user_speech_accum = Duration::ZERO;
+        self.user_silence_accum = Duration::ZERO;
+        self.waiting_for_speaker = true;
+        self.user_speech_end_at = Some(now);
+        self.reset_speaker_tracking();
+        info!("benchmark: detected end of user speech");
+    }
+
+    pub fn observe_speaker_audio(&mut self, samples: &[i16], sample_rate: u32) {
+        if !self.config.enabled || !self.waiting_for_speaker || samples.is_empty() {
+            return;
+        }
+
+        let level_dbfs = rms_dbfs(samples);
+        let chunk_duration = chunk_duration(samples.len(), sample_rate);
+        let now = Instant::now();
+        let chunk_start = now.checked_sub(chunk_duration).unwrap_or(now);
+
+        if let Some(user_end) = self.user_speech_end_at {
+            if now.duration_since(user_end) > self.config.wait_for_speaker_timeout {
+                self.waiting_for_speaker = false;
+                self.user_speech_end_at = None;
+                self.reset_speaker_tracking();
+                return;
+            }
+        }
+
+        if level_dbfs < self.config.speaker_speech_threshold_dbfs {
+            if self.speaker_segment_start.is_some() {
+                self.speaker_quiet_accum += chunk_duration;
+                if self.speaker_quiet_accum > self.config.speaker_gap_tolerance {
+                    self.reset_speaker_tracking();
+                }
+            }
+            return;
+        }
+
+        if self.speaker_segment_start.is_none() {
+            self.speaker_segment_start = Some(chunk_start);
+        }
+        self.speaker_quiet_accum = Duration::ZERO;
+        self.speaker_loud_accum += chunk_duration;
+
+        if self.speaker_loud_accum < self.config.speaker_confirm_duration {
+            return;
+        }
+
+        let Some(user_end) = self.user_speech_end_at.take() else {
+            return;
+        };
+        let speaker_start = self.speaker_segment_start.unwrap_or(chunk_start);
+        let latency = speaker_start.saturating_duration_since(user_end);
+        self.latencies.push(latency);
+        self.waiting_for_speaker = false;
+        self.reset_speaker_tracking();
+
+        info!(
+            "benchmark: detected start of speaker audio after user speech end, latency={:.1} ms | {}",
+            latency.as_secs_f64() * 1000.0,
+            self.summary()
+        );
+    }
+
+    fn reset_speaker_tracking(&mut self) {
+        self.speaker_loud_accum = Duration::ZERO;
+        self.speaker_quiet_accum = Duration::ZERO;
+        self.speaker_segment_start = None;
+    }
+
+    fn summary(&self) -> String {
+        if self.latencies.is_empty() {
+            return "n=0".to_string();
+        }
+
+        let mut sorted = self.latencies.clone();
+        sorted.sort_unstable();
+        let min = sorted[0];
+        let max = sorted[sorted.len() - 1];
+        let avg = self.latencies.iter().map(Duration::as_secs_f64).sum::<f64>()
+            / self.latencies.len() as f64;
+        let p50 = percentile(&sorted, 0.50);
+        let p95 = percentile(&sorted, 0.95);
+
+        format!(
+            "n={} avg={:.1}ms p50={:.1}ms p95={:.1}ms min={:.1}ms max={:.1}ms",
+            self.latencies.len(),
+            avg * 1000.0,
+            p50.as_secs_f64() * 1000.0,
+            p95.as_secs_f64() * 1000.0,
+            min.as_secs_f64() * 1000.0,
+            max.as_secs_f64() * 1000.0
+        )
+    }
+}
+
+fn chunk_duration(num_samples: usize, sample_rate: u32) -> Duration {
+    Duration::from_secs_f64(num_samples as f64 / sample_rate as f64)
+}
+
+fn rms_dbfs(samples: &[i16]) -> f32 {
+    let mean_square = samples
+        .iter()
+        .map(|sample| {
+            let normalized = *sample as f32 / i16::MAX as f32;
+            normalized * normalized
+        })
+        .sum::<f32>()
+        / samples.len() as f32;
+
+    if mean_square <= 0.0 {
+        -96.0
+    } else {
+        10.0 * mean_square.log10()
+    }
+}
+
+fn percentile(sorted: &[Duration], q: f64) -> Duration {
+    let index = ((sorted.len().saturating_sub(1)) as f64 * q).round() as usize;
+    sorted[index]
+}

--- a/examples/agent_audio_latency/src/latency.rs
+++ b/examples/agent_audio_latency/src/latency.rs
@@ -34,6 +34,7 @@ pub struct TurnLatencyBench {
     user_is_speaking: bool,
     user_speech_accum: Duration,
     user_silence_accum: Duration,
+    user_silence_start_at: Option<Instant>,
     waiting_for_speaker: bool,
     user_speech_end_at: Option<Instant>,
     speaker_loud_accum: Duration,
@@ -49,6 +50,7 @@ impl TurnLatencyBench {
             user_is_speaking: false,
             user_speech_accum: Duration::ZERO,
             user_silence_accum: Duration::ZERO,
+            user_silence_start_at: None,
             waiting_for_speaker: false,
             user_speech_end_at: None,
             speaker_loud_accum: Duration::ZERO,
@@ -70,6 +72,7 @@ impl TurnLatencyBench {
         let level_dbfs = rms_dbfs(samples);
         let chunk_duration = chunk_duration(samples.len(), sample_rate);
         let now = Instant::now();
+        let chunk_start = now.checked_sub(chunk_duration).unwrap_or(now);
 
         if level_dbfs >= self.config.user_speech_threshold_dbfs {
             if self.waiting_for_speaker {
@@ -84,6 +87,7 @@ impl TurnLatencyBench {
             self.user_is_speaking = true;
             self.user_speech_accum += chunk_duration;
             self.user_silence_accum = Duration::ZERO;
+            self.user_silence_start_at = None;
             return;
         }
 
@@ -91,6 +95,9 @@ impl TurnLatencyBench {
             return;
         }
 
+        if self.user_silence_start_at.is_none() {
+            self.user_silence_start_at = Some(chunk_start);
+        }
         self.user_silence_accum += chunk_duration;
         if self.user_silence_accum < self.config.user_silence_hold {
             return;
@@ -107,7 +114,8 @@ impl TurnLatencyBench {
         self.user_speech_accum = Duration::ZERO;
         self.user_silence_accum = Duration::ZERO;
         self.waiting_for_speaker = true;
-        self.user_speech_end_at = Some(now);
+        self.user_speech_end_at = Some(self.user_silence_start_at.unwrap_or(chunk_start));
+        self.user_silence_start_at = None;
         self.reset_speaker_tracking();
         info!("benchmark: detected end of user speech");
     }

--- a/examples/agent_audio_latency/src/main.rs
+++ b/examples/agent_audio_latency/src/main.rs
@@ -25,6 +25,7 @@ use livekit::{
 };
 use livekit_api::access_token;
 use log::{debug, info};
+use rand::Rng;
 use std::env;
 use std::future::Future;
 use std::sync::{Arc, Mutex};
@@ -34,7 +35,21 @@ use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 
 const SAMPLE_RATE_HZ: u32 = 48_000;
-const CPAL_BUFFER_FRAMES_10MS: u32 = SAMPLE_RATE_HZ / 100;
+
+fn generate_random_string(length: usize) -> String {
+    const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
+                             abcdefghijklmnopqrstuvwxyz\
+                             0123456789";
+    let mut rng = rand::thread_rng();
+
+    (0..length)
+        .map(|_| {
+            let idx = rng.gen_range(0..CHARSET.len());
+            CHARSET[idx] as char
+        })
+        .collect()
+}
+
 
 #[derive(Parser, Debug)]
 #[command(
@@ -58,7 +73,7 @@ struct Args {
     #[arg(long)]
     api_secret: Option<String>,
 
-    #[arg(long, default_value = "audio-room")]
+    #[arg(long, default_value = "test-room")]
     room_name: String,
 
     #[arg(long, default_value = "rust-agent-client")]
@@ -182,6 +197,7 @@ async fn main() -> Result<()> {
     let input_supported_config = input_device.default_input_config()?;
     let output_supported_config = output_device.default_output_config()?;
 
+    /*
     if args.sample_rate != SAMPLE_RATE_HZ {
         return Err(anyhow!(
             "this example is tuned for {} Hz real-time audio; got {}",
@@ -189,6 +205,7 @@ async fn main() -> Result<()> {
             args.sample_rate
         ));
     }
+    */
 
     let available_channels = input_supported_config.channels() as u32;
     if args.channel >= available_channels {
@@ -264,13 +281,19 @@ async fn main() -> Result<()> {
     let mut uplink_runtime = DedicatedRuntime::new("uplink")?;
     let mut downlink_runtime = DedicatedRuntime::new("downlink")?;
 
+    let cpal_buffer_frames_10ms: u32 = args.sample_rate / 100;
+    info!("about to start audio capture on device '{}': sample rate: {} Hz, {} channels, channel {}, StreamConfig(channels: {}, sample_rate: {}, buffer_size: Fixed({} frames), format: {}, num_channels: {}",
+        input_name,
+        args.sample_rate, available_channels, args.channel, input_supported_config.channels(),
+        args.sample_rate, cpal_buffer_frames_10ms, input_supported_config.sample_format(),
+        input_supported_config.channels());
     let _capture = AudioCapture::new(
         input_device,
         StreamConfig {
             channels: input_supported_config.channels(),
             sample_rate: SampleRate(args.sample_rate),
             // Request a 10 ms device buffer to keep capture latency predictable.
-            buffer_size: cpal::BufferSize::Fixed(CPAL_BUFFER_FRAMES_10MS),
+            buffer_size: cpal::BufferSize::Fixed(cpal_buffer_frames_10ms),
         },
         input_supported_config.sample_format(),
         audio_tx,
@@ -279,22 +302,25 @@ async fn main() -> Result<()> {
         if args.benchmark { Some(latency_bench.clone()) } else { None },
     )?;
 
+    info!("about to start audio playback");
     let _playback = AudioPlayback::new(
         output_device,
         StreamConfig {
             channels: 1,
             sample_rate: SampleRate(args.sample_rate),
             // Match speaker output to the same 10 ms pacing used by capture and WebRTC.
-            buffer_size: cpal::BufferSize::Fixed(CPAL_BUFFER_FRAMES_10MS),
+            buffer_size: cpal::BufferSize::Fixed(cpal_buffer_frames_10ms),
         },
         output_supported_config.sample_format(),
         mixer.clone(),
         if args.benchmark { Some(latency_bench.clone()) } else { None },
     )?;
 
+    info!("starting uplink to LiveKit task");
     let uplink_task =
         uplink_runtime.spawn(stream_audio_to_livekit(audio_rx, livekit_source, args.sample_rate));
 
+    info!("starting remote audio handling task");
     let remote_audio_task = downlink_runtime.spawn(handle_remote_audio(
         room.clone(),
         mixer,
@@ -411,12 +437,14 @@ fn resolve_token(args: &Args) -> Result<String> {
         .or_else(|| env::var("LIVEKIT_API_SECRET").ok())
         .ok_or_else(|| anyhow!("missing token and API secret; set --token or --api-secret"))?;
 
+    let room_name: String = args.room_name.clone() + "-" + &generate_random_string(8);
+    info!("connnecting to room: {}", room_name);
     Ok(access_token::AccessToken::with_api_key(&api_key, &api_secret)
         .with_identity(&args.identity)
         .with_name(&args.identity)
         .with_grants(access_token::VideoGrants {
             room_join: true,
-            room: args.room_name.clone(),
+            room: room_name,
             ..Default::default()
         })
         .to_jwt()?)

--- a/examples/agent_audio_latency/src/main.rs
+++ b/examples/agent_audio_latency/src/main.rs
@@ -1,0 +1,463 @@
+mod audio_capture;
+mod audio_mixer;
+mod audio_playback;
+mod latency;
+
+use anyhow::{anyhow, Result};
+use audio_capture::AudioCapture;
+use audio_mixer::AudioMixer;
+use audio_playback::AudioPlayback;
+use clap::Parser;
+use cpal::traits::{DeviceTrait, HostTrait};
+use cpal::{Device, SampleRate, StreamConfig};
+use futures_util::StreamExt;
+use latency::{TurnLatencyBench, TurnLatencyBenchConfig};
+use livekit::{
+    options::TrackPublishOptions,
+    track::{LocalAudioTrack, LocalTrack, RemoteTrack, TrackSource},
+    webrtc::{
+        audio_frame::AudioFrame,
+        audio_source::native::NativeAudioSource,
+        audio_stream::native::NativeAudioStream,
+        prelude::{AudioSourceOptions, RtcAudioSource},
+    },
+    Room, RoomEvent, RoomOptions,
+};
+use livekit_api::access_token;
+use log::{debug, info};
+use std::env;
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+
+const SAMPLE_RATE_HZ: u32 = 48_000;
+const CPAL_BUFFER_FRAMES_10MS: u32 = SAMPLE_RATE_HZ / 100;
+
+#[derive(Parser, Debug)]
+#[command(
+    author,
+    version,
+    about = "Audio-only LiveKit client with optional agent latency benchmark"
+)]
+struct Args {
+    #[arg(long)]
+    list_devices: bool,
+
+    #[arg(long)]
+    url: Option<String>,
+
+    #[arg(long)]
+    token: Option<String>,
+
+    #[arg(long)]
+    api_key: Option<String>,
+
+    #[arg(long)]
+    api_secret: Option<String>,
+
+    #[arg(long, default_value = "audio-room")]
+    room_name: String,
+
+    #[arg(long, default_value = "rust-agent-client")]
+    identity: String,
+
+    #[arg(long)]
+    input_device: Option<String>,
+
+    #[arg(long)]
+    output_device: Option<String>,
+
+    #[arg(long, default_value_t = SAMPLE_RATE_HZ)]
+    sample_rate: u32,
+
+    #[arg(long, default_value_t = 0)]
+    channel: u32,
+
+    #[arg(long, default_value_t = 1.0)]
+    volume: f32,
+
+    #[arg(long)]
+    agent_identity: Option<String>,
+
+    #[arg(long)]
+    benchmark: bool,
+
+    #[arg(long, default_value_t = -42.0)]
+    user_speech_threshold_dbfs: f32,
+
+    #[arg(long, default_value_t = 250)]
+    user_silence_hold_ms: u64,
+
+    #[arg(long, default_value_t = -38.0)]
+    speaker_speech_threshold_dbfs: f32,
+
+    #[arg(long, default_value_t = 300)]
+    speaker_confirm_ms: u64,
+}
+
+struct DedicatedRuntime {
+    name: &'static str,
+    handle: tokio::runtime::Handle,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl DedicatedRuntime {
+    fn new(name: &'static str) -> Result<Self> {
+        let (handle_tx, handle_rx) = std::sync::mpsc::sync_channel(1);
+        let thread =
+            thread::Builder::new().name(format!("agent-audio-{name}")).spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("failed to build dedicated tokio runtime");
+                let handle = runtime.handle().clone();
+                let (shutdown_tx, shutdown_rx) = oneshot::channel();
+                handle_tx
+                    .send((handle, shutdown_tx))
+                    .expect("failed to send runtime handle to main thread");
+                runtime.block_on(async move {
+                    let _ = shutdown_rx.await;
+                });
+            })?;
+
+        let (handle, shutdown_tx) = handle_rx
+            .recv()
+            .map_err(|_| anyhow!("failed to receive dedicated runtime handle for {name}"))?;
+
+        Ok(Self { name, handle, shutdown_tx: Some(shutdown_tx), thread: Some(thread) })
+    }
+
+    fn spawn<F>(&self, future: F) -> tokio::task::JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        self.handle.spawn(future)
+    }
+
+    fn shutdown(&mut self) {
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(());
+        }
+        if let Some(thread) = self.thread.take() {
+            if let Err(err) = thread.join() {
+                info!("dedicated runtime thread '{}' exited with error: {:?}", self.name, err);
+            }
+        }
+    }
+}
+
+impl Drop for DedicatedRuntime {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    env_logger::init();
+    let args = Args::parse();
+
+    if args.list_devices {
+        return list_audio_devices();
+    }
+    if !(0.0..=1.0).contains(&args.volume) {
+        return Err(anyhow!("volume must be between 0.0 and 1.0"));
+    }
+
+    let url = args
+        .url
+        .clone()
+        .or_else(|| env::var("LIVEKIT_URL").ok())
+        .ok_or_else(|| anyhow!("missing LiveKit URL, set --url or LIVEKIT_URL"))?;
+    let token = resolve_token(&args)?;
+
+    let host = cpal::default_host();
+    let input_device = select_input_device(&host, args.input_device.as_deref())?;
+    let output_device = select_output_device(&host, args.output_device.as_deref())?;
+    let input_supported_config = input_device.default_input_config()?;
+    let output_supported_config = output_device.default_output_config()?;
+
+    if args.sample_rate != SAMPLE_RATE_HZ {
+        return Err(anyhow!(
+            "this example is tuned for {} Hz real-time audio; got {}",
+            SAMPLE_RATE_HZ,
+            args.sample_rate
+        ));
+    }
+
+    let available_channels = input_supported_config.channels() as u32;
+    if args.channel >= available_channels {
+        return Err(anyhow!(
+            "input channel {} is out of range for device with {} channels",
+            args.channel,
+            available_channels
+        ));
+    }
+
+    let input_name = input_device.name().unwrap_or_else(|_| "unknown".to_string());
+    let output_name = output_device.name().unwrap_or_else(|_| "unknown".to_string());
+    info!("input device: {input_name}");
+    info!("output device: {output_name}");
+
+    let mut room_options = RoomOptions::default();
+    room_options.auto_subscribe = true;
+    let (room, _) = Room::connect(&url, &token, room_options).await?;
+    let room = Arc::new(room);
+    info!("connected to room: {} ({})", room.name(), room.sid().await);
+
+    let latency_bench = Arc::new(Mutex::new(TurnLatencyBench::new(TurnLatencyBenchConfig {
+        enabled: args.benchmark,
+        user_speech_threshold_dbfs: args.user_speech_threshold_dbfs,
+        user_silence_hold: Duration::from_millis(args.user_silence_hold_ms),
+        speaker_speech_threshold_dbfs: args.speaker_speech_threshold_dbfs,
+        speaker_confirm_duration: Duration::from_millis(args.speaker_confirm_ms),
+        ..Default::default()
+    })));
+
+    if latency_bench.lock().unwrap().enabled() {
+        info!(
+            "turn benchmark enabled: user_threshold={}dBFS user_silence={}ms speaker_threshold={}dBFS speaker_confirm={}ms",
+            args.user_speech_threshold_dbfs,
+            args.user_silence_hold_ms,
+            args.speaker_speech_threshold_dbfs,
+            args.speaker_confirm_ms
+        );
+    }
+
+    let livekit_source = NativeAudioSource::new(
+        AudioSourceOptions {
+            echo_cancellation: false,
+            noise_suppression: false,
+            auto_gain_control: false,
+        },
+        args.sample_rate,
+        1,
+        // Fast path for real-time audio: disable the SDK-side queue and push exact 10 ms frames
+        // directly into WebRTC. The uplink loop below already slices microphone data to 10 ms.
+        0,
+    );
+
+    let local_track = LocalAudioTrack::create_audio_track(
+        "microphone",
+        RtcAudioSource::Native(livekit_source.clone()),
+    );
+
+    room.local_participant()
+        .publish_track(
+            LocalTrack::Audio(local_track),
+            TrackPublishOptions { source: TrackSource::Microphone, ..Default::default() },
+        )
+        .await?;
+    info!("published local audio track");
+
+    let mixer = AudioMixer::new(args.sample_rate, 1, args.volume);
+    let (audio_tx, audio_rx) = mpsc::unbounded_channel();
+
+    // Real-time audio is sensitive to scheduler stalls. The microphone uplink path and
+    // the room downlink/playback path each get a dedicated Tokio runtime thread so that
+    // control-plane work or remote-audio processing on one side does not delay the other.
+    let mut uplink_runtime = DedicatedRuntime::new("uplink")?;
+    let mut downlink_runtime = DedicatedRuntime::new("downlink")?;
+
+    let _capture = AudioCapture::new(
+        input_device,
+        StreamConfig {
+            channels: input_supported_config.channels(),
+            sample_rate: SampleRate(args.sample_rate),
+            // Request a 10 ms device buffer to keep capture latency predictable.
+            buffer_size: cpal::BufferSize::Fixed(CPAL_BUFFER_FRAMES_10MS),
+        },
+        input_supported_config.sample_format(),
+        audio_tx,
+        args.channel,
+        available_channels,
+        if args.benchmark { Some(latency_bench.clone()) } else { None },
+    )?;
+
+    let _playback = AudioPlayback::new(
+        output_device,
+        StreamConfig {
+            channels: 1,
+            sample_rate: SampleRate(args.sample_rate),
+            // Match speaker output to the same 10 ms pacing used by capture and WebRTC.
+            buffer_size: cpal::BufferSize::Fixed(CPAL_BUFFER_FRAMES_10MS),
+        },
+        output_supported_config.sample_format(),
+        mixer.clone(),
+        if args.benchmark { Some(latency_bench.clone()) } else { None },
+    )?;
+
+    let uplink_task =
+        uplink_runtime.spawn(stream_audio_to_livekit(audio_rx, livekit_source, args.sample_rate));
+
+    let remote_audio_task = downlink_runtime.spawn(handle_remote_audio(
+        room.clone(),
+        mixer,
+        args.sample_rate,
+        args.agent_identity.clone(),
+    ));
+
+    info!("audio app is running, press Ctrl+C to stop");
+    tokio::signal::ctrl_c().await?;
+    info!("shutting down");
+
+    uplink_task.abort();
+    remote_audio_task.abort();
+    room.close().await?;
+    uplink_runtime.shutdown();
+    downlink_runtime.shutdown();
+    Ok(())
+}
+
+async fn stream_audio_to_livekit(
+    mut audio_rx: mpsc::UnboundedReceiver<Vec<i16>>,
+    livekit_source: NativeAudioSource,
+    sample_rate: u32,
+) -> Result<()> {
+    let mut buffer = Vec::new();
+    let samples_per_10ms = (sample_rate / 100) as usize;
+
+    while let Some(audio_data) = audio_rx.recv().await {
+        buffer.extend_from_slice(&audio_data);
+
+        while buffer.len() >= samples_per_10ms {
+            let chunk: Vec<i16> = buffer.drain(..samples_per_10ms).collect();
+
+            let frame = AudioFrame {
+                data: chunk.into(),
+                sample_rate,
+                num_channels: 1,
+                samples_per_channel: samples_per_10ms as u32,
+            };
+
+            livekit_source.capture_frame(&frame).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn handle_remote_audio(
+    room: Arc<Room>,
+    mixer: AudioMixer,
+    sample_rate: u32,
+    agent_identity: Option<String>,
+) -> Result<()> {
+    let mut room_events = room.subscribe();
+
+    while let Some(event) = room_events.recv().await {
+        match event {
+            RoomEvent::ParticipantConnected(participant) => {
+                info!("participant connected: {}", participant.identity());
+            }
+            RoomEvent::ParticipantDisconnected(participant) => {
+                info!("participant disconnected: {}", participant.identity());
+            }
+            RoomEvent::TrackSubscribed { track, participant, .. } => {
+                if let Some(expected) = agent_identity.as_deref() {
+                    if participant.identity().to_string() != expected {
+                        debug!(
+                            "ignoring remote audio from non-agent participant {}",
+                            participant.identity()
+                        );
+                        continue;
+                    }
+                }
+
+                if let RemoteTrack::Audio(audio_track) = track {
+                    let identity = participant.identity().to_string();
+                    info!("subscribed to remote audio track from {identity}");
+                    let mixer = mixer.clone();
+
+                    tokio::spawn(async move {
+                        let mut stream =
+                            NativeAudioStream::new(audio_track.rtc_track(), sample_rate as i32, 1);
+
+                        while let Some(frame) = stream.next().await {
+                            mixer.add_audio_data(frame.data.as_ref());
+                        }
+
+                        info!("remote audio stream ended for {identity}");
+                    });
+                }
+            }
+            other => {
+                debug!("room event: {other:?}");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn resolve_token(args: &Args) -> Result<String> {
+    if let Some(token) = args.token.clone().or_else(|| env::var("LIVEKIT_TOKEN").ok()) {
+        return Ok(token);
+    }
+
+    let api_key = args
+        .api_key
+        .clone()
+        .or_else(|| env::var("LIVEKIT_API_KEY").ok())
+        .ok_or_else(|| anyhow!("missing token and API key; set --token or --api-key"))?;
+    let api_secret = args
+        .api_secret
+        .clone()
+        .or_else(|| env::var("LIVEKIT_API_SECRET").ok())
+        .ok_or_else(|| anyhow!("missing token and API secret; set --token or --api-secret"))?;
+
+    Ok(access_token::AccessToken::with_api_key(&api_key, &api_secret)
+        .with_identity(&args.identity)
+        .with_name(&args.identity)
+        .with_grants(access_token::VideoGrants {
+            room_join: true,
+            room: args.room_name.clone(),
+            ..Default::default()
+        })
+        .to_jwt()?)
+}
+
+fn list_audio_devices() -> Result<()> {
+    let host = cpal::default_host();
+    println!("Input devices:");
+    for device in host.input_devices()? {
+        let name = device.name().unwrap_or_else(|_| "unknown".to_string());
+        println!("  {name}");
+    }
+    println!("Output devices:");
+    for device in host.output_devices()? {
+        let name = device.name().unwrap_or_else(|_| "unknown".to_string());
+        println!("  {name}");
+    }
+    Ok(())
+}
+
+fn select_input_device(host: &cpal::Host, requested_name: Option<&str>) -> Result<Device> {
+    if let Some(name) = requested_name {
+        return find_device(host.input_devices()?, name, "input");
+    }
+    host.default_input_device().ok_or_else(|| anyhow!("no default input device available"))
+}
+
+fn select_output_device(host: &cpal::Host, requested_name: Option<&str>) -> Result<Device> {
+    if let Some(name) = requested_name {
+        return find_device(host.output_devices()?, name, "output");
+    }
+    host.default_output_device().ok_or_else(|| anyhow!("no default output device available"))
+}
+
+fn find_device(devices: impl Iterator<Item = Device>, needle: &str, kind: &str) -> Result<Device> {
+    for device in devices {
+        if let Ok(name) = device.name() {
+            if name.contains(needle) {
+                return Ok(device);
+            }
+        }
+    }
+    Err(anyhow!("{kind} device containing '{needle}' was not found"))
+}

--- a/examples/agent_audio_latency/src/main.rs
+++ b/examples/agent_audio_latency/src/main.rs
@@ -1,12 +1,14 @@
 mod audio_capture;
 mod audio_mixer;
 mod audio_playback;
+mod audio_processing;
 mod latency;
 
 use anyhow::{anyhow, Result};
 use audio_capture::AudioCapture;
 use audio_mixer::AudioMixer;
 use audio_playback::AudioPlayback;
+use audio_processing::SharedAudioProcessing;
 use clap::Parser;
 use cpal::traits::{DeviceTrait, HostTrait};
 use cpal::{Device, SampleRate, StreamConfig};
@@ -49,7 +51,6 @@ fn generate_random_string(length: usize) -> String {
         })
         .collect()
 }
-
 
 #[derive(Parser, Debug)]
 #[command(
@@ -274,6 +275,7 @@ async fn main() -> Result<()> {
 
     let mixer = AudioMixer::new(args.sample_rate, 1, args.volume);
     let (audio_tx, audio_rx) = mpsc::unbounded_channel();
+    let apm = Arc::new(SharedAudioProcessing::new(args.sample_rate, 1));
 
     // Real-time audio is sensitive to scheduler stalls. The microphone uplink path and
     // the room downlink/playback path each get a dedicated Tokio runtime thread so that
@@ -299,6 +301,7 @@ async fn main() -> Result<()> {
         audio_tx,
         args.channel,
         available_channels,
+        Some(apm.clone()),
         if args.benchmark { Some(latency_bench.clone()) } else { None },
     )?;
 
@@ -313,6 +316,7 @@ async fn main() -> Result<()> {
         },
         output_supported_config.sample_format(),
         mixer.clone(),
+        Some(apm),
         if args.benchmark { Some(latency_bench.clone()) } else { None },
     )?;
 


### PR DESCRIPTION
Setup (Note, replace with your own endpoint and token from "lk token create" cmd)
export LIVEKIT_URL=wss://xianstaging-hixkk74p.staging.livekit.cloud # Note, change to your own endpoint
export LIVEKIT_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NzYzMjcyMDQsImlkZW50aXR5Ijoic3hpYW4iLCJpc3MiOiJBUElHejJLUXU0UGJ6YkEiLCJuYW1lIjoic3hpYW4iLCJuYmYiOjE3NzAzMjcyMDQsInN1YiI6InN4aWFuIiwidmlkZW8iOnsicm9vbSI6ImNwcCIsInJvb21Kb2luIjp0cnVlfX0.oI0DCLyCMK-y6yxyQ3cFPArGJa03XHeeUrC_t2LUCgU

Rust the test with benchmark and logging:
RUST_LOG=info cargo run -p agent_audio_latency -- \
--url "$LIVEKIT_URL"
--token "$LIVEKIT_TOKEN"
--benchmark
--user-speech-threshold-dbfs=-50
--speaker-speech-threshold-dbfs=-55
--speaker-confirm-ms=120

Run the pure tests without speech latency detection (this will reduce the unnecessary test processing overhead):
RUST_LOG=info cargo run -p agent_audio_latency -- \
--url "$LIVEKIT_URL"
--token "$LIVEKIT_TOKEN"