### PR TITLE
UniFFI: Swift dylibs

### DIFF
--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -286,7 +286,7 @@ install_crate = { crate_name = "tera-cli", binary = "tera", test_arg = "--versio
 script_runner = "@shell"
 script = """
 tera  --env --file ${SUPPORT_DIR}/${LANG}/Package.swift.tera > ${SPM_NAME}/Package.swift
-tera  --env --file ${SUPPORT_DIR}/${LANG}/Package@swift-6.0.swift.tera > ${SPM_NAME}/Package@swift-6.0.swift
+tera  --env --file ${SUPPORT_DIR}/${LANG}/Package@swift-6.2.swift.tera > ${SPM_NAME}/Package@swift-6.2.swift
 cp ${SUPPORT_DIR}/${LANG}/PrivacyInfo.xcprivacy ${SPM_NAME}/PrivacyInfo.xcprivacy
 cp ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/LICENSE ${SPM_NAME}/LICENSE
 """

--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -288,6 +288,7 @@ script = """
 tera  --env --file ${SUPPORT_DIR}/${LANG}/Package.swift.tera > ${SPM_NAME}/Package.swift
 tera  --env --file ${SUPPORT_DIR}/${LANG}/Package@swift-6.0.swift.tera > ${SPM_NAME}/Package@swift-6.0.swift
 cp ${SUPPORT_DIR}/${LANG}/PrivacyInfo.xcprivacy ${SPM_NAME}/PrivacyInfo.xcprivacy
+cp ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/LICENSE ${SPM_NAME}/LICENSE
 """
 
 [tasks.swift-move-to-packages]

--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -287,6 +287,7 @@ script_runner = "@shell"
 script = """
 tera  --env --file ${SUPPORT_DIR}/${LANG}/Package.swift.tera > ${SPM_NAME}/Package.swift
 tera  --env --file ${SUPPORT_DIR}/${LANG}/Package@swift-6.0.swift.tera > ${SPM_NAME}/Package@swift-6.0.swift
+cp ${SUPPORT_DIR}/${LANG}/PrivacyInfo.xcprivacy ${SPM_NAME}/PrivacyInfo.xcprivacy
 """
 
 [tasks.swift-move-to-packages]

--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -17,7 +17,6 @@ PACKAGES_DIR = "./packages"
 SUPPORT_DIR = "./support"
 LIB_NAME = "lib${CARGO_MAKE_CRATE_FS_NAME}"
 TARGET_DIR = "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}"
-SWIFT_VERSION = "6.0"
 SPM_NAME = "LiveKitUniFFI"
 NPM_NAME = "@livekit/uniffi"
 
@@ -252,11 +251,11 @@ script = """
 export IPHONEOS_DEPLOYMENT_TARGET=13.0
 export MACOSX_DEPLOYMENT_TARGET=10.15
 export TVOS_DEPLOYMENT_TARGET=17.0
-export XROS_DEPLOYMENT_TARGET=2.0
+export XROS_DEPLOYMENT_TARGET=26.0
 export CFLAGS_x86_64_apple_ios_macabi="--target=x86_64-apple-ios14.0-macabi"
 export CFLAGS_aarch64_apple_ios_macabi="--target=aarch64-apple-ios14.0-macabi"
 
-CMD="cargo swift package \
+cargo swift package \
 --accept-all \
 --name ${SPM_NAME} \
 --platforms macos \
@@ -265,15 +264,7 @@ CMD="cargo swift package \
 --platforms visionos \
 --platforms tvos \
 --lib-type dynamic \
-${SWIFT_RELEASE_FLAG}"
-
-if command -v swiftly >/dev/null 2>&1; then
-    echo "Using swiftly to select Swift ${SWIFT_VERSION} toolchain"
-    swiftly run $CMD +${SWIFT_VERSION}
-else
-    echo "swiftly not found, using system toolchain"
-    $CMD
-fi
+${SWIFT_RELEASE_FLAG}
 """
 
 [tasks.swift-generate-manifest.env]

--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -264,6 +264,7 @@ cargo swift package \
 --platforms visionos \
 --platforms tvos \
 --lib-type dynamic \
+--privacy-manifest ${SUPPORT_DIR}/swift/PrivacyInfo.xcprivacy \
 ${SWIFT_RELEASE_FLAG}
 """
 
@@ -278,25 +279,7 @@ script_runner = "@shell"
 script = """
 tera  --env --file ${SUPPORT_DIR}/${LANG}/Package.swift.tera > ${SPM_NAME}/Package.swift
 tera  --env --file ${SUPPORT_DIR}/${LANG}/Package@swift-6.2.swift.tera > ${SPM_NAME}/Package@swift-6.2.swift
-cp ${SUPPORT_DIR}/${LANG}/PrivacyInfo.xcprivacy ${SPM_NAME}/PrivacyInfo.xcprivacy
 cp ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/LICENSE ${SPM_NAME}/LICENSE
-"""
-
-[tasks.swift-embed-privacy-manifest]
-private = true
-description = "Copy PrivacyInfo.xcprivacy into each .framework slice (next to Info.plist)"
-script_runner = "@shell"
-script = """
-manifest="${SUPPORT_DIR}/${LANG}/PrivacyInfo.xcprivacy"
-for framework in ${SPM_NAME}/*.xcframework/*/*.framework; do
-    if [ -d "${framework}/Versions/A/Resources" ]; then
-        # Versioned bundle (macOS, Mac Catalyst): manifest lives alongside Info.plist
-        cp "${manifest}" "${framework}/Versions/A/Resources/PrivacyInfo.xcprivacy"
-    else
-        # Shallow bundle (iOS, tvOS, visionOS, watchOS): manifest at framework root
-        cp "${manifest}" "${framework}/PrivacyInfo.xcprivacy"
-    fi
-done
 """
 
 [tasks.swift-move-to-packages]
@@ -314,7 +297,6 @@ private = true
 dependencies = [
     "swift-xcframework",
     "swift-generate-manifest",
-    "swift-embed-privacy-manifest",
     "swift-move-to-packages"
 ]
 

--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -19,7 +19,6 @@ LIB_NAME = "lib${CARGO_MAKE_CRATE_FS_NAME}"
 TARGET_DIR = "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}"
 SWIFT_VERSION = "6.0"
 SPM_NAME = "LiveKitUniFFI"
-XCFRAMEWORK_NAME = "Rust${SPM_NAME}"
 NPM_NAME = "@livekit/uniffi"
 
 # Base URL for downloading release builds of the cdylib.
@@ -246,8 +245,8 @@ SWIFT_RELEASE_FLAG = { value = "--release", condition = { profiles = ["release"]
 
 [tasks.swift-xcframework]
 private = true
-install_crate = { crate_name = "cargo-swift", version = "0.10.0", binary = "cargo-swift", test_arg = "--help" }
-install_crate_args = ["--force"]
+install_crate = { crate_name = "cargo-swift", binary = "cargo-swift", test_arg = "--help" }
+install_crate_args = ["--git", "https://github.com/livekit/cargo-swift.git", "--branch", "feature/framework-wrapping", "--force"]
 script_runner = "@shell"
 script = """
 export IPHONEOS_DEPLOYMENT_TARGET=13.0
@@ -260,13 +259,12 @@ export CFLAGS_aarch64_apple_ios_macabi="--target=aarch64-apple-ios14.0-macabi"
 CMD="cargo swift package \
 --accept-all \
 --name ${SPM_NAME} \
---xcframework-name ${XCFRAMEWORK_NAME} \
 --platforms macos \
 --platforms ios \
 --platforms maccatalyst \
 --platforms visionos \
 --platforms tvos \
---lib-type static \
+--lib-type dynamic \
 ${SWIFT_RELEASE_FLAG}"
 
 if command -v swiftly >/dev/null 2>&1; then
@@ -295,20 +293,6 @@ tera  --env --file ${SUPPORT_DIR}/${LANG}/Package@swift-6.0.swift.tera > ${SPM_N
 private = true
 script_runner = "@shell"
 script = """
-# Patch the generated XCFramework and Swift sources to match the framework name
-# This ensures compatibility with Swift 6.2+ which requires the module name to match the framework name
-
-FFI_NAME="livekit_uniffiFFI"
-
-# 1. Rename header files inside the XCFramework
-find "${SPM_NAME}/${XCFRAMEWORK_NAME}.xcframework" -name "${FFI_NAME}.h" -exec bash -c 'mv "$1" "$(dirname "$1")/'"${XCFRAMEWORK_NAME}"'.h"' _ {} \\;
-
-# 2. Patch the modulemaps inside the XCFramework
-find "${SPM_NAME}/${XCFRAMEWORK_NAME}.xcframework" -name "module.modulemap" -exec sed -i '' "s/${FFI_NAME}/${XCFRAMEWORK_NAME}/g" {} +
-
-# 3. Patch the generated Swift sources
-find "${SPM_NAME}/Sources" -name "*.swift" -exec sed -i '' "s/${FFI_NAME}/${XCFRAMEWORK_NAME}/g" {} +
-
 out_dir="${PACKAGES_DIR}/${LANG}"
 rm -rf "${out_dir}"
 mkdir -p "${out_dir}"

--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -291,6 +291,23 @@ cp ${SUPPORT_DIR}/${LANG}/PrivacyInfo.xcprivacy ${SPM_NAME}/PrivacyInfo.xcprivac
 cp ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/LICENSE ${SPM_NAME}/LICENSE
 """
 
+[tasks.swift-embed-privacy-manifest]
+private = true
+description = "Copy PrivacyInfo.xcprivacy into each .framework slice (next to Info.plist)"
+script_runner = "@shell"
+script = """
+manifest="${SUPPORT_DIR}/${LANG}/PrivacyInfo.xcprivacy"
+for framework in ${SPM_NAME}/*.xcframework/*/*.framework; do
+    if [ -d "${framework}/Versions/A/Resources" ]; then
+        # Versioned bundle (macOS, Mac Catalyst): manifest lives alongside Info.plist
+        cp "${manifest}" "${framework}/Versions/A/Resources/PrivacyInfo.xcprivacy"
+    else
+        # Shallow bundle (iOS, tvOS, visionOS, watchOS): manifest at framework root
+        cp "${manifest}" "${framework}/PrivacyInfo.xcprivacy"
+    fi
+done
+"""
+
 [tasks.swift-move-to-packages]
 private = true
 script_runner = "@shell"
@@ -306,6 +323,7 @@ private = true
 dependencies = [
     "swift-xcframework",
     "swift-generate-manifest",
+    "swift-embed-privacy-manifest",
     "swift-move-to-packages"
 ]
 

--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -265,6 +265,7 @@ cargo swift package \
 --platforms tvos \
 --lib-type dynamic \
 --privacy-manifest ${SUPPORT_DIR}/swift/PrivacyInfo.xcprivacy \
+--exclude-arch x86_64-apple-tvos \
 ${SWIFT_RELEASE_FLAG}
 """
 

--- a/livekit-uniffi/support/swift/Package@swift-6.2.swift.tera
+++ b/livekit-uniffi/support/swift/Package@swift-6.2.swift.tera
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 // Generated from Rust template
 
 import PackageDescription
@@ -9,7 +9,7 @@ let package = Package(
         .iOS(.v13),
         .macOS(.v10_15),
         .macCatalyst(.v14),
-        .visionOS(.v2),
+        .visionOS(.v26),
         .tvOS(.v17),
     ],
     products: [

--- a/livekit-uniffi/support/swift/PrivacyInfo.xcprivacy
+++ b/livekit-uniffi/support/swift/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/livekit-uniffi/uniffi.toml
+++ b/livekit-uniffi/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.swift]
+ffi_module_name = "RustLiveKitUniFFI"


### PR DESCRIPTION
Uses this fork: https://github.com/livekit/cargo-swift

- Leverages proper dylib feature (most of the heavy lifting is in `cargo swift`)
- Removes some previous workarounds fixed in the upstream ⬆️ 

Validated on App Store builds (iOS/macOS):

<img width="875" height="110" alt="Screenshot 2026-04-15 at 11 53 32 AM" src="https://github.com/user-attachments/assets/3a3f757c-c0d4-4932-a3c9-f3e8400d0519" />

### Running

With system (Xcode) swift: `cargo make --profile release swift-package`
Using [swiftly](https://github.com/swiftlang/swiftly): `swiftly run cargo make --profile release swift-package +6.0`

### Platforms

Matches this matrix: https://github.com/livekit/webrtc-xcframework#binaries-included

### Tiers

These require `nightly` toolchain:
```
- aarch64-apple-tvos
- aarch64-apple-tvos-sim
- aarch64-apple-visionos
- aarch64-apple-visionos-sim
```

`x86_64-apple-tvos` is permanently tier3 (but not needed, see above Platforms)

### Sizes

With the current (unchanged) optimization level, each slice is about 920KB.

[RustLiveKitUniFFI.xcframework.zip](https://github.com/user-attachments/files/26745205/RustLiveKitUniFFI.xcframework.zip)
