### PR TITLE
Revert patch fix versioning for consistent ffi-versions

### DIFF
--- a/livekit-ffi-node-bindings/npm/darwin-arm64/package.json
+++ b/livekit-ffi-node-bindings/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livekit/rtc-ffi-bindings-darwin-arm64",
-  "version": "0.12.52-patch.0",
+  "version": "0.12.52",
   "cpu": [
     "arm64"
   ],

--- a/livekit-ffi-node-bindings/npm/darwin-x64/package.json
+++ b/livekit-ffi-node-bindings/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livekit/rtc-ffi-bindings-darwin-x64",
-  "version": "0.12.52-patch.0",
+  "version": "0.12.52",
   "cpu": [
     "x64"
   ],

--- a/livekit-ffi-node-bindings/npm/linux-arm64-gnu/package.json
+++ b/livekit-ffi-node-bindings/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livekit/rtc-ffi-bindings-linux-arm64-gnu",
-  "version": "0.12.52-patch.0",
+  "version": "0.12.52",
   "cpu": [
     "arm64"
   ],

--- a/livekit-ffi-node-bindings/npm/linux-x64-gnu/package.json
+++ b/livekit-ffi-node-bindings/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livekit/rtc-ffi-bindings-linux-x64-gnu",
-  "version": "0.12.52-patch.0",
+  "version": "0.12.52",
   "cpu": [
     "x64"
   ],

--- a/livekit-ffi-node-bindings/npm/win32-x64-msvc/package.json
+++ b/livekit-ffi-node-bindings/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livekit/rtc-ffi-bindings-win32-x64-msvc",
-  "version": "0.12.52-patch.0",
+  "version": "0.12.52",
   "cpu": [
     "x64"
   ],

--- a/livekit-ffi-node-bindings/package.json
+++ b/livekit-ffi-node-bindings/package.json
@@ -3,7 +3,7 @@
   "description": "LiveKit RTC Node FFI bindings for internal use only",
   "license": "Apache-2.0",
   "author": "LiveKit",
-  "version": "0.12.52-patch.0",
+  "version": "0.12.52",
   "main": "index.js",
   "types": "index.d.ts",
   "type": "commonjs",


### PR DESCRIPTION
knope bot appears to not run on the repo since we did this intermediate patch fix for the node bindings. 
running `knope --validate` showed that all versions have to be the same for a particular package, which makes sense. 