### PR TITLE
feat(livekit): auto-flag stereo on audio tracks with num_channels == 2

### DIFF
--- a/livekit/src/room/participant/local_participant.rs
+++ b/livekit/src/room/participant/local_participant.rs
@@ -316,6 +316,26 @@ impl LocalParticipant {
             req.audio_features.push(proto::AudioTrackFeature::TfPreconnectBuffer as i32);
         }
 
+        // Auto-flag stereo on audio tracks whose underlying source declares
+        // num_channels == 2. Without this, the server treats the track as
+        // mono and libwebrtc's Opus path downmixes asymmetric stereo to
+        // mono-duplicated-both-channels (identical content on L and R).
+        // This matches the JS client SDK's forceStereo+audioFeatures behaviour.
+        // RtcAudioSource's num_channels() accessor is private (generated via
+        // enum_dispatch!), so we match the variant directly.
+        if let LocalTrack::Audio(audio_track) = &track {
+            use libwebrtc::audio_source::RtcAudioSource;
+            let is_stereo = match audio_track.rtc_source() {
+                RtcAudioSource::Native(native) => native.num_channels() == 2,
+                #[allow(unreachable_patterns)]
+                _ => false,
+            };
+            if is_stereo {
+                req.audio_features.push(proto::AudioTrackFeature::TfStereo as i32);
+                req.stereo = true;
+            }
+        }
+
         let mut encodings = Vec::default();
         match &track {
             LocalTrack::Video(video_track) => {


### PR DESCRIPTION
## Problem

When an application publishes a 2-channel `NativeAudioSource` via the Rust SDK and pushes asymmetric stereo `AudioFrame`s (e.g. silence on L, speech on R), the client-side receive path sees **identical L and R content on every frame** — as if the track were mono-duplicated. SDP advertises `stereo=1` thanks to the standard Opus fmtp, and `MediaStreamTrack.getSettings().channelCount` returns 2 on the receiver, but the actual decoded content is mono.

Root cause: the server locks the track to mono-encoded Opus at negotiation time, and libwebrtc's Opus encoder downmixes asymmetric input accordingly, *before* any content reaches the wire. The server makes this decision based on `AddTrackRequest.audio_features` (specifically `TF_STEREO`) and the deprecated `AddTrackRequest.stereo` bool. The JS client SDK ([`LocalParticipant.ts`](https://github.com/livekit/client-sdk-js/blob/main/src/room/participant/LocalParticipant.ts)) sets both flags when `opts.forceStereo === true` or when `MediaStreamTrack.getSettings().channelCount === 2`. The Rust SDK never sets either — it doesn't read `num_channels` off the source, and `TrackPublishOptions` has no `force_stereo` / `audio_preset` field.

## Fix

If the track being published has an audio source with `num_channels() == 2`, push `TfStereo` into `audio_features` and set the deprecated `stereo` bool. Both go on the `AddTrackRequest` built in `publish_track`, next to the analogous `TfPreconnectBuffer` handling. Includes a changeset.

## Verified

Built `liblivekit_ffi` for `aarch64-apple-darwin` with this patch, dropped it into a Python SDK install, ran a LiveKit session with an agent publishing 2-channel 24 kHz audio (silence on L, TTS speech on R), and captured the decoded track at the Chrome client via `MediaStreamTrackProcessor`:

```
frame 5:  ch=2 L=-InfinitydBFS R=-12.8dBFS  |diff|=Infinity
frame 10: ch=2 L=-InfinitydBFS R=-90.5dBFS  |diff|=Infinity
frame 15: ch=2 L=-InfinitydBFS R=-21.8dBFS  |diff|=Infinity
...
```

L reads at codec floor on every frame; R tracks the speech envelope. Without the patch, L == R exactly on every frame with content magnitude matching whatever we pushed on R.

## Context

This came out of building a stereo marker channel on top of the speech track (silent L → marker tones placed sample-aligned with speech boundaries on L, speech PCM on R) for turn-boundary synchronization. All publisher-side workarounds we tried (disabling APM via `AudioSourceOptions`, labelling as `SOURCE_SCREENSHARE_AUDIO`, pinning `max_bitrate`, pushing native 48 kHz frames to bypass the resampler) failed because the server's mono negotiation precedes everything else. The JS SDK's explicit stereo hint on `AddTrackRequest` is the only thing that prevents it.

Sending both the deprecated `stereo` bool and `TfStereo` for robustness across server versions, as the JS SDK does. Happy to drop the bool if you prefer.
