### PR TITLE
fix(webrtc-sys): replace __sF with POSIX fdopen for NDK 28+

### DIFF
--- a/webrtc-sys/src/android.cpp
+++ b/webrtc-sys/src/android.cpp
@@ -18,6 +18,7 @@
 
 #include <jni.h>
 #include <stdio.h>
+#include <unistd.h>
 #include <memory>
 
 #include "api/video_codecs/video_decoder_factory.h"
@@ -27,14 +28,16 @@
 #include "sdk/android/native_api/jni/scoped_java_ref.h"
 #include "sdk/android/src/jni/jni_helpers.h"
 
-// When we compiling the examples app on Android results in errors
-// indicating that the `stderr` and `stdout` symbols cannot be found; 
-// so we need to force hardcoding them to point to the system symbols.
+// When compiling the examples app on Android, the linker complains that
+// `stdout` and `stderr` symbols cannot be found. The previous workaround
+// referenced `__sF`, but that symbol was removed in NDK 28+.
+// Use POSIX `fdopen()` with the standard file descriptors instead — works
+// across all NDK versions.
 #undef stdout
-FILE *stdout = &__sF[1];
+FILE *stdout = fdopen(STDOUT_FILENO, "w");
 
 #undef stderr
-FILE *stderr = &__sF[2];
+FILE *stderr = fdopen(STDERR_FILENO, "w");
 
 namespace livekit_ffi {
 


### PR DESCRIPTION
## Problem

`webrtc-sys/src/android.cpp` references `__sF`, a libc internal symbol that was removed in Android NDK 28. This causes compilation errors when building with NDK 28 or 29:

```
src/android.cpp:34:17: error: use of undeclared identifier '__sF'
   34 | FILE *stdout = &__sF[1];
src/android.cpp:37:17: error: use of undeclared identifier '__sF'
   37 | FILE *stderr = &__sF[2];
```

## Fix

Replace the `__sF` references with POSIX `fdopen(STDOUT_FILENO, ...)` and `fdopen(STDERR_FILENO, ...)`. This:
- Works across all NDK versions (no internal libc symbols)
- Achieves the same goal: providing `stdout`/`stderr` symbols when WebRTC examples need them
- Uses standard POSIX APIs

## Tested

Builds successfully with NDK 28.0.12916984 and NDK 29.0.14206865 targeting `aarch64-linux-android`.

Closes #992