### PR TITLE
Add dynacast support

### DIFF
--- a/.changeset/add_dynacast_support.md
+++ b/.changeset/add_dynacast_support.md
@@ -1,0 +1,7 @@
+---
+libwebrtc: patch
+livekit: patch
+livekit-ffi: patch
+---
+
+Add dynacast support - #1003 (@chenosaurus)

--- a/.changeset/add_dynacast_support.md
+++ b/.changeset/add_dynacast_support.md
@@ -1,7 +1,11 @@
 ---
-libwebrtc: patch
+libwebrtc: minor
 livekit: patch
 livekit-ffi: patch
 ---
 
 Add dynacast support - #1003 (@chenosaurus, @stephen-derosa)
+
+This includes a minor breaking change for `libwebrtc`: `RtpParameters` now
+contains additional RTP sender state that must be preserved when round-tripping
+through `set_parameters()`.

--- a/.changeset/add_dynacast_support.md
+++ b/.changeset/add_dynacast_support.md
@@ -4,4 +4,4 @@ livekit: patch
 livekit-ffi: patch
 ---
 
-Add dynacast support - #1003 (@chenosaurus)
+Add dynacast support - #1003 (@chenosaurus, @stephen-derosa)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Use this SDK to add realtime video, audio and data features to your Rust app. By
 - [x] Simulcast
 - [x] SVC codecs (AV1/VP9)
 - [ ] Adaptive Streaming
-- [ ] Dynacast
+- [x] Dynacast
 - [x] Hardware video enc/dec
   - [x] H.264, H.265 using VideoToolbox (MacOS/iOS)
   - [x] H.264, H.265 on NVidia discrete GPUs (Linux)

--- a/examples/local_video/src/publisher.rs
+++ b/examples/local_video/src/publisher.rs
@@ -75,6 +75,10 @@ struct Args {
     /// Use H.265/HEVC encoding if supported (falls back to H.264 on failure)
     #[arg(long, default_value_t = false)]
     h265: bool,
+
+    /// Enable dynacast (pause unused simulcast layers based on subscriber demand)
+    #[arg(long, default_value_t = false)]
+    dynacast: bool,
 }
 
 fn list_cameras() -> Result<()> {
@@ -137,6 +141,7 @@ async fn run(args: Args, ctrl_c_received: Arc<AtomicBool>) -> Result<()> {
     info!("Connecting to LiveKit room '{}' as '{}'...", args.room_name, args.identity);
     let mut room_options = RoomOptions::default();
     room_options.auto_subscribe = true;
+    room_options.dynacast = args.dynacast;
     let (room, _) = Room::connect(&url, &token, room_options).await?;
     let room = std::sync::Arc::new(room);
     info!("Connected: {} - {}", room.name(), room.sid().await);
@@ -419,11 +424,24 @@ async fn run(args: Args, ctrl_c_received: Arc<AtomicBool>) -> Result<()> {
             let secs = last_fps_log.elapsed().as_secs_f64();
             let fps_est = frames as f64 / secs;
             let n = frames.max(1) as f64;
+            let layers = track.publishing_layers();
+            let layers_str = if layers.is_empty() {
+                "n/a".to_string()
+            } else {
+                layers
+                    .iter()
+                    .map(|(rid, quality, active)| {
+                        format!("{}({})={}", rid, quality, if *active { "ON" } else { "off" })
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
             info!(
-                "Publishing video: {}x{}, ~{:.1} fps | avg ms: get {:.2}, decode {:.2}, convert {:.2}, capture {:.2}, sleep {:.2}, iter {:.2} | target {:.2}",
+                "Publishing video: {}x{}, ~{:.1} fps | layers: [{}] | avg ms: get {:.2}, decode {:.2}, convert {:.2}, capture {:.2}, sleep {:.2}, iter {:.2} | target {:.2}",
                 width,
                 height,
                 fps_est,
+                layers_str,
                 sum_get_ms / n,
                 sum_decode_ms / n,
                 sum_convert_ms / n,

--- a/examples/local_video/src/publisher.rs
+++ b/examples/local_video/src/publisher.rs
@@ -238,6 +238,10 @@ struct Args {
     #[arg(long, default_value_t = false)]
     attach_timestamp: bool,
 
+    /// Enable dynacast (pause unused simulcast layers based on subscriber demand)
+    #[arg(long, default_value_t = false)]
+    dynacast: bool,
+
     /// Burn the attached timestamp into each video frame; does nothing unless --attach-timestamp is also enabled
     #[arg(long, default_value_t = false)]
     burn_timestamp: bool,
@@ -924,8 +928,8 @@ async fn run(args: Args, ctrl_c_received: Arc<AtomicBool>) -> Result<()> {
 
     info!("Connecting to LiveKit room '{}' as '{}'...", args.room_name, args.identity);
     let mut room_options = RoomOptions::default();
-    room_options.auto_subscribe = false;
-    room_options.dynacast = true;
+    room_options.auto_subscribe = true;
+    room_options.dynacast = args.dynacast;
 
     // Configure E2EE if an encryption key is provided
     if let Some(ref e2ee_key) = args.e2ee_key {
@@ -1253,6 +1257,7 @@ async fn run(args: Args, ctrl_c_received: Arc<AtomicBool>) -> Result<()> {
                 let capture_task = tokio::spawn(run_capture_loop(
                     capture_config,
                     ctrl_c_received.clone(),
+                    track.clone(),
                     rtc_source,
                     video_input,
                     width,
@@ -1277,6 +1282,7 @@ async fn run(args: Args, ctrl_c_received: Arc<AtomicBool>) -> Result<()> {
                 let capture_result = run_capture_loop(
                     capture_config,
                     ctrl_c_received,
+                    track,
                     rtc_source,
                     video_input,
                     width,
@@ -1297,6 +1303,7 @@ async fn run(args: Args, ctrl_c_received: Arc<AtomicBool>) -> Result<()> {
 async fn run_capture_loop(
     config: CaptureConfig,
     ctrl_c_received: Arc<AtomicBool>,
+    track: LocalVideoTrack,
     rtc_source: NativeVideoSource,
     mut video_input: VideoInput,
     width: u32,
@@ -1646,11 +1653,29 @@ async fn run_capture_loop(
         if last_fps_log.elapsed() >= std::time::Duration::from_secs(2) {
             let secs = last_fps_log.elapsed().as_secs_f64();
             let fps_est = frames as f64 / secs;
+            let layers = track.publishing_layers();
+            let layers_str = if layers.is_empty() {
+                "n/a".to_string()
+            } else {
+                layers
+                    .iter()
+                    .map(|layer| {
+                        format!(
+                            "{}({})={}",
+                            layer.rid,
+                            layer.quality,
+                            if layer.active { "ON" } else { "off" }
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
             info!(
-                "Video status: {}x{} | ~{:.1} fps | target {:.2} ms",
+                "Video status: {}x{} | ~{:.1} fps | layers: [{}] | target {:.2} ms",
                 width,
                 height,
                 fps_est,
+                layers_str,
                 target.as_secs_f64() * 1000.0,
             );
             info!("{}", format_timing_line(&timings));

--- a/examples/local_video/src/publisher.rs
+++ b/examples/local_video/src/publisher.rs
@@ -1664,7 +1664,7 @@ async fn run_capture_loop(
                             "{}({})={}",
                             layer.rid,
                             layer.quality,
-                            if layer.active { "ON" } else { "off" }
+                            if layer.active { "on" } else { "off" }
                         )
                     })
                     .collect::<Vec<_>>()

--- a/examples/local_video/src/subscriber.rs
+++ b/examples/local_video/src/subscriber.rs
@@ -502,6 +502,7 @@ impl eframe::App for VideoApp {
                         let resp = ui.selectable_label(is_selected, label);
                         if resp.clicked() {
                             if let Some(ref pub_remote) = sc.publication {
+                                info!("Requesting layer: {:?}", q);
                                 pub_remote.set_video_quality(q);
                                 sc.requested_quality = Some(q);
                             }

--- a/examples/local_video/src/subscriber.rs
+++ b/examples/local_video/src/subscriber.rs
@@ -1276,6 +1276,7 @@ impl eframe::App for VideoApp {
                         let resp = ui.selectable_label(is_selected, label);
                         if resp.clicked() {
                             if let Some(ref pub_remote) = sc.publication {
+                                info!("Requesting layer: {:?}", q);
                                 pub_remote.set_video_quality(q);
                                 sc.requested_quality = Some(q);
                             }

--- a/libwebrtc/src/native/rtp_parameters.rs
+++ b/libwebrtc/src/native/rtp_parameters.rs
@@ -39,7 +39,13 @@ impl From<sys_rp::ffi::RtpParameters> for RtpParameters {
         Self {
             codecs: value.codecs.into_iter().map(Into::into).collect(),
             header_extensions: value.header_extensions.into_iter().map(Into::into).collect(),
+            encodings: value.encodings.into_iter().map(Into::into).collect(),
             rtcp: value.rtcp.into(),
+            transaction_id: value.transaction_id,
+            mid: value.mid,
+            has_degradation_preference: value.has_degradation_preference,
+            // Safety: DegradationPreference is #[repr(i32)]
+            degradation_preference: unsafe { std::mem::transmute(value.degradation_preference) },
         }
     }
 }
@@ -51,13 +57,40 @@ impl From<sys_rp::ffi::RtpCodecParameters> for RtpCodecParameters {
             payload_type: value.payload_type as u8,
             clock_rate: value.has_clock_rate.then_some(value.clock_rate as u64),
             channels: value.has_num_channels.then_some(value.num_channels as u16),
+            name: value.name,
+            // Safety: MediaType, RtcpFeedbackType, RtcpFeedbackMessageType are #[repr(i32)]
+            kind: unsafe { std::mem::transmute(value.kind) },
+            has_max_ptime: value.has_max_ptime,
+            max_ptime: value.max_ptime,
+            has_ptime: value.has_ptime,
+            ptime: value.ptime,
+            rtcp_feedback: value
+                .rtcp_feedback
+                .into_iter()
+                .map(|f| CodecFeedback {
+                    feedback_type: unsafe { std::mem::transmute(f.feedback_type) },
+                    has_message_type: f.has_message_type,
+                    message_type: unsafe { std::mem::transmute(f.message_type) },
+                })
+                .collect(),
+            parameters: value
+                .parameters
+                .into_iter()
+                .map(|kv| (kv.key, kv.value))
+                .collect(),
         }
     }
 }
 
 impl From<sys_rp::ffi::RtcpParameters> for RtcpParameters {
     fn from(value: sys_rp::ffi::RtcpParameters) -> Self {
-        Self { cname: value.cname, reduced_size: value.reduced_size }
+        Self {
+            cname: value.cname,
+            reduced_size: value.reduced_size,
+            mux: value.mux,
+            has_ssrc: value.has_ssrc,
+            ssrc: value.ssrc,
+        }
     }
 }
 
@@ -72,6 +105,8 @@ impl From<sys_rp::ffi::RtpEncodingParameters> for RtpEncodingParameters {
             scale_resolution_down_by: value
                 .has_scale_resolution_down_by
                 .then_some(value.scale_resolution_down_by),
+            has_ssrc: value.has_ssrc,
+            ssrc: value.ssrc,
         }
     }
 }
@@ -139,21 +174,26 @@ impl From<RtpHeaderExtensionParameters> for sys_rp::ffi::RtpExtension {
 
 impl From<RtpParameters> for sys_rp::ffi::RtpParameters {
     fn from(value: RtpParameters) -> Self {
+        // Safety: DegradationPreference is #[repr(i32)]
+        let degradation_preference: sys_rp::ffi::DegradationPreference =
+            unsafe { std::mem::transmute(value.degradation_preference) };
         Self {
             codecs: value.codecs.into_iter().map(Into::into).collect(),
             header_extensions: value.header_extensions.into_iter().map(Into::into).collect(),
-            encodings: Vec::new(),
+            encodings: value.encodings.into_iter().map(Into::into).collect(),
             rtcp: value.rtcp.into(),
-            transaction_id: "".to_string(),
-            mid: "".to_string(),
-            has_degradation_preference: false,
-            degradation_preference: sys_rp::ffi::DegradationPreference::Balanced,
+            transaction_id: value.transaction_id,
+            mid: value.mid,
+            has_degradation_preference: value.has_degradation_preference,
+            degradation_preference,
         }
     }
 }
 
 impl From<RtpCodecParameters> for sys_rp::ffi::RtpCodecParameters {
     fn from(value: RtpCodecParameters) -> Self {
+        // Safety: MediaType, RtcpFeedbackType, RtcpFeedbackMessageType are all #[repr(i32)]
+        let kind: sys_webrtc::ffi::MediaType = unsafe { std::mem::transmute(value.kind) };
         Self {
             payload_type: value.payload_type as i32,
             mime_type: value.mime_type,
@@ -161,14 +201,32 @@ impl From<RtpCodecParameters> for sys_rp::ffi::RtpCodecParameters {
             clock_rate: value.clock_rate.unwrap_or_default() as i32,
             has_num_channels: value.channels.is_some(),
             num_channels: value.channels.unwrap_or_default() as i32,
-            name: "".to_string(),
-            kind: sys_rp::ffi::MediaType::Audio,
-            has_max_ptime: false,
-            max_ptime: 0,
-            has_ptime: false,
-            ptime: 0,
-            rtcp_feedback: Vec::new(),
-            parameters: Vec::new(),
+            name: value.name,
+            kind,
+            has_max_ptime: value.has_max_ptime,
+            max_ptime: value.max_ptime,
+            has_ptime: value.has_ptime,
+            ptime: value.ptime,
+            rtcp_feedback: value
+                .rtcp_feedback
+                .into_iter()
+                .map(|f| {
+                    let feedback_type: sys_rp::ffi::RtcpFeedbackType =
+                        unsafe { std::mem::transmute(f.feedback_type) };
+                    let message_type: sys_rp::ffi::RtcpFeedbackMessageType =
+                        unsafe { std::mem::transmute(f.message_type) };
+                    sys_rp::ffi::RtcpFeedback {
+                        feedback_type,
+                        has_message_type: f.has_message_type,
+                        message_type,
+                    }
+                })
+                .collect(),
+            parameters: value
+                .parameters
+                .into_iter()
+                .map(|(key, value)| sys_rp::ffi::StringKeyValue { key, value })
+                .collect(),
         }
     }
 }
@@ -178,9 +236,9 @@ impl From<RtcpParameters> for sys_rp::ffi::RtcpParameters {
         Self {
             cname: value.cname,
             reduced_size: value.reduced_size,
-            has_ssrc: false,
-            ssrc: 0,
-            mux: false,
+            has_ssrc: value.has_ssrc,
+            ssrc: value.ssrc,
+            mux: value.mux,
         }
     }
 }
@@ -205,8 +263,8 @@ impl From<RtpEncodingParameters> for sys_rp::ffi::RtpEncodingParameters {
             num_temporal_layers: 0,
             has_scalability_mode: false,
             scalability_mode: "".to_string(),
-            has_ssrc: false,
-            ssrc: 0,
+            has_ssrc: value.has_ssrc,
+            ssrc: value.ssrc,
         }
     }
 }

--- a/libwebrtc/src/native/rtp_parameters.rs
+++ b/libwebrtc/src/native/rtp_parameters.rs
@@ -73,11 +73,7 @@ impl From<sys_rp::ffi::RtpCodecParameters> for RtpCodecParameters {
                     message_type: unsafe { std::mem::transmute(f.message_type) },
                 })
                 .collect(),
-            parameters: value
-                .parameters
-                .into_iter()
-                .map(|kv| (kv.key, kv.value))
-                .collect(),
+            parameters: value.parameters.into_iter().map(|kv| (kv.key, kv.value)).collect(),
         }
     }
 }

--- a/libwebrtc/src/native/rtp_parameters.rs
+++ b/libwebrtc/src/native/rtp_parameters.rs
@@ -39,7 +39,12 @@ impl From<sys_rp::ffi::RtpParameters> for RtpParameters {
         Self {
             codecs: value.codecs.into_iter().map(Into::into).collect(),
             header_extensions: value.header_extensions.into_iter().map(Into::into).collect(),
+            encodings: value.encodings.into_iter().map(Into::into).collect(),
             rtcp: value.rtcp.into(),
+            transaction_id: value.transaction_id,
+            mid: value.mid,
+            has_degradation_preference: value.has_degradation_preference,
+            degradation_preference: value.degradation_preference.repr,
         }
     }
 }
@@ -51,13 +56,35 @@ impl From<sys_rp::ffi::RtpCodecParameters> for RtpCodecParameters {
             payload_type: value.payload_type as u8,
             clock_rate: value.has_clock_rate.then_some(value.clock_rate as u64),
             channels: value.has_num_channels.then_some(value.num_channels as u16),
+            name: value.name,
+            kind: value.kind.repr,
+            has_max_ptime: value.has_max_ptime,
+            max_ptime: value.max_ptime,
+            has_ptime: value.has_ptime,
+            ptime: value.ptime,
+            rtcp_feedback: value
+                .rtcp_feedback
+                .into_iter()
+                .map(|f| CodecFeedback {
+                    feedback_type: f.feedback_type.repr,
+                    has_message_type: f.has_message_type,
+                    message_type: f.message_type.repr,
+                })
+                .collect(),
+            parameters: value.parameters.into_iter().map(|kv| (kv.key, kv.value)).collect(),
         }
     }
 }
 
 impl From<sys_rp::ffi::RtcpParameters> for RtcpParameters {
     fn from(value: sys_rp::ffi::RtcpParameters) -> Self {
-        Self { cname: value.cname, reduced_size: value.reduced_size }
+        Self {
+            cname: value.cname,
+            reduced_size: value.reduced_size,
+            mux: value.mux,
+            has_ssrc: value.has_ssrc,
+            ssrc: value.ssrc,
+        }
     }
 }
 
@@ -73,6 +100,8 @@ impl From<sys_rp::ffi::RtpEncodingParameters> for RtpEncodingParameters {
                 .has_scale_resolution_down_by
                 .then_some(value.scale_resolution_down_by),
             scalability_mode: value.has_scalability_mode.then_some(value.scalability_mode),
+            has_ssrc: value.has_ssrc,
+            ssrc: value.ssrc,
         }
     }
 }
@@ -140,21 +169,24 @@ impl From<RtpHeaderExtensionParameters> for sys_rp::ffi::RtpExtension {
 
 impl From<RtpParameters> for sys_rp::ffi::RtpParameters {
     fn from(value: RtpParameters) -> Self {
+        let degradation_preference =
+            sys_rp::ffi::DegradationPreference { repr: value.degradation_preference };
         Self {
             codecs: value.codecs.into_iter().map(Into::into).collect(),
             header_extensions: value.header_extensions.into_iter().map(Into::into).collect(),
-            encodings: Vec::new(),
+            encodings: value.encodings.into_iter().map(Into::into).collect(),
             rtcp: value.rtcp.into(),
-            transaction_id: "".to_string(),
-            mid: "".to_string(),
-            has_degradation_preference: false,
-            degradation_preference: sys_rp::ffi::DegradationPreference::Balanced,
+            transaction_id: value.transaction_id,
+            mid: value.mid,
+            has_degradation_preference: value.has_degradation_preference,
+            degradation_preference,
         }
     }
 }
 
 impl From<RtpCodecParameters> for sys_rp::ffi::RtpCodecParameters {
     fn from(value: RtpCodecParameters) -> Self {
+        let kind = sys_webrtc::ffi::MediaType { repr: value.kind };
         Self {
             payload_type: value.payload_type as i32,
             mime_type: value.mime_type,
@@ -162,14 +194,31 @@ impl From<RtpCodecParameters> for sys_rp::ffi::RtpCodecParameters {
             clock_rate: value.clock_rate.unwrap_or_default() as i32,
             has_num_channels: value.channels.is_some(),
             num_channels: value.channels.unwrap_or_default() as i32,
-            name: "".to_string(),
-            kind: sys_rp::ffi::MediaType::Audio,
-            has_max_ptime: false,
-            max_ptime: 0,
-            has_ptime: false,
-            ptime: 0,
-            rtcp_feedback: Vec::new(),
-            parameters: Vec::new(),
+            name: value.name,
+            kind,
+            has_max_ptime: value.has_max_ptime,
+            max_ptime: value.max_ptime,
+            has_ptime: value.has_ptime,
+            ptime: value.ptime,
+            rtcp_feedback: value
+                .rtcp_feedback
+                .into_iter()
+                .map(|f| {
+                    let feedback_type = sys_rp::ffi::RtcpFeedbackType { repr: f.feedback_type };
+                    let message_type =
+                        sys_rp::ffi::RtcpFeedbackMessageType { repr: f.message_type };
+                    sys_rp::ffi::RtcpFeedback {
+                        feedback_type,
+                        has_message_type: f.has_message_type,
+                        message_type,
+                    }
+                })
+                .collect(),
+            parameters: value
+                .parameters
+                .into_iter()
+                .map(|(key, value)| sys_rp::ffi::StringKeyValue { key, value })
+                .collect(),
         }
     }
 }
@@ -179,9 +228,9 @@ impl From<RtcpParameters> for sys_rp::ffi::RtcpParameters {
         Self {
             cname: value.cname,
             reduced_size: value.reduced_size,
-            has_ssrc: false,
-            ssrc: 0,
-            mux: false,
+            has_ssrc: value.has_ssrc,
+            ssrc: value.ssrc,
+            mux: value.mux,
         }
     }
 }
@@ -206,8 +255,8 @@ impl From<RtpEncodingParameters> for sys_rp::ffi::RtpEncodingParameters {
             num_temporal_layers: 0,
             has_scalability_mode: value.scalability_mode.is_some(),
             scalability_mode: value.scalability_mode.unwrap_or_default(),
-            has_ssrc: false,
-            ssrc: 0,
+            has_ssrc: value.has_ssrc,
+            ssrc: value.ssrc,
         }
     }
 }

--- a/libwebrtc/src/rtp_parameters.rs
+++ b/libwebrtc/src/rtp_parameters.rs
@@ -33,7 +33,22 @@ pub struct RtpHeaderExtensionParameters {
 pub struct RtpParameters {
     pub codecs: Vec<RtpCodecParameters>,
     pub header_extensions: Vec<RtpHeaderExtensionParameters>,
+    pub encodings: Vec<RtpEncodingParameters>,
     pub rtcp: RtcpParameters,
+    /// Opaque token used by WebRTC to pair getParameters/setParameters calls.
+    /// Must be preserved when round-tripping through set_parameters().
+    pub(crate) transaction_id: String,
+    pub(crate) mid: String,
+    pub(crate) has_degradation_preference: bool,
+    pub(crate) degradation_preference: i32,
+}
+
+/// Mirrors webrtc_sys RtcpFeedback for round-trip fidelity.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct CodecFeedback {
+    pub feedback_type: i32,
+    pub has_message_type: bool,
+    pub message_type: i32,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -42,12 +57,23 @@ pub struct RtpCodecParameters {
     pub mime_type: String, // read-only
     pub clock_rate: Option<u64>,
     pub channels: Option<u16>,
+    pub(crate) name: String,
+    pub(crate) kind: i32,
+    pub(crate) has_max_ptime: bool,
+    pub(crate) max_ptime: i32,
+    pub(crate) has_ptime: bool,
+    pub(crate) ptime: i32,
+    pub(crate) rtcp_feedback: Vec<CodecFeedback>,
+    pub(crate) parameters: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct RtcpParameters {
     pub cname: String,
     pub reduced_size: bool,
+    pub(crate) mux: bool,
+    pub(crate) has_ssrc: bool,
+    pub(crate) ssrc: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -58,6 +84,9 @@ pub struct RtpEncodingParameters {
     pub priority: Priority,
     pub rid: String,
     pub scale_resolution_down_by: Option<f64>,
+    /// Preserved for round-trip fidelity with WebRTC's getParameters/setParameters.
+    pub has_ssrc: bool,
+    pub ssrc: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -89,6 +118,8 @@ impl Default for RtpEncodingParameters {
             priority: Priority::Low,
             rid: String::default(),
             scale_resolution_down_by: None,
+            has_ssrc: false,
+            ssrc: 0,
         }
     }
 }

--- a/libwebrtc/src/rtp_parameters.rs
+++ b/libwebrtc/src/rtp_parameters.rs
@@ -33,7 +33,22 @@ pub struct RtpHeaderExtensionParameters {
 pub struct RtpParameters {
     pub codecs: Vec<RtpCodecParameters>,
     pub header_extensions: Vec<RtpHeaderExtensionParameters>,
+    pub encodings: Vec<RtpEncodingParameters>,
     pub rtcp: RtcpParameters,
+    /// Opaque token used by WebRTC to pair getParameters/setParameters calls.
+    /// Must be preserved when round-tripping through set_parameters().
+    pub(crate) transaction_id: String,
+    pub(crate) mid: String,
+    pub(crate) has_degradation_preference: bool,
+    pub(crate) degradation_preference: i32,
+}
+
+/// Mirrors webrtc_sys RtcpFeedback for round-trip fidelity.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct CodecFeedback {
+    pub feedback_type: i32,
+    pub has_message_type: bool,
+    pub message_type: i32,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -42,12 +57,23 @@ pub struct RtpCodecParameters {
     pub mime_type: String, // read-only
     pub clock_rate: Option<u64>,
     pub channels: Option<u16>,
+    pub(crate) name: String,
+    pub(crate) kind: i32,
+    pub(crate) has_max_ptime: bool,
+    pub(crate) max_ptime: i32,
+    pub(crate) has_ptime: bool,
+    pub(crate) ptime: i32,
+    pub(crate) rtcp_feedback: Vec<CodecFeedback>,
+    pub(crate) parameters: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct RtcpParameters {
     pub cname: String,
     pub reduced_size: bool,
+    pub(crate) mux: bool,
+    pub(crate) has_ssrc: bool,
+    pub(crate) ssrc: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -61,6 +87,9 @@ pub struct RtpEncodingParameters {
     /// RTP scalability mode (e.g. "L3T3_KEY"). Required to enable true
     /// SVC for codecs that support it (VP9, AV1).
     pub scalability_mode: Option<String>,
+    /// Preserved for round-trip fidelity with WebRTC's getParameters/setParameters.
+    pub has_ssrc: bool,
+    pub ssrc: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -93,6 +122,8 @@ impl Default for RtpEncodingParameters {
             rid: String::default(),
             scale_resolution_down_by: None,
             scalability_mode: None,
+            has_ssrc: false,
+            ssrc: 0,
         }
     }
 }

--- a/livekit/src/prelude.rs
+++ b/livekit/src/prelude.rs
@@ -28,9 +28,10 @@ pub use crate::{
     publication::{LocalTrackPublication, RemoteTrackPublication, TrackPublication},
     track::{
         AudioTrack, LocalAudioTrack, LocalTrack, LocalVideoTrack, PublishTimingEvent,
-        PublishTimingEventStream, PublishTimingStage, RemoteAudioTrack, RemoteTrack,
-        RemoteVideoTrack, StreamState, SubscribeTimingEvent, SubscribeTimingEventStream,
-        SubscribeTimingStage, Track, TrackDimension, TrackKind, TrackSource, VideoTrack,
+        PublishTimingEventStream, PublishTimingStage, PublishingLayer, RemoteAudioTrack,
+        RemoteTrack, RemoteVideoTrack, StreamState, SubscribeTimingEvent,
+        SubscribeTimingEventStream, SubscribeTimingStage, Track, TrackDimension, TrackKind,
+        TrackSource, VideoTrack,
     },
     ConnectionState, DataPacket, DataPacketKind, Room, RoomError, RoomEvent, RoomOptions,
     RoomResult, RoomSdkOptions, SipDTMF, Transcription, TranscriptionSegment,

--- a/livekit/src/prelude.rs
+++ b/livekit/src/prelude.rs
@@ -28,8 +28,8 @@ pub use crate::{
     publication::{LocalTrackPublication, RemoteTrackPublication, TrackPublication},
     track::{
         AudioTrack, LocalAudioTrack, LocalTrack, LocalVideoTrack, PublishTimingEvent,
-        PublishTimingEventStream, PublishTimingStage, PublishingLayer, RemoteAudioTrack,
-        RemoteTrack, RemoteVideoTrack, StreamState, SubscribeTimingEvent,
+        PublishTimingEventStream, PublishTimingStage, PublishingLayer, PublishingLayerQuality,
+        RemoteAudioTrack, RemoteTrack, RemoteVideoTrack, StreamState, SubscribeTimingEvent,
         SubscribeTimingEventStream, SubscribeTimingStage, Track, TrackDimension, TrackKind,
         TrackSource, VideoTrack,
     },

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -1837,10 +1837,7 @@ impl RoomSession {
         let publication = match self.local_participant.get_track_publication(&track_sid) {
             Some(pub_) => pub_,
             None => {
-                log::warn!(
-                    "dynacast: local track publication not found for sid {}",
-                    track_sid
-                );
+                log::warn!("dynacast: local track publication not found for sid {}", track_sid);
                 return;
             }
         };
@@ -1883,9 +1880,18 @@ impl RoomSession {
                         .unwrap_or_default()
                 })
         } else {
-            let qs: Vec<String> = update.subscribed_qualities.iter().map(|q| {
-                format!("{:?}={}", proto::VideoQuality::try_from(q.quality).unwrap_or(proto::VideoQuality::High), q.enabled)
-            }).collect();
+            let qs: Vec<String> = update
+                .subscribed_qualities
+                .iter()
+                .map(|q| {
+                    format!(
+                        "{:?}={}",
+                        proto::VideoQuality::try_from(q.quality)
+                            .unwrap_or(proto::VideoQuality::High),
+                        q.enabled
+                    )
+                })
+                .collect();
             log::info!(
                 "dynacast: SFU quality update for {} (legacy): [{}]",
                 track_sid,

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -1030,6 +1030,9 @@ impl RoomSession {
             EngineEvent::TrackMuted { sid, muted } => {
                 self.handle_server_initiated_mute_track(sid, muted);
             }
+            EngineEvent::SubscribedQualityUpdate { update } => {
+                self.handle_subscribed_quality_update(update);
+            }
             EngineEvent::LocalDataTrackInput(event) => {
                 _ = self.local_dt_input.send(event);
             }
@@ -1812,6 +1815,88 @@ impl RoomSession {
         }
 
         log::warn!("Track not found in mute request: {}", sid_for_log);
+    }
+
+    #[allow(deprecated)]
+    fn handle_subscribed_quality_update(&self, update: proto::SubscribedQualityUpdate) {
+        if !self.options.dynacast {
+            return;
+        }
+
+        let track_sid: TrackSid = match update.track_sid.clone().try_into() {
+            Ok(sid) => sid,
+            Err(_) => {
+                log::warn!(
+                    "dynacast: invalid track sid in subscribed quality update: {}",
+                    update.track_sid
+                );
+                return;
+            }
+        };
+
+        let publication = match self.local_participant.get_track_publication(&track_sid) {
+            Some(pub_) => pub_,
+            None => {
+                log::warn!(
+                    "dynacast: local track publication not found for sid {}",
+                    track_sid
+                );
+                return;
+            }
+        };
+
+        let video_track = match publication.track() {
+            Some(LocalTrack::Video(vt)) => vt,
+            _ => {
+                log::debug!(
+                    "dynacast: track {} is not a local video track, ignoring quality update",
+                    track_sid
+                );
+                return;
+            }
+        };
+
+        let qualities: Vec<proto::SubscribedQuality> = if !update.subscribed_codecs.is_empty() {
+            let codec = publication.publish_options().video_codec.as_str().to_lowercase();
+            log::info!(
+                "dynacast: SFU quality update for {}: subscribed_codecs={:?}, looking for codec '{}'",
+                track_sid,
+                update.subscribed_codecs.iter().map(|sc| {
+                    let qs: Vec<String> = sc.qualities.iter().map(|q| {
+                        format!("{:?}={}", proto::VideoQuality::try_from(q.quality).unwrap_or(proto::VideoQuality::High), q.enabled)
+                    }).collect();
+                    format!("{}:[{}]", sc.codec, qs.join(", "))
+                }).collect::<Vec<_>>().join("; "),
+                codec,
+            );
+            update
+                .subscribed_codecs
+                .iter()
+                .find(|sc| sc.codec.to_lowercase() == codec)
+                .map(|sc| sc.qualities.clone())
+                .unwrap_or_else(|| {
+                    log::warn!("dynacast: codec '{}' not found in subscribed_codecs, falling back to first", codec);
+                    update
+                        .subscribed_codecs
+                        .first()
+                        .map(|sc| sc.qualities.clone())
+                        .unwrap_or_default()
+                })
+        } else {
+            let qs: Vec<String> = update.subscribed_qualities.iter().map(|q| {
+                format!("{:?}={}", proto::VideoQuality::try_from(q.quality).unwrap_or(proto::VideoQuality::High), q.enabled)
+            }).collect();
+            log::info!(
+                "dynacast: SFU quality update for {} (legacy): [{}]",
+                track_sid,
+                qs.join(", "),
+            );
+            update.subscribed_qualities.clone()
+        };
+
+        if let Err(e) = video_track.set_publishing_layers(&qualities) {
+            log::error!("dynacast: failed to set publishing layers for {}: {}", track_sid, e);
+        }
     }
 
     /// Create a new participant

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -1063,6 +1063,9 @@ impl RoomSession {
             EngineEvent::TrackMuted { sid, muted } => {
                 self.handle_server_initiated_mute_track(sid, muted);
             }
+            EngineEvent::SubscribedQualityUpdate { update } => {
+                self.handle_subscribed_quality_update(update);
+            }
             EngineEvent::LocalDataTrackInput(event) => {
                 _ = self.local_dt_input.send(event);
             }
@@ -1872,6 +1875,99 @@ impl RoomSession {
         }
 
         log::warn!("Track not found in mute request: {}", sid_for_log);
+    }
+
+    #[allow(deprecated)]
+    fn handle_subscribed_quality_update(&self, update: proto::SubscribedQualityUpdate) {
+        if !self.options.dynacast {
+            return;
+        }
+
+        let track_sid: TrackSid = match update.track_sid.clone().try_into() {
+            Ok(sid) => sid,
+            Err(_) => {
+                log::warn!(
+                    "dynacast: invalid track sid in subscribed quality update: {}",
+                    update.track_sid
+                );
+                return;
+            }
+        };
+
+        let publication = match self.local_participant.get_track_publication(&track_sid) {
+            Some(pub_) => pub_,
+            None => {
+                log::warn!("dynacast: local track publication not found for sid {}", track_sid);
+                return;
+            }
+        };
+
+        let video_track = match publication.track() {
+            Some(LocalTrack::Video(vt)) => vt,
+            _ => {
+                log::debug!(
+                    "dynacast: track {} is not a local video track, ignoring quality update",
+                    track_sid
+                );
+                return;
+            }
+        };
+
+        let qualities: Vec<proto::SubscribedQuality> = if !update.subscribed_codecs.is_empty() {
+            // This is the requested codec, which we also advertise in simulcast_codecs and use
+            // for sender codec preferences, so it should match the SFU's subscribed codec key.
+            let codec = publication.publish_options().video_codec.as_str().to_lowercase();
+            log::info!(
+                "dynacast: SFU quality update for {}: subscribed_codecs={:?}, looking for codec '{}'",
+                track_sid,
+                update.subscribed_codecs.iter().map(|sc| {
+                    let qs: Vec<String> = sc.qualities.iter().map(|q| {
+                        format!(
+                            "{:?}={}",
+                            crate::options::video_quality_from_i32_or_default(q.quality),
+                            q.enabled
+                        )
+                    }).collect();
+                    format!("{}:[{}]", sc.codec, qs.join(", "))
+                }).collect::<Vec<_>>().join("; "),
+                codec,
+            );
+            update
+                .subscribed_codecs
+                .iter()
+                .find(|sc| sc.codec.to_lowercase() == codec)
+                .map(|sc| sc.qualities.clone())
+                .unwrap_or_else(|| {
+                    log::warn!("dynacast: codec '{}' not found in subscribed_codecs, falling back to first", codec);
+                    update
+                        .subscribed_codecs
+                        .first()
+                        .map(|sc| sc.qualities.clone())
+                        .unwrap_or_default()
+                })
+        } else {
+            let qs: Vec<String> = update
+                .subscribed_qualities
+                .iter()
+                .map(|q| {
+                    format!(
+                        "{:?}={}",
+                        crate::options::video_quality_from_i32_or_default(q.quality),
+                        q.enabled
+                    )
+                })
+                .collect();
+            log::info!(
+                "dynacast: SFU quality update for {} (legacy): [{}]",
+                track_sid,
+                qs.join(", "),
+            );
+            update.subscribed_qualities.clone()
+        };
+
+        if let Err(e) = video_track.set_publishing_layers(&qualities) {
+            log::error!("dynacast: failed to set publishing layers for {}: {}", track_sid, e);
+        }
     }
 
     /// Create a new participant

--- a/livekit/src/room/options.rs
+++ b/livekit/src/room/options.rs
@@ -347,17 +347,15 @@ pub fn spatial_layers_from_scalability_mode(mode: &str) -> u32 {
     1
 }
 
-pub(crate) fn default_video_quality() -> proto::VideoQuality {
-    // A single encoding, or one without a recognized RID, represents the full-quality layer.
-    proto::VideoQuality::High
-}
+/// A single encoding, or one without a recognized RID, represents the full-quality layer.
+pub(crate) const DEFAULT_VIDEO_QUALITY: proto::VideoQuality = proto::VideoQuality::High;
 
 pub(crate) fn video_quality_for_rid_or_default(rid: &str) -> proto::VideoQuality {
-    video_quality_for_rid(rid).unwrap_or_else(default_video_quality)
+    video_quality_for_rid(rid).unwrap_or(DEFAULT_VIDEO_QUALITY)
 }
 
 pub(crate) fn video_quality_from_i32_or_default(quality: i32) -> proto::VideoQuality {
-    proto::VideoQuality::try_from(quality).unwrap_or_else(|_| default_video_quality())
+    proto::VideoQuality::try_from(quality).unwrap_or(DEFAULT_VIDEO_QUALITY)
 }
 
 pub fn video_layers_from_encodings(
@@ -367,7 +365,7 @@ pub fn video_layers_from_encodings(
 ) -> Vec<proto::VideoLayer> {
     if encodings.is_empty() {
         return vec![proto::VideoLayer {
-            quality: default_video_quality() as i32,
+            quality: DEFAULT_VIDEO_QUALITY as i32,
             width,
             height,
             bitrate: 0,

--- a/livekit/src/room/options.rs
+++ b/livekit/src/room/options.rs
@@ -347,6 +347,19 @@ pub fn spatial_layers_from_scalability_mode(mode: &str) -> u32 {
     1
 }
 
+pub(crate) fn default_video_quality() -> proto::VideoQuality {
+    // A single encoding, or one without a recognized RID, represents the full-quality layer.
+    proto::VideoQuality::High
+}
+
+pub(crate) fn video_quality_for_rid_or_default(rid: &str) -> proto::VideoQuality {
+    video_quality_for_rid(rid).unwrap_or_else(default_video_quality)
+}
+
+pub(crate) fn video_quality_from_i32_or_default(quality: i32) -> proto::VideoQuality {
+    proto::VideoQuality::try_from(quality).unwrap_or_else(|_| default_video_quality())
+}
+
 pub fn video_layers_from_encodings(
     width: u32,
     height: u32,
@@ -354,7 +367,7 @@ pub fn video_layers_from_encodings(
 ) -> Vec<proto::VideoLayer> {
     if encodings.is_empty() {
         return vec![proto::VideoLayer {
-            quality: proto::VideoQuality::High as i32,
+            quality: default_video_quality() as i32,
             width,
             height,
             bitrate: 0,
@@ -399,7 +412,7 @@ pub fn video_layers_from_encodings(
     let mut layers = Vec::with_capacity(encodings.len());
     for encoding in encodings {
         let scale = encoding.scale_resolution_down_by.unwrap_or(1.0);
-        let quality = video_quality_for_rid(&encoding.rid).unwrap_or(proto::VideoQuality::High);
+        let quality = video_quality_for_rid_or_default(&encoding.rid);
 
         layers.push(proto::VideoLayer {
             quality: quality as i32,

--- a/livekit/src/room/participant/remote_participant.rs
+++ b/livekit/src/room/participant/remote_participant.rs
@@ -456,21 +456,21 @@ impl RemoteParticipant {
                 let rtc_engine = rtc_engine.clone();
                 livekit_runtime::spawn(async move {
                     let tsid: String = publication.sid().into();
-                    let proto_quality = match quality {
+                    let quality = match quality {
                         VideoQuality::Low => proto::VideoQuality::Low,
                         VideoQuality::Medium => proto::VideoQuality::Medium,
                         VideoQuality::High => proto::VideoQuality::High,
-                    };
+                    }.into();
                     let update_track_settings = proto::UpdateTrackSettings {
                         track_sids: vec![tsid.clone()],
-                        quality: proto_quality.into(),
+                        quality,
                         ..Default::default()
                     };
 
                     log::info!(
                         "subscriber: sending UpdateTrackSettings to SFU: track={}, quality={:?}",
                         tsid,
-                        proto_quality,
+                        proto::VideoQuality::try_from(quality),
                     );
                     rtc_engine
                         .send_request(proto::signal_request::Message::TrackSetting(

--- a/livekit/src/room/participant/remote_participant.rs
+++ b/livekit/src/room/participant/remote_participant.rs
@@ -456,18 +456,22 @@ impl RemoteParticipant {
                 let rtc_engine = rtc_engine.clone();
                 livekit_runtime::spawn(async move {
                     let tsid: String = publication.sid().into();
-                    let quality = match quality {
+                    let proto_quality = match quality {
                         VideoQuality::Low => proto::VideoQuality::Low,
                         VideoQuality::Medium => proto::VideoQuality::Medium,
                         VideoQuality::High => proto::VideoQuality::High,
-                    }
-                    .into();
+                    };
                     let update_track_settings = proto::UpdateTrackSettings {
                         track_sids: vec![tsid.clone()],
-                        quality,
+                        quality: proto_quality.into(),
                         ..Default::default()
                     };
 
+                    log::info!(
+                        "subscriber: sending UpdateTrackSettings to SFU: track={}, quality={:?}",
+                        tsid,
+                        proto_quality,
+                    );
                     rtc_engine
                         .send_request(proto::signal_request::Message::TrackSetting(
                             update_track_settings,

--- a/livekit/src/room/participant/remote_participant.rs
+++ b/livekit/src/room/participant/remote_participant.rs
@@ -460,7 +460,8 @@ impl RemoteParticipant {
                         VideoQuality::Low => proto::VideoQuality::Low,
                         VideoQuality::Medium => proto::VideoQuality::Medium,
                         VideoQuality::High => proto::VideoQuality::High,
-                    }.into();
+                    }
+                    .into();
                     let update_track_settings = proto::UpdateTrackSettings {
                         track_sids: vec![tsid.clone()],
                         quality,

--- a/livekit/src/room/participant/remote_participant.rs
+++ b/livekit/src/room/participant/remote_participant.rs
@@ -28,11 +28,7 @@ use super::{
     ConnectionQuality, ParticipantInner, ParticipantKind, ParticipantKindDetail, ParticipantState,
     TrackKind,
 };
-use crate::{
-    prelude::*,
-    rtc_engine::RtcEngine,
-    track::{TrackError, VideoQuality},
-};
+use crate::{prelude::*, rtc_engine::RtcEngine, track::TrackError};
 
 const ADD_TRACK_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -458,12 +454,7 @@ impl RemoteParticipant {
                 let rtc_engine = rtc_engine.clone();
                 livekit_runtime::spawn(async move {
                     let tsid: String = publication.sid().into();
-                    let quality = match quality {
-                        VideoQuality::Low => proto::VideoQuality::Low,
-                        VideoQuality::Medium => proto::VideoQuality::Medium,
-                        VideoQuality::High => proto::VideoQuality::High,
-                    }
-                    .into();
+                    let quality: i32 = proto::VideoQuality::from(quality).into();
                     let update_track_settings = proto::UpdateTrackSettings {
                         track_sids: vec![tsid.clone()],
                         quality,

--- a/livekit/src/room/participant/remote_participant.rs
+++ b/livekit/src/room/participant/remote_participant.rs
@@ -470,6 +470,11 @@ impl RemoteParticipant {
                         ..Default::default()
                     };
 
+                    log::info!(
+                        "subscriber: sending UpdateTrackSettings to SFU: track={}, quality={:?}",
+                        tsid,
+                        proto::VideoQuality::try_from(quality),
+                    );
                     rtc_engine
                         .send_request(proto::signal_request::Message::TrackSetting(
                             update_track_settings,

--- a/livekit/src/room/track/local_video_track.rs
+++ b/livekit/src/room/track/local_video_track.rs
@@ -224,9 +224,9 @@ impl LocalVideoTrack {
             log::debug!("dynacast: layers unchanged [{}]", layers.join(", "));
         }
 
-        sender.set_parameters(params).map_err(|e| {
-            RoomError::Internal(format!("failed to set sender parameters: {}", e))
-        })?;
+        sender
+            .set_parameters(params)
+            .map_err(|e| RoomError::Internal(format!("failed to set sender parameters: {}", e)))?;
 
         Ok(())
     }

--- a/livekit/src/room/track/local_video_track.rs
+++ b/livekit/src/room/track/local_video_track.rs
@@ -146,4 +146,88 @@ impl LocalVideoTrack {
     pub(crate) fn update_info(&self, info: proto::TrackInfo) {
         super::update_info(&self.inner, &Track::LocalVideo(self.clone()), info);
     }
+
+    /// Returns a snapshot of each simulcast layer's RID, quality label, and active state.
+    /// Useful for diagnostics / HUD display. Returns an empty vec if no transceiver is set.
+    pub fn publishing_layers(&self) -> Vec<(String, String, bool)> {
+        let Some(transceiver) = self.transceiver() else {
+            return Vec::new();
+        };
+        let params = transceiver.sender().parameters();
+        params
+            .encodings
+            .iter()
+            .map(|e| {
+                let quality = crate::options::video_quality_for_rid(&e.rid)
+                    .unwrap_or(proto::VideoQuality::High);
+                (e.rid.clone(), format!("{:?}", quality), e.active)
+            })
+            .collect()
+    }
+
+    /// Toggle simulcast encoding layers on/off based on subscriber demand.
+    /// Used by dynacast: the SFU tells us which quality levels are needed,
+    /// and we set `encoding.active` accordingly on the RTP sender.
+    pub(crate) fn set_publishing_layers(
+        &self,
+        qualities: &[proto::SubscribedQuality],
+    ) -> RoomResult<()> {
+        let transceiver = self.transceiver().ok_or_else(|| {
+            RoomError::Internal("cannot set publishing layers: no transceiver".into())
+        })?;
+
+        let sender = transceiver.sender();
+        let mut params = sender.parameters();
+
+        let mut any_enabled = false;
+        let mut changed = false;
+        for encoding in &mut params.encodings {
+            let quality = crate::options::video_quality_for_rid(&encoding.rid)
+                .unwrap_or(proto::VideoQuality::High);
+
+            let should_active = qualities
+                .iter()
+                .find(|q| q.quality == quality as i32)
+                .map(|q| q.enabled)
+                .unwrap_or(false);
+
+            if should_active {
+                any_enabled = true;
+            }
+
+            if encoding.active != should_active {
+                changed = true;
+                encoding.active = should_active;
+            }
+        }
+
+        if !any_enabled {
+            for encoding in &mut params.encodings {
+                encoding.active = false;
+            }
+        }
+
+        let layers: Vec<String> = params
+            .encodings
+            .iter()
+            .map(|e| {
+                let quality = crate::options::video_quality_for_rid(&e.rid)
+                    .unwrap_or(proto::VideoQuality::High);
+                let state = if e.active { "ON" } else { "off" };
+                format!("{}({:?})={}", e.rid, quality, state)
+            })
+            .collect();
+
+        if changed {
+            log::info!("dynacast: layers changed -> [{}]", layers.join(", "));
+        } else {
+            log::debug!("dynacast: layers unchanged [{}]", layers.join(", "));
+        }
+
+        sender.set_parameters(params).map_err(|e| {
+            RoomError::Internal(format!("failed to set sender parameters: {}", e))
+        })?;
+
+        Ok(())
+    }
 }

--- a/livekit/src/room/track/local_video_track.rs
+++ b/livekit/src/room/track/local_video_track.rs
@@ -86,7 +86,12 @@ impl From<PublishingLayerQuality> for proto::VideoQuality {
 
 impl Display for PublishingLayerQuality {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        match self {
+            Self::Low => write!(f, "low"),
+            Self::Medium => write!(f, "medium"),
+            Self::High => write!(f, "high"),
+            Self::Off => write!(f, "off"),
+        }
     }
 }
 
@@ -388,7 +393,7 @@ impl LocalVideoTrack {
             .map_err(|e| RoomError::Internal(format!("failed to set sender parameters: {}", e)))?;
 
         if changed {
-            log::info!("dynacast: layers changed -> [{}]", layers.join(", "));
+            log::debug!("dynacast: layers changed -> [{}]", layers.join(", "));
         } else {
             log::debug!("dynacast: layers unchanged [{}]", layers.join(", "));
         }

--- a/livekit/src/room/track/local_video_track.rs
+++ b/livekit/src/room/track/local_video_track.rs
@@ -58,7 +58,13 @@ pub enum PublishingLayerQuality {
     Medium,
     /// High video quality.
     High,
-    /// Disabled video quality.
+    /// The layer is disabled and not being encoded/sent.
+    ///
+    /// Mirrors `VideoQuality::OFF` from the LiveKit protocol. In practice this
+    /// is not emitted by [`LocalVideoTrack::publishing_layers`] (a disabled
+    /// layer is instead reflected by [`PublishingLayer::active`] being
+    /// `false`); it exists to fully model the protocol enum and for conversions
+    /// to/from it.
     Off,
 }
 

--- a/livekit/src/room/track/local_video_track.rs
+++ b/livekit/src/room/track/local_video_track.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::{
-    fmt::Debug,
+    fmt::{Debug, Display},
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
@@ -38,11 +38,56 @@ pub use libwebrtc::native::packet_trailer::{PublishTimingEvent, PublishTimingSta
 
 const PUBLISH_TIMING_BUFFER: usize = 256;
 
+/// A simulcast layer currently configured on a local video publisher.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PublishingLayer {
+    /// RTP stream identifier for this simulcast layer.
     pub rid: String,
-    pub quality: String,
+    /// Video quality represented by this simulcast layer.
+    pub quality: PublishingLayerQuality,
+    /// Whether this simulcast layer is currently being published.
     pub active: bool,
+}
+
+/// Video quality for a publishing layer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PublishingLayerQuality {
+    /// Low video quality.
+    Low,
+    /// Medium video quality.
+    Medium,
+    /// High video quality.
+    High,
+    /// Disabled video quality.
+    Off,
+}
+
+impl From<proto::VideoQuality> for PublishingLayerQuality {
+    fn from(quality: proto::VideoQuality) -> Self {
+        match quality {
+            proto::VideoQuality::Low => Self::Low,
+            proto::VideoQuality::Medium => Self::Medium,
+            proto::VideoQuality::High => Self::High,
+            proto::VideoQuality::Off => Self::Off,
+        }
+    }
+}
+
+impl From<PublishingLayerQuality> for proto::VideoQuality {
+    fn from(quality: PublishingLayerQuality) -> Self {
+        match quality {
+            PublishingLayerQuality::Low => Self::Low,
+            PublishingLayerQuality::Medium => Self::Medium,
+            PublishingLayerQuality::High => Self::High,
+            PublishingLayerQuality::Off => Self::Off,
+        }
+    }
+}
+
+impl Display for PublishingLayerQuality {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }
 
 #[derive(Clone)]
@@ -274,7 +319,7 @@ impl LocalVideoTrack {
         super::update_info(&self.inner, &Track::LocalVideo(self.clone()), info);
     }
 
-    /// Returns a snapshot of each simulcast layer's RID, quality label, and active state.
+    /// Returns a snapshot of each simulcast layer's RID, quality, and active state.
     /// Useful for diagnostics / HUD display.
     /// Returns an empty vec if no transceiver is set, or if the sender has no encodings yet.
     pub fn publishing_layers(&self) -> Vec<PublishingLayer> {
@@ -288,11 +333,7 @@ impl LocalVideoTrack {
             .iter()
             .map(|e| {
                 let quality = crate::options::video_quality_for_rid_or_default(&e.rid);
-                PublishingLayer {
-                    rid: e.rid.clone(),
-                    quality: format!("{:?}", quality),
-                    active: e.active,
-                }
+                PublishingLayer { rid: e.rid.clone(), quality: quality.into(), active: e.active }
             })
             .collect()
     }

--- a/livekit/src/room/track/local_video_track.rs
+++ b/livekit/src/room/track/local_video_track.rs
@@ -279,6 +279,7 @@ impl LocalVideoTrack {
     /// Returns an empty vec if no transceiver is set, or if the sender has no encodings yet.
     pub fn publishing_layers(&self) -> Vec<PublishingLayer> {
         let Some(transceiver) = self.transceiver() else {
+            log::debug!("dynacast: no transceiver, returning empty layers");
             return Vec::new();
         };
         let params = transceiver.sender().parameters();

--- a/livekit/src/room/track/local_video_track.rs
+++ b/livekit/src/room/track/local_video_track.rs
@@ -38,6 +38,13 @@ pub use libwebrtc::native::packet_trailer::{PublishTimingEvent, PublishTimingSta
 
 const PUBLISH_TIMING_BUFFER: usize = 256;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PublishingLayer {
+    pub rid: String,
+    pub quality: String,
+    pub active: bool,
+}
+
 #[derive(Clone)]
 pub struct LocalVideoTrack {
     inner: Arc<TrackInner>,
@@ -265,5 +272,85 @@ impl LocalVideoTrack {
 
     pub(crate) fn update_info(&self, info: proto::TrackInfo) {
         super::update_info(&self.inner, &Track::LocalVideo(self.clone()), info);
+    }
+
+    /// Returns a snapshot of each simulcast layer's RID, quality label, and active state.
+    /// Useful for diagnostics / HUD display.
+    /// Returns an empty vec if no transceiver is set, or if the sender has no encodings yet.
+    pub fn publishing_layers(&self) -> Vec<PublishingLayer> {
+        let Some(transceiver) = self.transceiver() else {
+            return Vec::new();
+        };
+        let params = transceiver.sender().parameters();
+        params
+            .encodings
+            .iter()
+            .map(|e| {
+                let quality = crate::options::video_quality_for_rid_or_default(&e.rid);
+                PublishingLayer {
+                    rid: e.rid.clone(),
+                    quality: format!("{:?}", quality),
+                    active: e.active,
+                }
+            })
+            .collect()
+    }
+
+    /// Toggle simulcast encoding layers on/off based on subscriber demand.
+    /// Used by dynacast: the SFU tells us which quality levels are needed,
+    /// and we set `encoding.active` accordingly on the RTP sender.
+    pub(crate) fn set_publishing_layers(
+        &self,
+        qualities: &[proto::SubscribedQuality],
+    ) -> RoomResult<()> {
+        let transceiver = self.transceiver().ok_or_else(|| {
+            RoomError::Internal("cannot set publishing layers: no transceiver".into())
+        })?;
+
+        let sender = transceiver.sender();
+        let mut params = sender.parameters();
+
+        if params.encodings.is_empty() {
+            log::debug!("dynacast: no sender encodings available, ignoring quality update");
+            return Ok(());
+        }
+
+        let mut changed = false;
+        for encoding in &mut params.encodings {
+            let quality = crate::options::video_quality_for_rid_or_default(&encoding.rid);
+
+            let should_active = qualities
+                .iter()
+                .find(|q| q.quality == quality as i32)
+                .map(|q| q.enabled)
+                .unwrap_or(false);
+
+            if encoding.active != should_active {
+                changed = true;
+                encoding.active = should_active;
+            }
+        }
+
+        let layers: Vec<String> = params
+            .encodings
+            .iter()
+            .map(|e| {
+                let quality = crate::options::video_quality_for_rid_or_default(&e.rid);
+                let state = if e.active { "ON" } else { "off" };
+                format!("{}({:?})={}", e.rid, quality, state)
+            })
+            .collect();
+
+        sender
+            .set_parameters(params)
+            .map_err(|e| RoomError::Internal(format!("failed to set sender parameters: {}", e)))?;
+
+        if changed {
+            log::info!("dynacast: layers changed -> [{}]", layers.join(", "));
+        } else {
+            log::debug!("dynacast: layers unchanged [{}]", layers.join(", "));
+        }
+
+        Ok(())
     }
 }

--- a/livekit/src/room/track/mod.rs
+++ b/livekit/src/room/track/mod.rs
@@ -78,6 +78,16 @@ pub enum VideoQuality {
     High,
 }
 
+impl From<VideoQuality> for proto::VideoQuality {
+    fn from(quality: VideoQuality) -> Self {
+        match quality {
+            VideoQuality::Low => Self::Low,
+            VideoQuality::Medium => Self::Medium,
+            VideoQuality::High => Self::High,
+        }
+    }
+}
+
 macro_rules! track_dispatch {
     ([$($variant:ident),+]) => {
         enum_dispatch!(

--- a/livekit/src/rtc_engine/mod.rs
+++ b/livekit/src/rtc_engine/mod.rs
@@ -192,6 +192,9 @@ pub enum EngineEvent {
         sid: String,
         muted: bool,
     },
+    SubscribedQualityUpdate {
+        update: proto::SubscribedQualityUpdate,
+    },
     LocalDataTrackInput(dt::local::InputEvent),
     RemoteDataTrackInput(dt::remote::InputEvent),
 }
@@ -637,6 +640,9 @@ impl EngineInner {
             }
             SessionEvent::TrackMuted { sid, muted } => {
                 let _ = self.engine_tx.send(EngineEvent::TrackMuted { sid, muted });
+            }
+            SessionEvent::SubscribedQualityUpdate { update } => {
+                let _ = self.engine_tx.send(EngineEvent::SubscribedQualityUpdate { update });
             }
             SessionEvent::LocalDataTrackInput(event) => {
                 let _ = self.engine_tx.send(EngineEvent::LocalDataTrackInput(event));

--- a/livekit/src/rtc_engine/mod.rs
+++ b/livekit/src/rtc_engine/mod.rs
@@ -208,6 +208,9 @@ pub enum EngineEvent {
         sid: String,
         muted: bool,
     },
+    SubscribedQualityUpdate {
+        update: proto::SubscribedQualityUpdate,
+    },
     LocalDataTrackInput(dt::local::InputEvent),
     RemoteDataTrackInput(dt::remote::InputEvent),
 }
@@ -655,6 +658,9 @@ impl EngineInner {
             }
             SessionEvent::TrackMuted { sid, muted } => {
                 let _ = self.engine_tx.send(EngineEvent::TrackMuted { sid, muted });
+            }
+            SessionEvent::SubscribedQualityUpdate { update } => {
+                let _ = self.engine_tx.send(EngineEvent::SubscribedQualityUpdate { update });
             }
             SessionEvent::LocalDataTrackInput(event) => {
                 let _ = self.engine_tx.send(EngineEvent::LocalDataTrackInput(event));

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -1218,8 +1218,7 @@ impl SessionInner {
                     update.track_sid,
                     update.subscribed_codecs
                 );
-                let _ =
-                    self.emitter.send(SessionEvent::SubscribedQualityUpdate { update });
+                let _ = self.emitter.send(SessionEvent::SubscribedQualityUpdate { update });
             }
             _ => {}
         }

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -205,6 +205,9 @@ pub enum SessionEvent {
         sid: String,
         muted: bool,
     },
+    SubscribedQualityUpdate {
+        update: proto::SubscribedQualityUpdate,
+    },
     LocalDataTrackInput(dt::local::InputEvent),
     RemoteDataTrackInput(dt::remote::InputEvent),
 }
@@ -1208,6 +1211,16 @@ impl SessionInner {
                 if self.single_pc_mode {
                     self.handle_media_sections_requirement(req)?;
                 }
+            }
+            #[allow(deprecated)]
+            proto::signal_response::Message::SubscribedQualityUpdate(update) => {
+                log::debug!(
+                    "received subscribed quality update for track {}: {:?}",
+                    update.track_sid,
+                    update.subscribed_codecs
+                );
+                let _ =
+                    self.emitter.send(SessionEvent::SubscribedQualityUpdate { update });
             }
             _ => {}
         }

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -1212,7 +1212,6 @@ impl SessionInner {
                     self.handle_media_sections_requirement(req)?;
                 }
             }
-            #[allow(deprecated)]
             proto::signal_response::Message::SubscribedQualityUpdate(update) => {
                 log::debug!(
                     "received subscribed quality update for track {}: {:?}",

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -215,6 +215,9 @@ pub enum SessionEvent {
         sid: String,
         muted: bool,
     },
+    SubscribedQualityUpdate {
+        update: proto::SubscribedQualityUpdate,
+    },
     LocalDataTrackInput(dt::local::InputEvent),
     RemoteDataTrackInput(dt::remote::InputEvent),
 }
@@ -1432,6 +1435,14 @@ impl SessionInner {
                 if self.single_pc_mode {
                     self.handle_media_sections_requirement(req)?;
                 }
+            }
+            proto::signal_response::Message::SubscribedQualityUpdate(update) => {
+                log::debug!(
+                    "received subscribed quality update for track {}: {:?}",
+                    update.track_sid,
+                    update.subscribed_codecs
+                );
+                let _ = self.emitter.send(SessionEvent::SubscribedQualityUpdate { update });
             }
             _ => {}
         }

--- a/livekit/tests/dynacast_test.rs
+++ b/livekit/tests/dynacast_test.rs
@@ -1,0 +1,164 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "__lk-e2e-test")]
+use {
+    anyhow::{anyhow, Result},
+    common::{
+        test_rooms_with_options,
+        video::{SolidColorParams, SolidColorTrack},
+        TestRoomOptions,
+    },
+    livekit::{options::VideoCodec, prelude::*, track::VideoQuality},
+    std::{sync::Arc, time::Duration},
+    tokio::time::{self, timeout},
+};
+
+mod common;
+
+/// Extracts the `LocalVideoTrack` from the publisher's first video track publication.
+#[cfg(feature = "__lk-e2e-test")]
+fn publisher_video_track(room: &Room) -> Result<LocalVideoTrack> {
+    for pub_ in room.local_participant().track_publications().values() {
+        if let Some(LocalTrack::Video(vt)) = pub_.track() {
+            return Ok(vt);
+        }
+    }
+    Err(anyhow!("No local video track publication found"))
+}
+
+/// Polls `publishing_layers()` until the `check` predicate returns true, or times out.
+#[cfg(feature = "__lk-e2e-test")]
+async fn wait_for_layers(
+    track: &LocalVideoTrack,
+    label: &str,
+    max_wait: Duration,
+    check: impl Fn(&[(String, String, bool)]) -> bool,
+) -> Result<Vec<(String, String, bool)>> {
+    let deadline = tokio::time::Instant::now() + max_wait;
+    loop {
+        let layers = track.publishing_layers();
+        log::info!("dynacast test [{}]: layers = {:?}", label, layers);
+        if check(&layers) {
+            return Ok(layers);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "dynacast test [{}]: timed out waiting for expected layer state, last = {:?}",
+                label,
+                layers
+            ));
+        }
+        time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+/// Verifies that dynacast toggles publisher simulcast layers in response to subscriber quality
+/// requests.
+///
+/// 1. Publisher connects with `dynacast: true` and publishes a simulcast VP8 track.
+/// 2. Subscriber receives the track -- baseline expects all layers active.
+/// 3. Subscriber requests LOW quality via `set_video_quality` -- the SFU should send a
+///    `SubscribedQualityUpdate` that disables the higher layers.
+/// 4. Subscriber requests HIGH quality again -- all layers should re-activate.
+///
+#[cfg(feature = "__lk-e2e-test")]
+#[test_log::test(tokio::test)]
+async fn test_dynacast() -> Result<()> {
+    let mut pub_room_opts = RoomOptions::default();
+    pub_room_opts.dynacast = true;
+    let pub_options = TestRoomOptions { room: pub_room_opts, ..Default::default() };
+    let sub_options = TestRoomOptions::default();
+
+    let mut rooms = test_rooms_with_options([pub_options, sub_options]).await?;
+    let (pub_room, _pub_events) = rooms.remove(0);
+    let (_sub_room, mut sub_events) = rooms.remove(0);
+
+    let pub_room = Arc::new(pub_room);
+    let solid_params = SolidColorParams { width: 1280, height: 720, luma: 128 };
+    let mut solid_track = SolidColorTrack::new(pub_room.clone(), solid_params);
+    solid_track.publish(VideoCodec::VP8, true).await?;
+
+    let sub_publication: RemoteTrackPublication = timeout(Duration::from_secs(15), async {
+        loop {
+            let Some(event) = sub_events.recv().await else {
+                return Err(anyhow!("Event channel closed before TrackSubscribed"));
+            };
+            if let RoomEvent::TrackSubscribed { publication, .. } = event {
+                return Ok(publication);
+            }
+        }
+    })
+    .await??;
+
+    let pub_video_track = publisher_video_track(&pub_room)?;
+
+    // --- Baseline: all simulcast layers should be active after initial subscription ---
+    let layers = wait_for_layers(
+        &pub_video_track,
+        "baseline",
+        Duration::from_secs(15),
+        |layers| layers.len() > 1 && layers.iter().all(|(_, _, active)| *active),
+    )
+    .await?;
+    log::info!("dynacast baseline layers: {:?}", layers);
+    assert!(layers.len() > 1, "expected multiple simulcast layers, got {}", layers.len());
+
+    // --- Request LOW quality: SFU should tell publisher to deactivate Medium and High ---
+    log::info!("dynacast test: requesting LOW quality");
+    sub_publication.set_video_quality(VideoQuality::Low);
+
+    let layers = wait_for_layers(
+        &pub_video_track,
+        "after LOW request",
+        Duration::from_secs(30),
+        |layers| {
+            let low_active = layers.iter().any(|(_, q, a)| q == "Low" && *a);
+            let high_inactive = layers.iter().filter(|(_, q, _)| q != "Low").all(|(_, _, a)| !*a);
+            low_active && high_inactive
+        },
+    )
+    .await?;
+    log::info!("dynacast layers after LOW request: {:?}", layers);
+    assert!(
+        layers.iter().any(|(_, q, a)| q == "Low" && *a),
+        "expected Low layer to be active, got {:?}",
+        layers
+    );
+    assert!(
+        layers.iter().filter(|(_, q, _)| q != "Low").all(|(_, _, a)| !*a),
+        "expected Medium and High layers to be inactive, got {:?}",
+        layers
+    );
+
+    // --- Request HIGH quality: all layers should become active again ---
+    log::info!("dynacast test: requesting HIGH quality");
+    sub_publication.set_video_quality(VideoQuality::High);
+
+    let layers = wait_for_layers(
+        &pub_video_track,
+        "after HIGH request",
+        Duration::from_secs(30),
+        |layers| layers.len() > 1 && layers.iter().all(|(_, _, active)| *active),
+    )
+    .await?;
+    log::info!("dynacast layers after HIGH request: {:?}", layers);
+    assert!(
+        layers.iter().all(|(_, _, active)| *active),
+        "expected all layers active after HIGH request, got {:?}",
+        layers
+    );
+
+    Ok(())
+}

--- a/livekit/tests/dynacast_test.rs
+++ b/livekit/tests/dynacast_test.rs
@@ -45,22 +45,6 @@ fn publisher_video_track(room: &Room) -> Result<LocalVideoTrack> {
     Err(anyhow!("No local video track publication found"))
 }
 
-/// Returns the publisher's local video tracks keyed by track SID.
-#[cfg(feature = "__lk-e2e-test")]
-fn publisher_video_tracks(room: &Room) -> HashMap<TrackSid, LocalVideoTrack> {
-    room.local_participant()
-        .track_publications()
-        .into_values()
-        .filter_map(|publication| {
-            let sid = publication.sid();
-            let Some(LocalTrack::Video(track)) = publication.track() else {
-                return None;
-            };
-            Some((sid, track))
-        })
-        .collect()
-}
-
 /// Polls `publishing_layers()` until the `check` predicate returns true, or times out.
 #[cfg(feature = "__lk-e2e-test")]
 async fn wait_for_layers(
@@ -87,62 +71,68 @@ async fn wait_for_layers(
     }
 }
 
-/// Waits for the publisher to expose `expected_count` local video tracks.
+/// Waits for the publisher's next local video track publication.
 #[cfg(feature = "__lk-e2e-test")]
-async fn wait_for_publisher_video_tracks(
-    room: &Room,
-    expected_count: usize,
+async fn wait_for_next_publisher_video_track(
+    events: &mut UnboundedReceiver<RoomEvent>,
     label: &str,
     max_wait: Duration,
-) -> Result<HashMap<TrackSid, LocalVideoTrack>> {
-    let deadline = tokio::time::Instant::now() + max_wait;
-    loop {
-        let tracks = publisher_video_tracks(room);
-        if tracks.len() == expected_count {
-            return Ok(tracks);
+) -> Result<(TrackSid, LocalVideoTrack)> {
+    timeout(max_wait, async {
+        while let Some(event) = events.recv().await {
+            if let RoomEvent::LocalTrackPublished {
+                publication,
+                track: LocalTrack::Video(track),
+                ..
+            } = event
+            {
+                return Ok((publication.sid(), track));
+            }
         }
-        if tokio::time::Instant::now() >= deadline {
-            return Err(anyhow!(
-                "dynacast test [{}]: timed out waiting for {} publisher video tracks, got {}",
-                label,
-                expected_count,
-                tracks.len()
-            ));
-        }
-        time::sleep(Duration::from_millis(250)).await;
-    }
+        Err(anyhow!("dynacast test [{}]: event channel closed before video track published", label))
+    })
+    .await
+    .map_err(|_| {
+        anyhow!("dynacast test [{}]: timed out waiting for publisher video track", label)
+    })?
 }
 
 /// Waits for a subscriber to observe all expected remote track publications.
 #[cfg(feature = "__lk-e2e-test")]
 async fn wait_for_remote_publications(
-    room: &Room,
+    events: &mut UnboundedReceiver<RoomEvent>,
     track_sids: &[TrackSid],
     label: &str,
     max_wait: Duration,
 ) -> Result<HashMap<TrackSid, RemoteTrackPublication>> {
-    let deadline = tokio::time::Instant::now() + max_wait;
-    loop {
-        let publications: HashMap<_, _> = room
-            .remote_participants()
-            .into_values()
-            .flat_map(|participant| participant.track_publications())
-            .filter(|(sid, _)| track_sids.contains(sid))
-            .collect();
-
-        if publications.len() == track_sids.len() {
-            return Ok(publications);
+    let mut publications: HashMap<TrackSid, RemoteTrackPublication> = HashMap::new();
+    timeout(max_wait, async {
+        while publications.len() < track_sids.len() {
+            let Some(event) = events.recv().await else {
+                return Err(anyhow!(
+                    "dynacast test [{}]: event channel closed before all remote publications observed",
+                    label
+                ));
+            };
+            if let RoomEvent::TrackPublished { publication, .. } = event {
+                let sid = publication.sid();
+                if track_sids.contains(&sid) {
+                    publications.insert(sid, publication);
+                }
+            }
         }
-        if tokio::time::Instant::now() >= deadline {
-            return Err(anyhow!(
-                "dynacast test [{}]: timed out waiting for remote publications, got {}/{}",
-                label,
-                publications.len(),
-                track_sids.len()
-            ));
-        }
-        time::sleep(Duration::from_millis(250)).await;
-    }
+        Ok(())
+    })
+    .await
+    .map_err(|_| {
+        anyhow!(
+            "dynacast test [{}]: timed out waiting for remote publications, got {}/{}",
+            label,
+            publications.len(),
+            track_sids.len()
+        )
+    })??;
+    Ok(publications)
 }
 
 /// Subscribes to exactly one of the provided publications and waits for it to attach a track.
@@ -363,63 +353,41 @@ async fn test_dynacast_multiple_subscribers_only_publish_requested_tracks() -> R
 
     let mut rooms =
         test_rooms_with_options([pub_options, sub_options.clone(), sub_options]).await?;
-    let (pub_room, _pub_events) = rooms.remove(0);
-    let (sub1_room, mut sub1_events) = rooms.remove(0);
-    let (sub2_room, mut sub2_events) = rooms.remove(0);
+    let (pub_room, mut pub_events) = rooms.remove(0);
+    let (_sub1_room, mut sub1_events) = rooms.remove(0);
+    let (_sub2_room, mut sub2_events) = rooms.remove(0);
 
     let pub_room = Arc::new(pub_room);
     let mut solid_tracks = Vec::new();
     let mut track_sids: Vec<TrackSid> = Vec::new();
+    let mut publisher_tracks: Vec<(TrackSid, LocalVideoTrack)> = Vec::new();
 
     for (index, luma) in [64, 128, 192].into_iter().enumerate() {
         let solid_params = SolidColorParams { width: 1280, height: 720, luma };
         let mut solid_track = SolidColorTrack::new(pub_room.clone(), solid_params);
         solid_track.publish(VideoCodec::VP8, true).await?;
 
-        let published_tracks = wait_for_publisher_video_tracks(
-            &pub_room,
-            index + 1,
+        let (new_sid, track) = wait_for_next_publisher_video_track(
+            &mut pub_events,
             &format!("publish track {}", index + 1),
             Duration::from_secs(15),
         )
         .await?;
-        let Some(new_sid) = published_tracks
-            .keys()
-            .find(|sid| !track_sids.iter().any(|published_sid| published_sid == *sid))
-        else {
-            return Err(anyhow!("No new track SID found after publishing track {}", index + 1));
-        };
         log::info!("dynacast multi: published track {} as {}", index + 1, new_sid);
         track_sids.push(new_sid.clone());
+        publisher_tracks.push((new_sid, track));
         solid_tracks.push(solid_track);
     }
 
-    let published_tracks = wait_for_publisher_video_tracks(
-        &pub_room,
-        3,
-        "all published tracks",
-        Duration::from_secs(5),
-    )
-    .await?;
-    let publisher_tracks: Vec<_> = track_sids
-        .iter()
-        .map(|sid| {
-            let track = published_tracks
-                .get(sid)
-                .ok_or_else(|| anyhow!("Missing local video track {}", sid))?;
-            Ok((sid.clone(), track.clone()))
-        })
-        .collect::<Result<_>>()?;
-
     let sub1_publications = wait_for_remote_publications(
-        &sub1_room,
+        &mut sub1_events,
         &track_sids,
         "subscriber 1",
         Duration::from_secs(15),
     )
     .await?;
     let sub2_publications = wait_for_remote_publications(
-        &sub2_room,
+        &mut sub2_events,
         &track_sids,
         "subscriber 2",
         Duration::from_secs(15),

--- a/livekit/tests/dynacast_test.rs
+++ b/livekit/tests/dynacast_test.rs
@@ -1,0 +1,158 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "__lk-e2e-test")]
+use {
+    anyhow::{anyhow, Result},
+    common::{
+        test_rooms_with_options,
+        video::{SolidColorParams, SolidColorTrack},
+        TestRoomOptions,
+    },
+    livekit::{options::VideoCodec, prelude::*, track::VideoQuality},
+    std::{sync::Arc, time::Duration},
+    tokio::time::{self, timeout},
+};
+
+mod common;
+
+/// Extracts the `LocalVideoTrack` from the publisher's first video track publication.
+#[cfg(feature = "__lk-e2e-test")]
+fn publisher_video_track(room: &Room) -> Result<LocalVideoTrack> {
+    for pub_ in room.local_participant().track_publications().values() {
+        if let Some(LocalTrack::Video(vt)) = pub_.track() {
+            return Ok(vt);
+        }
+    }
+    Err(anyhow!("No local video track publication found"))
+}
+
+/// Polls `publishing_layers()` until the `check` predicate returns true, or times out.
+#[cfg(feature = "__lk-e2e-test")]
+async fn wait_for_layers(
+    track: &LocalVideoTrack,
+    label: &str,
+    max_wait: Duration,
+    check: impl Fn(&[PublishingLayer]) -> bool,
+) -> Result<Vec<PublishingLayer>> {
+    let deadline = tokio::time::Instant::now() + max_wait;
+    loop {
+        let layers = track.publishing_layers();
+        log::info!("dynacast test [{}]: layers = {:?}", label, layers);
+        if check(&layers) {
+            return Ok(layers);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "dynacast test [{}]: timed out waiting for expected layer state, last = {:?}",
+                label,
+                layers
+            ));
+        }
+        time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+/// Verifies that dynacast toggles publisher simulcast layers in response to subscriber quality
+/// requests.
+///
+/// 1. Publisher connects with `dynacast: true` and publishes a simulcast VP8 track.
+/// 2. Subscriber receives the track -- baseline expects all layers active.
+/// 3. Subscriber requests LOW quality via `set_video_quality` -- the SFU should send a
+///    `SubscribedQualityUpdate` that disables the higher layers.
+/// 4. Subscriber requests HIGH quality again -- all layers should re-activate.
+///
+#[cfg(feature = "__lk-e2e-test")]
+#[test_log::test(tokio::test)]
+async fn test_dynacast() -> Result<()> {
+    let mut pub_room_opts = RoomOptions::default();
+    pub_room_opts.dynacast = true;
+    let pub_options = TestRoomOptions { room: pub_room_opts, ..Default::default() };
+    let sub_options = TestRoomOptions::default();
+
+    let mut rooms = test_rooms_with_options([pub_options, sub_options]).await?;
+    let (pub_room, _pub_events) = rooms.remove(0);
+    let (_sub_room, mut sub_events) = rooms.remove(0);
+
+    let pub_room = Arc::new(pub_room);
+    let solid_params = SolidColorParams { width: 1280, height: 720, luma: 128 };
+    let mut solid_track = SolidColorTrack::new(pub_room.clone(), solid_params);
+    solid_track.publish(VideoCodec::VP8, true).await?;
+
+    let sub_publication: RemoteTrackPublication = timeout(Duration::from_secs(15), async {
+        loop {
+            let Some(event) = sub_events.recv().await else {
+                return Err(anyhow!("Event channel closed before TrackSubscribed"));
+            };
+            if let RoomEvent::TrackSubscribed { publication, .. } = event {
+                return Ok(publication);
+            }
+        }
+    })
+    .await??;
+
+    let pub_video_track = publisher_video_track(&pub_room)?;
+
+    // --- Baseline: all simulcast layers should be active after initial subscription ---
+    let layers = wait_for_layers(&pub_video_track, "baseline", Duration::from_secs(15), |layers| {
+        layers.len() > 1 && layers.iter().all(|layer| layer.active)
+    })
+    .await?;
+    log::info!("dynacast baseline layers: {:?}", layers);
+    assert!(layers.len() > 1, "expected multiple simulcast layers, got {}", layers.len());
+
+    // --- Request LOW quality: SFU should tell publisher to deactivate Medium and High ---
+    log::info!("dynacast test: requesting LOW quality");
+    sub_publication.set_video_quality(VideoQuality::Low);
+
+    let layers =
+        wait_for_layers(&pub_video_track, "after LOW request", Duration::from_secs(30), |layers| {
+            let low_active = layers.iter().any(|layer| layer.quality == "Low" && layer.active);
+            let high_inactive =
+                layers.iter().filter(|layer| layer.quality != "Low").all(|layer| !layer.active);
+            low_active && high_inactive
+        })
+        .await?;
+    log::info!("dynacast layers after LOW request: {:?}", layers);
+    assert!(
+        layers.iter().any(|layer| layer.quality == "Low" && layer.active),
+        "expected Low layer to be active, got {:?}",
+        layers
+    );
+    assert!(
+        layers.iter().filter(|layer| layer.quality != "Low").all(|layer| !layer.active),
+        "expected Medium and High layers to be inactive, got {:?}",
+        layers
+    );
+
+    // --- Request HIGH quality: all layers should become active again ---
+    log::info!("dynacast test: requesting HIGH quality");
+    sub_publication.set_video_quality(VideoQuality::High);
+
+    let layers = wait_for_layers(
+        &pub_video_track,
+        "after HIGH request",
+        Duration::from_secs(30),
+        |layers| layers.len() > 1 && layers.iter().all(|layer| layer.active),
+    )
+    .await?;
+    log::info!("dynacast layers after HIGH request: {:?}", layers);
+    assert!(
+        layers.iter().all(|layer| layer.active),
+        "expected all layers active after HIGH request, got {:?}",
+        layers
+    );
+
+    Ok(())
+}

--- a/livekit/tests/dynacast_test.rs
+++ b/livekit/tests/dynacast_test.rs
@@ -20,7 +20,11 @@ use {
         video::{SolidColorParams, SolidColorTrack},
         TestRoomOptions,
     },
-    livekit::{options::VideoCodec, prelude::*, track::VideoQuality},
+    livekit::{
+        options::VideoCodec,
+        prelude::*,
+        track::{PublishingLayerQuality, VideoQuality},
+    },
     std::{collections::HashMap, sync::Arc, time::Duration},
     tokio::{
         sync::mpsc::UnboundedReceiver,
@@ -292,20 +296,27 @@ async fn test_dynacast() -> Result<()> {
 
     let layers =
         wait_for_layers(&pub_video_track, "after LOW request", Duration::from_secs(30), |layers| {
-            let low_active = layers.iter().any(|layer| layer.quality == "Low" && layer.active);
-            let high_inactive =
-                layers.iter().filter(|layer| layer.quality != "Low").all(|layer| !layer.active);
+            let low_active = layers
+                .iter()
+                .any(|layer| layer.quality == PublishingLayerQuality::Low && layer.active);
+            let high_inactive = layers
+                .iter()
+                .filter(|layer| layer.quality != PublishingLayerQuality::Low)
+                .all(|layer| !layer.active);
             low_active && high_inactive
         })
         .await?;
     log::info!("dynacast layers after LOW request: {:?}", layers);
     assert!(
-        layers.iter().any(|layer| layer.quality == "Low" && layer.active),
+        layers.iter().any(|layer| layer.quality == PublishingLayerQuality::Low && layer.active),
         "expected Low layer to be active, got {:?}",
         layers
     );
     assert!(
-        layers.iter().filter(|layer| layer.quality != "Low").all(|layer| !layer.active),
+        layers
+            .iter()
+            .filter(|layer| layer.quality != PublishingLayerQuality::Low)
+            .all(|layer| !layer.active),
         "expected Medium and High layers to be inactive, got {:?}",
         layers
     );

--- a/livekit/tests/dynacast_test.rs
+++ b/livekit/tests/dynacast_test.rs
@@ -21,8 +21,11 @@ use {
         TestRoomOptions,
     },
     livekit::{options::VideoCodec, prelude::*, track::VideoQuality},
-    std::{sync::Arc, time::Duration},
-    tokio::time::{self, timeout},
+    std::{collections::HashMap, sync::Arc, time::Duration},
+    tokio::{
+        sync::mpsc::UnboundedReceiver,
+        time::{self, timeout},
+    },
 };
 
 mod common;
@@ -36,6 +39,22 @@ fn publisher_video_track(room: &Room) -> Result<LocalVideoTrack> {
         }
     }
     Err(anyhow!("No local video track publication found"))
+}
+
+/// Returns the publisher's local video tracks keyed by track SID.
+#[cfg(feature = "__lk-e2e-test")]
+fn publisher_video_tracks(room: &Room) -> HashMap<TrackSid, LocalVideoTrack> {
+    room.local_participant()
+        .track_publications()
+        .into_values()
+        .filter_map(|publication| {
+            let sid = publication.sid();
+            let Some(LocalTrack::Video(track)) = publication.track() else {
+                return None;
+            };
+            Some((sid, track))
+        })
+        .collect()
 }
 
 /// Polls `publishing_layers()` until the `check` predicate returns true, or times out.
@@ -58,6 +77,161 @@ async fn wait_for_layers(
                 "dynacast test [{}]: timed out waiting for expected layer state, last = {:?}",
                 label,
                 layers
+            ));
+        }
+        time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+/// Waits for the publisher to expose `expected_count` local video tracks.
+#[cfg(feature = "__lk-e2e-test")]
+async fn wait_for_publisher_video_tracks(
+    room: &Room,
+    expected_count: usize,
+    label: &str,
+    max_wait: Duration,
+) -> Result<HashMap<TrackSid, LocalVideoTrack>> {
+    let deadline = tokio::time::Instant::now() + max_wait;
+    loop {
+        let tracks = publisher_video_tracks(room);
+        if tracks.len() == expected_count {
+            return Ok(tracks);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "dynacast test [{}]: timed out waiting for {} publisher video tracks, got {}",
+                label,
+                expected_count,
+                tracks.len()
+            ));
+        }
+        time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+/// Waits for a subscriber to observe all expected remote track publications.
+#[cfg(feature = "__lk-e2e-test")]
+async fn wait_for_remote_publications(
+    room: &Room,
+    track_sids: &[TrackSid],
+    label: &str,
+    max_wait: Duration,
+) -> Result<HashMap<TrackSid, RemoteTrackPublication>> {
+    let deadline = tokio::time::Instant::now() + max_wait;
+    loop {
+        let publications: HashMap<_, _> = room
+            .remote_participants()
+            .into_values()
+            .flat_map(|participant| participant.track_publications())
+            .filter(|(sid, _)| track_sids.contains(sid))
+            .collect();
+
+        if publications.len() == track_sids.len() {
+            return Ok(publications);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "dynacast test [{}]: timed out waiting for remote publications, got {}/{}",
+                label,
+                publications.len(),
+                track_sids.len()
+            ));
+        }
+        time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+/// Subscribes to exactly one of the provided publications and waits for it to attach a track.
+#[cfg(feature = "__lk-e2e-test")]
+async fn set_only_subscribed(
+    publications: &HashMap<TrackSid, RemoteTrackPublication>,
+    events: &mut UnboundedReceiver<RoomEvent>,
+    active_sid: &TrackSid,
+    label: &str,
+) -> Result<()> {
+    let Some(active_publication) = publications.get(active_sid) else {
+        return Err(anyhow!("dynacast test [{}]: missing publication {}", label, active_sid));
+    };
+
+    for (sid, publication) in publications {
+        publication.set_subscribed(sid == active_sid);
+    }
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        if active_publication.track().is_some() {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "dynacast test [{}]: timed out waiting to subscribe to {}",
+                label,
+                active_sid
+            ));
+        }
+
+        match timeout(Duration::from_millis(250), events.recv()).await {
+            Ok(Some(RoomEvent::TrackSubscriptionFailed { track_sid, error, .. }))
+                if track_sid == *active_sid =>
+            {
+                log::warn!(
+                    "dynacast test [{}]: subscription failed for {}: {:?}; retrying",
+                    label,
+                    active_sid,
+                    error
+                );
+                active_publication.set_subscribed(false);
+                active_publication.set_subscribed(true);
+            }
+            Ok(Some(_)) | Err(_) => {}
+            Ok(None) => return Err(anyhow!("dynacast test [{}]: event channel closed", label)),
+        }
+    }
+}
+
+/// Waits until the requested tracks have active layers and all other tracks are fully inactive.
+#[cfg(feature = "__lk-e2e-test")]
+async fn wait_for_requested_tracks_only(
+    tracks: &[(TrackSid, LocalVideoTrack)],
+    active_sids: &[TrackSid],
+    label: &str,
+    max_wait: Duration,
+) -> Result<()> {
+    let deadline = tokio::time::Instant::now() + max_wait;
+    loop {
+        let mut states = Vec::with_capacity(tracks.len());
+        let expected = tracks.iter().all(|(sid, track)| {
+            let layers = track.publishing_layers();
+            let active_count = layers.iter().filter(|layer| layer.active).count();
+            let should_publish = active_sids.contains(sid);
+            states.push(format!(
+                "{}={}/{} active ({})",
+                sid,
+                active_count,
+                layers.len(),
+                if should_publish { "requested" } else { "not requested" }
+            ));
+
+            !layers.is_empty()
+                && if should_publish {
+                    layers.len() > 1 && layers.iter().all(|layer| layer.active)
+                } else {
+                    layers.iter().all(|layer| !layer.active)
+                }
+        });
+
+        log::info!("dynacast test [{}]: {}", label, states.join(", "));
+        if expected {
+            for (sid, _) in tracks.iter().filter(|(sid, _)| !active_sids.contains(sid)) {
+                log::info!("dynacast test [{}]: track {} is not being published", label, sid);
+            }
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "dynacast test [{}]: timed out waiting for requested publishing state: {}",
+                label,
+                states.join(", ")
             ));
         }
         time::sleep(Duration::from_millis(250)).await;
@@ -153,6 +327,125 @@ async fn test_dynacast() -> Result<()> {
         "expected all layers active after HIGH request, got {:?}",
         layers
     );
+
+    Ok(())
+}
+
+/// Verifies that dynacast only publishes video tracks requested by subscribers.
+///
+/// A single publisher publishes three simulcast VP8 video tracks while two subscribers manually
+/// subscribe to one track each. The subscribers rotate through the three tracks, leaving a
+/// different track without subscribers on each cycle; the publisher should disable all layers for
+/// that unrequested track.
+#[cfg(feature = "__lk-e2e-test")]
+#[test_log::test(tokio::test)]
+async fn test_dynacast_multiple_subscribers_only_publish_requested_tracks() -> Result<()> {
+    let mut pub_room_opts = RoomOptions::default();
+    pub_room_opts.dynacast = true;
+
+    let mut sub_room_opts = RoomOptions::default();
+    sub_room_opts.dynacast = true;
+    sub_room_opts.auto_subscribe = false;
+
+    let pub_options = TestRoomOptions { room: pub_room_opts, ..Default::default() };
+    let sub_options = TestRoomOptions { room: sub_room_opts, ..Default::default() };
+
+    let mut rooms =
+        test_rooms_with_options([pub_options, sub_options.clone(), sub_options]).await?;
+    let (pub_room, _pub_events) = rooms.remove(0);
+    let (sub1_room, mut sub1_events) = rooms.remove(0);
+    let (sub2_room, mut sub2_events) = rooms.remove(0);
+
+    let pub_room = Arc::new(pub_room);
+    let mut solid_tracks = Vec::new();
+    let mut track_sids: Vec<TrackSid> = Vec::new();
+
+    for (index, luma) in [64, 128, 192].into_iter().enumerate() {
+        let solid_params = SolidColorParams { width: 1280, height: 720, luma };
+        let mut solid_track = SolidColorTrack::new(pub_room.clone(), solid_params);
+        solid_track.publish(VideoCodec::VP8, true).await?;
+
+        let published_tracks = wait_for_publisher_video_tracks(
+            &pub_room,
+            index + 1,
+            &format!("publish track {}", index + 1),
+            Duration::from_secs(15),
+        )
+        .await?;
+        let Some(new_sid) = published_tracks
+            .keys()
+            .find(|sid| !track_sids.iter().any(|published_sid| published_sid == *sid))
+        else {
+            return Err(anyhow!("No new track SID found after publishing track {}", index + 1));
+        };
+        log::info!("dynacast multi: published track {} as {}", index + 1, new_sid);
+        track_sids.push(new_sid.clone());
+        solid_tracks.push(solid_track);
+    }
+
+    let published_tracks = wait_for_publisher_video_tracks(
+        &pub_room,
+        3,
+        "all published tracks",
+        Duration::from_secs(5),
+    )
+    .await?;
+    let publisher_tracks: Vec<_> = track_sids
+        .iter()
+        .map(|sid| {
+            let track = published_tracks
+                .get(sid)
+                .ok_or_else(|| anyhow!("Missing local video track {}", sid))?;
+            Ok((sid.clone(), track.clone()))
+        })
+        .collect::<Result<_>>()?;
+
+    let sub1_publications = wait_for_remote_publications(
+        &sub1_room,
+        &track_sids,
+        "subscriber 1",
+        Duration::from_secs(15),
+    )
+    .await?;
+    let sub2_publications = wait_for_remote_publications(
+        &sub2_room,
+        &track_sids,
+        "subscriber 2",
+        Duration::from_secs(15),
+    )
+    .await?;
+
+    for (cycle_index, (sub1_index, sub2_index, inactive_index)) in
+        [(0, 1, 2), (1, 2, 0), (2, 0, 1)].into_iter().enumerate()
+    {
+        let sub1_sid = &track_sids[sub1_index];
+        let sub2_sid = &track_sids[sub2_index];
+        let inactive_sid = &track_sids[inactive_index];
+        let label = format!("cycle {}", cycle_index + 1);
+
+        log::info!(
+            "dynacast multi [{}]: subscriber 1 -> {}, subscriber 2 -> {}, unrequested -> {}",
+            label,
+            sub1_sid,
+            sub2_sid,
+            inactive_sid
+        );
+
+        set_only_subscribed(&sub1_publications, &mut sub1_events, sub1_sid, &label).await?;
+        set_only_subscribed(&sub2_publications, &mut sub2_events, sub2_sid, &label).await?;
+
+        wait_for_requested_tracks_only(
+            &publisher_tracks,
+            &[sub1_sid.clone(), sub2_sid.clone()],
+            &label,
+            Duration::from_secs(30),
+        )
+        .await?;
+    }
+
+    for solid_track in &mut solid_tracks {
+        solid_track.unpublish().await?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
- properly handle `SubscribedQualityUpdate` events from SFU and update published layers.
- Add e2e tests for dynacast

Heres a video of dynacast working. We can see that if we get server commands down, we properly respond
https://github.com/user-attachments/assets/41bb2da5-c58d-47cb-8399-a767d987c353

