### PR TITLE
TEL-464: reduce redundant resampling in audio filter

### DIFF
--- a/.changeset/tel_464_reduce_redundant_resampling_in_audio_filter.md
+++ b/.changeset/tel_464_reduce_redundant_resampling_in_audio_filter.md
@@ -1,0 +1,6 @@
+---
+livekit: patch
+livekit-ffi: patch
+---
+
+TEL-464: reduce redundant resampling in audio filter - #1019 (@hechen-eng)

--- a/livekit-ffi/src/server/audio_stream.rs
+++ b/livekit-ffi/src/server/audio_stream.rs
@@ -109,14 +109,12 @@ impl FfiAudioStream {
                 // When the audio filter supports separate rates (v2), create
                 // the WebRTC sink at 48000 (WebRTC's internal pipeline rate)
                 // to skip resampling — the filter handles rate conversion.
-                let input_sample_rate = if audio_filter
-                    .as_ref()
-                    .is_some_and(|f| f.supports_separate_rates())
-                {
-                    48000
-                } else {
-                    output_sample_rate
-                };
+                let input_sample_rate =
+                    if audio_filter.as_ref().is_some_and(|f| f.supports_separate_rates()) {
+                        48000
+                    } else {
+                        output_sample_rate
+                    };
 
                 let native_stream = NativeAudioStream::with_options(
                     rtc_track,
@@ -289,14 +287,12 @@ impl FfiAudioStream {
                     }
                 });
 
-                let input_sample_rate = if filter
-                    .as_ref()
-                    .is_some_and(|f| f.supports_separate_rates())
-                {
-                    48000
-                } else {
-                    output_sample_rate
-                };
+                let input_sample_rate =
+                    if filter.as_ref().is_some_and(|f| f.supports_separate_rates()) {
+                        48000
+                    } else {
+                        output_sample_rate
+                    };
 
                 let (mut audio_filter_session, info) = match &filter {
                     Some(filter) => match &request.audio_filter_options {

--- a/livekit-ffi/src/server/audio_stream.rs
+++ b/livekit-ffi/src/server/audio_stream.rs
@@ -107,11 +107,11 @@ impl FfiAudioStream {
                 };
 
                 // When the audio filter supports separate rates (v2), create
-                // the WebRTC sink at 48000 (WebRTC's internal pipeline rate)
-                // to skip resampling — the filter handles rate conversion.
+                // the WebRTC sink at the codec's native rate to skip
+                // resampling — the filter handles rate conversion.
                 let input_sample_rate =
                     if audio_filter.as_ref().is_some_and(|f| f.supports_separate_rates()) {
-                        48000
+                        ffi_track.track.codec_clock_rate().unwrap_or(48000)
                     } else {
                         output_sample_rate
                     };
@@ -289,7 +289,7 @@ impl FfiAudioStream {
 
                 let input_sample_rate =
                     if filter.as_ref().is_some_and(|f| f.supports_separate_rates()) {
-                        48000
+                        track.codec_clock_rate().unwrap_or(48000) as i32
                     } else {
                         output_sample_rate
                     };

--- a/livekit-ffi/src/server/audio_stream.rs
+++ b/livekit-ffi/src/server/audio_stream.rs
@@ -98,7 +98,7 @@ impl FfiAudioStream {
             #[cfg(not(target_arch = "wasm32"))]
             proto::AudioStreamType::AudioStreamNative => {
                 let audio_stream = Self { handle_id, stream_type, self_dropped_tx };
-                let sample_rate = new_stream.sample_rate.unwrap_or(48000);
+                let output_sample_rate = new_stream.sample_rate.unwrap_or(48000);
                 let num_channels = new_stream.num_channels.unwrap_or(1);
                 let options = NativeAudioStreamOptions {
                     queue_size_frames: new_stream
@@ -106,16 +106,29 @@ impl FfiAudioStream {
                         .map(|capacity| capacity as usize),
                 };
 
+                // When the audio filter supports separate rates (v2), create
+                // the WebRTC sink at 48000 (WebRTC's internal pipeline rate)
+                // to skip resampling — the filter handles rate conversion.
+                let input_sample_rate = if audio_filter
+                    .as_ref()
+                    .is_some_and(|f| f.supports_separate_rates())
+                {
+                    48000
+                } else {
+                    output_sample_rate
+                };
+
                 let native_stream = NativeAudioStream::with_options(
                     rtc_track,
-                    sample_rate as i32,
+                    input_sample_rate as i32,
                     num_channels as i32,
                     options,
                 );
 
                 let stream = if let Some(audio_filter) = &audio_filter {
                     let session = audio_filter.clone().new_session(
-                        sample_rate,
+                        input_sample_rate,
+                        output_sample_rate,
                         new_stream.audio_filter_options.unwrap_or("".into()),
                         info.as_ref().map(|i| i.stream_info.clone()).unwrap(),
                     );
@@ -126,7 +139,8 @@ impl FfiAudioStream {
                                 native_stream,
                                 session,
                                 Duration::from_millis(10),
-                                sample_rate,
+                                input_sample_rate,
+                                output_sample_rate,
                                 num_channels,
                             );
                             AudioStreamKind::Filtered(stream)
@@ -149,7 +163,7 @@ impl FfiAudioStream {
                     true,
                     info,
                     new_stream.frame_size_ms,
-                    sample_rate.try_into().unwrap(),
+                    output_sample_rate.try_into().unwrap(),
                     num_channels.try_into().unwrap(),
                 ));
                 server.watch_panic(handle);
@@ -253,7 +267,7 @@ impl FfiAudioStream {
                 let (c_tx, c_rx) = oneshot::channel::<()>();
                 let (handle_dropped_tx, handle_dropped_rx) = oneshot::channel::<()>();
                 let (done_tx, mut done_rx) = oneshot::channel::<()>();
-                let sample_rate = request.sample_rate.unwrap_or(48000) as i32;
+                let output_sample_rate = request.sample_rate.unwrap_or(48000) as i32;
                 let num_channels = request.num_channels.unwrap_or(1) as i32;
                 let track_sid = track.sid();
                 let options = NativeAudioStreamOptions {
@@ -275,6 +289,15 @@ impl FfiAudioStream {
                     }
                 });
 
+                let input_sample_rate = if filter
+                    .as_ref()
+                    .is_some_and(|f| f.supports_separate_rates())
+                {
+                    48000
+                } else {
+                    output_sample_rate
+                };
+
                 let (mut audio_filter_session, info) = match &filter {
                     Some(filter) => match &request.audio_filter_options {
                         Some(options) => {
@@ -293,7 +316,8 @@ impl FfiAudioStream {
                             };
 
                             let session = filter.clone().new_session(
-                                sample_rate as u32,
+                                input_sample_rate as u32,
+                                output_sample_rate as u32,
                                 &options,
                                 info.stream_info.clone(),
                             );
@@ -307,15 +331,20 @@ impl FfiAudioStream {
                     None => (None, None),
                 };
 
-                let native_stream =
-                    NativeAudioStream::with_options(rtc_track, sample_rate, num_channels, options);
+                let native_stream = NativeAudioStream::with_options(
+                    rtc_track,
+                    input_sample_rate,
+                    num_channels,
+                    options,
+                );
 
                 let stream = if let Some(session) = audio_filter_session.take() {
                     let stream = AudioFilterAudioStream::new(
                         native_stream,
                         session,
                         Duration::from_millis(10),
-                        sample_rate as u32,
+                        input_sample_rate as u32,
+                        output_sample_rate as u32,
                         num_channels as u32,
                     );
                     AudioStreamKind::Filtered(stream)
@@ -333,7 +362,7 @@ impl FfiAudioStream {
                         false,
                         info,
                         request.frame_size_ms,
-                        sample_rate.try_into().unwrap(),
+                        output_sample_rate.try_into().unwrap(),
                         num_channels.try_into().unwrap(),
                     )
                     .await;

--- a/livekit/src/plugin.rs
+++ b/livekit/src/plugin.rs
@@ -44,9 +44,17 @@ type CreateFn = unsafe extern "C" fn(
     options: *const c_char,
     stream_info: *const c_char,
 ) -> *mut c_void;
+type CreateV2Fn = unsafe extern "C" fn(
+    input_sample_rate: u32,
+    output_sample_rate: u32,
+    options: *const c_char,
+    stream_info: *const c_char,
+) -> *mut c_void;
 type DestroyFn = unsafe extern "C" fn(*const c_void);
 type ProcessI16Fn = unsafe extern "C" fn(*const c_void, usize, *const i16, *mut i16);
+type ProcessI16V2Fn = unsafe extern "C" fn(*const c_void, usize, *const i16, usize, *mut i16);
 type ProcessF32Fn = unsafe extern "C" fn(*const c_void, usize, *const f32, *mut f32);
+type ProcessF32V2Fn = unsafe extern "C" fn(*const c_void, usize, *const f32, usize, *mut f32);
 type UpdateStreamInfoFn = unsafe extern "C" fn(*const c_void, *const c_char);
 type UpdateRefreshedTokenFn = unsafe extern "C" fn(*const c_char, *const c_char);
 
@@ -70,9 +78,12 @@ pub struct AudioFilterPlugin {
     dependencies: Vec<Library>,
     on_load_fn_ptr: *const c_void,
     create_fn_ptr: *const c_void,
+    create_v2_fn_ptr: *const c_void,
     destroy_fn_ptr: *const c_void,
     process_i16_fn_ptr: *const c_void,
+    process_i16_v2_fn_ptr: *const c_void,
     process_f32_fn_ptr: *const c_void,
+    process_f32_v2_fn_ptr: *const c_void,
     update_stream_info_fn_ptr: *const c_void,
     update_token_fn_ptr: *const c_void,
 }
@@ -106,7 +117,13 @@ impl AudioFilterPlugin {
         let create_fn_ptr = unsafe {
             lib.get::<Symbol<CreateFn>>(b"audio_filter_create")?.try_as_raw_ptr().unwrap()
         };
-        if create_fn_ptr.is_null() {
+        let create_v2_fn_ptr = unsafe {
+            match lib.get::<Symbol<CreateV2Fn>>(b"audio_filter_create_v2") {
+                Ok(sym) => sym.try_as_raw_ptr().unwrap(),
+                Err(_) => std::ptr::null(),
+            }
+        };
+        if create_fn_ptr.is_null() && create_v2_fn_ptr.is_null() {
             return Err(PluginError::NotImplemented(
                 "audio_filter_create is not implemented".into(),
             ));
@@ -124,7 +141,13 @@ impl AudioFilterPlugin {
                 .try_as_raw_ptr()
                 .unwrap()
         };
-        if process_i16_fn_ptr.is_null() {
+        let process_i16_v2_fn_ptr = unsafe {
+            match lib.get::<Symbol<ProcessI16V2Fn>>(b"audio_filter_process_int16_v2") {
+                Ok(sym) => sym.try_as_raw_ptr().unwrap(),
+                Err(_) => std::ptr::null(),
+            }
+        };
+        if process_i16_fn_ptr.is_null() && process_i16_v2_fn_ptr.is_null() {
             return Err(PluginError::NotImplemented(
                 "audio_filter_process_int16 is not implemented".into(),
             ));
@@ -133,6 +156,12 @@ impl AudioFilterPlugin {
             lib.get::<Symbol<ProcessF32Fn>>(b"audio_filter_process_float")?
                 .try_as_raw_ptr()
                 .unwrap()
+        };
+        let process_f32_v2_fn_ptr = unsafe {
+            match lib.get::<Symbol<ProcessF32V2Fn>>(b"audio_filter_process_float_v2") {
+                Ok(sym) => sym.try_as_raw_ptr().unwrap(),
+                Err(_) => std::ptr::null(),
+            }
         };
         let update_stream_info_fn_ptr = unsafe {
             lib.get::<Symbol<UpdateStreamInfoFn>>(b"audio_filter_update_stream_info")?
@@ -152,9 +181,12 @@ impl AudioFilterPlugin {
             dependencies: Default::default(),
             on_load_fn_ptr,
             create_fn_ptr,
+            create_v2_fn_ptr,
             destroy_fn_ptr,
             process_i16_fn_ptr,
+            process_i16_v2_fn_ptr,
             process_f32_fn_ptr,
+            process_f32_v2_fn_ptr,
             update_stream_info_fn_ptr,
             update_token_fn_ptr,
         })
@@ -197,20 +229,36 @@ impl AudioFilterPlugin {
         unsafe { update_token_fn(url.as_ptr(), token.as_ptr()) }
     }
 
+    pub fn supports_separate_rates(&self) -> bool {
+        !self.create_v2_fn_ptr.is_null() && !self.process_i16_v2_fn_ptr.is_null()
+    }
+
     pub fn new_session<S: AsRef<str>>(
         self: Arc<Self>,
-        sampling_rate: u32,
+        input_sample_rate: u32,
+        output_sample_rate: u32,
         options: S,
         stream_info: AudioFilterStreamInfo,
     ) -> Option<AudioFilterSession> {
-        let create_fn: CreateFn = unsafe { std::mem::transmute(self.create_fn_ptr) };
-
         let options = CString::new(options.as_ref()).unwrap_or(CString::new("").unwrap());
 
         let stream_info = serde_json::to_string(&stream_info).unwrap();
         let stream_info = CString::new(stream_info).unwrap_or(CString::new("").unwrap());
 
-        let ptr = unsafe { create_fn(sampling_rate, options.as_ptr(), stream_info.as_ptr()) };
+        let ptr = if !self.create_v2_fn_ptr.is_null() {
+            let create_fn: CreateV2Fn = unsafe { std::mem::transmute(self.create_v2_fn_ptr) };
+            unsafe {
+                create_fn(
+                    input_sample_rate,
+                    output_sample_rate,
+                    options.as_ptr(),
+                    stream_info.as_ptr(),
+                )
+            }
+        } else {
+            let create_fn: CreateFn = unsafe { std::mem::transmute(self.create_fn_ptr) };
+            unsafe { create_fn(input_sample_rate, options.as_ptr(), stream_info.as_ptr()) }
+        };
         if ptr.is_null() {
             return None;
         }
@@ -230,14 +278,56 @@ impl AudioFilterSession {
         unsafe { destroy(self.ptr) };
     }
 
-    pub fn process_i16(&self, num_samples: usize, input: &[i16], output: &mut [i16]) {
-        let process: ProcessI16Fn = unsafe { std::mem::transmute(self.plugin.process_i16_fn_ptr) };
-        unsafe { process(self.ptr, num_samples, input.as_ptr(), output.as_mut_ptr()) };
+    pub fn process_i16(
+        &self,
+        in_num_samples: usize,
+        input: &[i16],
+        out_num_samples: usize,
+        output: &mut [i16],
+    ) {
+        if !self.plugin.process_i16_v2_fn_ptr.is_null() {
+            let process: ProcessI16V2Fn =
+                unsafe { std::mem::transmute(self.plugin.process_i16_v2_fn_ptr) };
+            unsafe {
+                process(
+                    self.ptr,
+                    in_num_samples,
+                    input.as_ptr(),
+                    out_num_samples,
+                    output.as_mut_ptr(),
+                )
+            };
+        } else {
+            let process: ProcessI16Fn =
+                unsafe { std::mem::transmute(self.plugin.process_i16_fn_ptr) };
+            unsafe { process(self.ptr, in_num_samples, input.as_ptr(), output.as_mut_ptr()) };
+        }
     }
 
-    pub fn process_f32(&self, num_samples: usize, input: &[f32], output: &mut [f32]) {
-        let process: ProcessF32Fn = unsafe { std::mem::transmute(self.plugin.process_f32_fn_ptr) };
-        unsafe { process(self.ptr, num_samples, input.as_ptr(), output.as_mut_ptr()) };
+    pub fn process_f32(
+        &self,
+        in_num_samples: usize,
+        input: &[f32],
+        out_num_samples: usize,
+        output: &mut [f32],
+    ) {
+        if !self.plugin.process_f32_v2_fn_ptr.is_null() {
+            let process: ProcessF32V2Fn =
+                unsafe { std::mem::transmute(self.plugin.process_f32_v2_fn_ptr) };
+            unsafe {
+                process(
+                    self.ptr,
+                    in_num_samples,
+                    input.as_ptr(),
+                    out_num_samples,
+                    output.as_mut_ptr(),
+                )
+            };
+        } else {
+            let process: ProcessF32Fn =
+                unsafe { std::mem::transmute(self.plugin.process_f32_fn_ptr) };
+            unsafe { process(self.ptr, in_num_samples, input.as_ptr(), output.as_mut_ptr()) };
+        }
     }
 
     pub fn update_stream_info(&self, info: AudioFilterStreamInfo) {
@@ -264,9 +354,10 @@ pub struct AudioFilterAudioStream {
     inner: NativeAudioStream,
     session: AudioFilterSession,
     buffer: Vec<i16>,
-    sample_rate: u32,
+    output_sample_rate: u32,
     num_channels: u32,
-    frame_size: usize,
+    input_frame_size: usize,
+    output_frame_size: usize,
 }
 
 impl AudioFilterAudioStream {
@@ -274,18 +365,22 @@ impl AudioFilterAudioStream {
         inner: NativeAudioStream,
         session: AudioFilterSession,
         duration: Duration,
-        sample_rate: u32,
+        input_sample_rate: u32,
+        output_sample_rate: u32,
         num_channels: u32,
     ) -> Self {
-        let frame_size =
-            ((sample_rate as f64) * duration.as_secs_f64() * num_channels as f64) as usize;
+        let input_frame_size =
+            ((input_sample_rate as f64) * duration.as_secs_f64() * num_channels as f64) as usize;
+        let output_frame_size =
+            ((output_sample_rate as f64) * duration.as_secs_f64() * num_channels as f64) as usize;
         Self {
             inner,
             session,
-            buffer: Vec::with_capacity(frame_size),
-            sample_rate,
+            buffer: Vec::with_capacity(input_frame_size),
+            output_sample_rate,
             num_channels,
-            frame_size,
+            input_frame_size,
+            output_frame_size,
         }
     }
 
@@ -306,17 +401,23 @@ impl Stream for AudioFilterAudioStream {
             };
             this.buffer.extend_from_slice(&frame.data);
 
-            if this.buffer.len() >= this.frame_size {
-                let data = this.buffer.drain(..this.frame_size).collect::<Vec<_>>();
-                let mut out: Vec<i16> = vec![0; this.frame_size];
+            if this.buffer.len() >= this.input_frame_size {
+                let data = this.buffer.drain(..this.input_frame_size).collect::<Vec<_>>();
+                let mut out: Vec<i16> = vec![0; this.output_frame_size];
 
-                this.session.process_i16(this.frame_size, &data, &mut out);
+                this.session.process_i16(
+                    this.input_frame_size,
+                    &data,
+                    this.output_frame_size,
+                    &mut out,
+                );
 
                 return Poll::Ready(Some(AudioFrame {
                     data: out.into(),
-                    sample_rate: this.sample_rate,
+                    sample_rate: this.output_sample_rate,
                     num_channels: this.num_channels,
-                    samples_per_channel: (this.frame_size / this.num_channels as usize) as u32,
+                    samples_per_channel: (this.output_frame_size / this.num_channels as usize)
+                        as u32,
                 }));
             }
         }

--- a/livekit/src/room/track/mod.rs
+++ b/livekit/src/room/track/mod.rs
@@ -130,6 +130,18 @@ impl Track {
             Self::RemoteVideo(track) => track.get_stats().await,
         }
     }
+
+    /// Returns the codec clock rate from the receiver's RTP parameters.
+    /// This is the actual sample rate of the audio delivered by WebRTC's decoder.
+    pub fn codec_clock_rate(&self) -> Option<u32> {
+        self.transceiver()?
+            .receiver()
+            .parameters()
+            .codecs
+            .first()
+            .and_then(|c| c.clock_rate)
+            .map(|r| r as u32)
+    }
 }
 
 pub(super) use track_dispatch;


### PR DESCRIPTION
## Problem

When an audio filter (Krisp NC or ai-coustics) is active, audio gets resampled multiple times unnecessarily. The root cause is that the `livekit-ffi` audio filter plugin interface only supports a single `sample_rate`, used for both input and output. The WebRTC sink resamples audio to the target rate *before* passing it to the filter, and the filter may resample again internally to match its model's native rate.

### Current pipeline (agents, default `sample_rate=24000`)

```
WebRTC track (48000 Hz)
  → WebRTC native audio sink resamples (48000 → 24000)
  → Audio filter receives frames at 24000
  → Filter internally resamples to model rate and back (24000 → model_rate → 24000)
  → Agents receive frames at 24000
```

Krisp model native rates (per [Krisp SDK model selection guide](https://sdk-docs.krisp.ai/docs/krisp-audio-sdk-model-selection-guide)):

| Model | File | Native rate |
|-------|------|-------------|
| NC | `c8.f.s.026300-1.0.0_3.1.kef` | 32kHz |
| BVC | `hs.c6.f.m.75df8f.kef` | 32kHz |
| BVC Telephony | `inb.bvc.hs.c6.w.s.23cdb3.kef` | 16kHz |

Current resampling with agents default `sample_rate=24000`:

| Model | Current pipeline | After fix |
|-------|-----------------|-----------|
| Krisp NC (32kHz) | 48→24→32→24 (3 steps) | 48→32→24 (2 steps) |
| Krisp BVC (32kHz) | 48→24→32→24 (3 steps) | 48→32→24 (2 steps) |
| Krisp BVC Telephony (16kHz) | 48→24→16→24 (3 steps) | 48→16→24 (2 steps) |
| ai-coustics QuailL (16kHz) | 48→24→16→24 (3 steps) | no change (v1 fallback) |

ai-coustics model rate per `resolve_for_sample_rate` and [ai-coustics docs](https://docs.ai-coustics.com/guides/models).

### Ideal pipeline

```
WebRTC track (48000 Hz)
  → Audio filter receives frames at 48000, outputs at 24000
  → Filter internally: 48000 → model_rate → 24000
  → Agents receive frames at 24000
```

The WebRTC resampling step is eliminated. The filter handles rate conversion as part of its processing.

### Same problem existed in SIP (https://github.com/livekit/cloud-sip/pull/337)

This is the same issue that was fixed in `cloud-sip` + `sip`. The SIP pipeline had:
```
audioIn(A) → external resampler(A→B) → Krisp(B→B) → downstream(B)
```
Fixed to:
```
audioIn(A) → Krisp(input=A, output=B) → downstream(B)
```
The Krisp C SDK already supports separate input/output rates via `krispAudioNcCreateSession(inputSampleRate, outputSampleRate, ...)`.

## Solution

Add v2 plugin ABI symbols (`audio_filter_create_v2`, `audio_filter_process_int16_v2`, `audio_filter_process_float_v2`) that accept separate input and output sample rates. The FFI server probes for v2 symbols at plugin load time. When present, it creates the WebRTC sink at 48000 Hz (WebRTC's internal pipeline rate) so audio passes through without resampling, and the filter handles the rate conversion. When absent (v1 plugins), behavior is unchanged.

## Further Work: ai-coustics

ai-coustics currently processes audio in-place at a single rate (`process(&mut frame)`). Their SDK does not support separate input and output sample rates, so ai-coustics cannot take advantage of the v2 plugin ABI today. The FFI server falls back to v1 behavior (WebRTC resamples first, then ai-coustics processes at the resampled rate, potentially resampling again internally to the model's native 16kHz).

Two options to eliminate the redundant resampling for ai-coustics:

1. **Request ai-coustics to support separate input/output sample rates** in their SDK (similar to how Krisp's `krispAudioNcCreateSession` accepts both). The ai-coustics plugin would then export v2 symbols and the fix works the same way as Krisp.

2. **Handle the resampling ourselves in the plugin wrapper**. Resample from the input rate (48kHz) to the model's native rate (e.g., 16kHz for QuailL) before calling `process()`, then resample the output to the desired output rate (24kHz). This avoids the unnecessary 48→24 step in WebRTC while still using the existing in-place ai-coustics API. The trade-off is that we own the resampling logic and need to keep it in sync with whichever model is selected.