### PR TITLE
Fix data tracks extension encoding

### DIFF
--- a/.changeset/fix_data_track_packet_issue_breaking_e2ee.md
+++ b/.changeset/fix_data_track_packet_issue_breaking_e2ee.md
@@ -1,0 +1,7 @@
+---
+livekit: patch
+livekit-datatrack: patch
+livekit-ffi: patch
+---
+
+# Fix data track packet format issue breaking E2EE

--- a/livekit-datatrack/docs/packet-v0.md
+++ b/livekit-datatrack/docs/packet-v0.md
@@ -49,7 +49,7 @@ packet
 | Final Flag (F) | 1 | If set, this is the final packet in a frame. |
 | Extension Flag (X) | 1 | If set, extensions follow the base header. See format details below. |
 | Reserved | 10 | Reserved for future use. |
-| Track Handle | 16 |  Unique identifier of the track the frame belongs to, assigned during signaling. Zero is not a valid track identifier. |
+| Track Handle | 16 | Unique identifier of the track the frame belongs to, assigned during signaling. Zero is not a valid track identifier. |
 | Sequence Number | 16 | Incremented by the publisher for each packet sent, used to detect missing/out-of-order packets. |
 | Frame Number | 16 | The frame this packet belongs to. |
 | Timestamp | 32 | Equivalent to RTP media timestamp, uses a clock rate of 90K ticks per second. |
@@ -63,7 +63,7 @@ packet
 
 If the extension flag in the base header is set, one or more extensions will follow. The format is a variant of [RFC 5285 §4.3](https://datatracker.ietf.org/doc/html/rfc5285#section-4.3) with two notable differences:
 
-1. There is no fixed-bit pattern following the base header. Instead, it is immediately followed by 16-bit integer indicating total length of all header extensions and padding expressed in number of 32-bit words (i.e., 1 word = 4 bytes) minus one.
+1. There is no fixed-bit pattern following the base header. Instead, it is immediately followed by a 16-bit length field $L$. This field, the extensions, and any padding together occupy $(L + 1) \times 4$ bytes.
 
 2. Available extensions and their format are defined by this specification rather than out-of-band. The following extensions are currently defined:
 
@@ -100,26 +100,26 @@ packet
 +16: "Extension Words (7)"
 
 %% E2EE extension
-+8: "ID (2)"
++8: "ID (1)"
 +8: "Length (13)"
 +8: "Key Index"
 +96: "IV"
 
 %% User timestamp extension
-+8: "ID (1)"
++8: "ID (2)"
 +8: "Length (8)"
 +64: "User Timestamp"
 
-+24: "Padding (0)"
++8: "Padding (0)"
 
 %% Payload
 + 32: "Payload"
 ```
 
-- 46 bytes total
-  - Header: 42 bytes
+- 44 bytes total
+  - Header: 40 bytes
   - Payload: 4 bytes
-- Note the padding between the two extensions. This is required per [RFC 5285](https://datatracker.ietf.org/doc/html/rfc5285#section-4.3) to ensure the extension block is word aligned. This example shows it placed between the two extensions, but it is allowed before or after any extension.
+- Note the trailing padding byte. This is required per [RFC 5285](https://datatracker.ietf.org/doc/html/rfc5285#section-4.3) to ensure the extension block (including the 2-byte length field) is word aligned. The example places it after the last extension, but it is allowed before or after any extension.
 
 ## Length calculations
 

--- a/livekit-datatrack/src/packet/deserialize.rs
+++ b/livekit-datatrack/src/packet/deserialize.rs
@@ -81,7 +81,7 @@ impl Header {
             }
             let ext_words = raw.get_u16();
 
-            let ext_len = 4 * (ext_words as usize + 1);
+            let ext_len = 4 * (ext_words as usize + 1) - EXT_WORDS_INDICATOR_SIZE;
             if ext_len > raw.remaining() {
                 Err(DeserializeError::HeaderOverrun)?
             }
@@ -158,6 +158,7 @@ impl E2eeExt {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::packet::consts::EXT_WORDS_INDICATOR_SIZE;
     use bytes::{BufMut, BytesMut};
     use test_case::test_matrix;
 
@@ -232,7 +233,8 @@ mod tests {
         raw[0] |= 1 << EXT_FLAG_SHIFT; // Extension flag
 
         raw.put_u16(ext_words as u16); // Extension words
-        raw.put_bytes(0, (ext_words + 1) * 4); // Padding
+        let data_len = (ext_words + 1) * 4 - EXT_WORDS_INDICATOR_SIZE;
+        raw.put_bytes(0, data_len); // Padding
 
         let packet = Packet::deserialize(raw.freeze()).unwrap();
         assert_eq!(packet.payload.len(), 0);
@@ -242,13 +244,13 @@ mod tests {
     fn test_ext_e2ee() {
         let mut raw = valid_packet();
         raw[0] |= 1 << EXT_FLAG_SHIFT; // Extension flag
-        raw.put_u16(3); // Extension words
+        raw.put_u16(4); // Extension words (includes 2-byte indicator in word count)
 
         raw.put_u8(1); // ID 1
         raw.put_u8(13); // Length
         raw.put_u8(0xFA); // Key index
         raw.put_bytes(0x3C, 12); // IV
-        raw.put_bytes(0, 1); // Padding
+        raw.put_bytes(0, 3); // Padding
 
         let packet = Packet::deserialize(raw.freeze()).unwrap();
         let e2ee = packet.header.extensions.e2ee.unwrap();
@@ -265,7 +267,6 @@ mod tests {
         raw.put_u8(2);
         raw.put_u8(8); // Length
         raw.put_slice(&[0x44, 0x11, 0x22, 0x11, 0x11, 0x11, 0x88, 0x11]); // User timestamp
-        raw.put_bytes(0, 2); // Padding
 
         let packet = Packet::deserialize(raw.freeze()).unwrap();
         assert_eq!(
@@ -284,7 +285,6 @@ mod tests {
         raw.put_u8(12); // Longer than known length (8), extra bytes are skipped
         raw.put_slice(&[0x44, 0x11, 0x22, 0x11, 0x11, 0x11, 0x88, 0x11]); // Known 8 bytes
         raw.put_bytes(0xFF, 4); // 4 extra bytes from a future version
-        raw.put_bytes(0, 2); // Padding
 
         let packet = Packet::deserialize(raw.freeze()).unwrap();
         assert_eq!(
@@ -302,7 +302,6 @@ mod tests {
         raw.put_u8(2); // User timestamp tag
         raw.put_u8(4); // Shorter than known length (8), treated as unknown
         raw.put_bytes(0x3C, 4);
-        raw.put_bytes(0, 2); // Padding
 
         let packet = Packet::deserialize(raw.freeze()).unwrap();
         assert!(packet.header.extensions.user_timestamp.is_none());
@@ -312,10 +311,12 @@ mod tests {
     fn test_ext_unknown() {
         let mut raw = valid_packet();
         raw[0] |= 1 << EXT_FLAG_SHIFT; // Extension flag
-        raw.put_u16(0); // Extension words
+        raw.put_u16(1); // Extension words
 
         raw.put_u8(8); // ID 8 (unknown)
-        raw.put_bytes(0, 7);
+        raw.put_u8(0); // Length 0
+        raw.put_bytes(0, 4); // Remaining padding
+
         Packet::deserialize(raw.freeze()).expect("Should skip unknown extension");
     }
 
@@ -323,8 +324,8 @@ mod tests {
     fn test_ext_required_word_alignment() {
         let mut raw = valid_packet();
         raw[0] |= 1 << EXT_FLAG_SHIFT; // Extension flag
-        raw.put_u16(0); // Extension words
-        raw.put_bytes(0, 3); // Padding, missing one byte
+        raw.put_u16(0); // Extension words (data_budget = 2)
+        raw.put_bytes(0, 1); // Only 1 byte, but 2 needed
 
         assert!(Packet::deserialize(raw.freeze()).is_err());
     }

--- a/livekit-datatrack/src/packet/deserialize.rs
+++ b/livekit-datatrack/src/packet/deserialize.rs
@@ -158,7 +158,6 @@ impl E2eeExt {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::packet::consts::EXT_WORDS_INDICATOR_SIZE;
     use bytes::{BufMut, BytesMut};
     use test_case::test_matrix;
 

--- a/livekit-datatrack/src/packet/serialize.rs
+++ b/livekit-datatrack/src/packet/serialize.rs
@@ -239,43 +239,4 @@ mod tests {
 
         assert_eq!(buf.remaining(), 0);
     }
-
-    /// Demonstrates the ext_words encoding for E2EE-only (no user timestamp).
-    /// The Go server decodes: data_budget = (wire_ext_words + 1) * 4 - 2
-    /// The E2EE extension TLV is 15 bytes (tag=1 + len=1 + key_index=1 + iv=12).
-    #[test]
-    fn test_e2ee_only_ext_words_matches_server() {
-        use crate::packet::consts::{EXT_MARKER_LEN, EXT_WORDS_INDICATOR_SIZE};
-
-        let e2ee_only = Packet {
-            header: Header {
-                marker: FrameMarker::Single,
-                track_handle: 1u32.try_into().unwrap(),
-                sequence: 0,
-                frame_number: 0,
-                timestamp: Timestamp::from_ticks(0),
-                extensions: Extensions {
-                    user_timestamp: None,
-                    e2ee: E2eeExt { key_index: 0, iv: [0; 12] }.into(),
-                },
-            },
-            payload: vec![0xAB; 64].into(),
-        };
-
-        let metrics = e2ee_only.header.metrics();
-
-        let serialized = e2ee_only.serialize();
-        let wire_ext_words = u16::from_be_bytes([serialized[12], serialized[13]]);
-
-        // Go server computes: data_budget = (wire_ext_words + 1) * 4 - EXT_WORDS_INDICATOR_SIZE
-        let go_data_budget = (wire_ext_words as usize + 1) * 4 - EXT_WORDS_INDICATOR_SIZE;
-
-        let e2ee_tlv_size = EXT_MARKER_LEN + E2eeExt::LEN;
-
-        assert!(
-            go_data_budget >= e2ee_tlv_size,
-            "Go server data_budget ({}) < E2EE TLV size ({}). Wire ext_words={}, ext_len={}",
-            go_data_budget, e2ee_tlv_size, wire_ext_words, metrics.ext_len
-        );
-    }
 }

--- a/livekit-datatrack/src/packet/serialize.rs
+++ b/livekit-datatrack/src/packet/serialize.rs
@@ -77,8 +77,8 @@ impl Header {
     /// Lengths of individual elements in the serialized header.
     fn metrics(&self) -> HeaderMetrics {
         let ext_len = self.extensions.serialized_len();
-        let ext_words = ext_len.div_ceil(4);
-        let padding_len = (ext_words * 4) - ext_len;
+        let ext_words = (EXT_WORDS_INDICATOR_SIZE + ext_len).div_ceil(4);
+        let padding_len = (ext_words * 4) - EXT_WORDS_INDICATOR_SIZE - ext_len;
         HeaderMetrics { ext_len, ext_words, padding_len }
     }
 
@@ -198,21 +198,21 @@ mod tests {
         let metrics = packet().header.metrics();
         assert_eq!(metrics.ext_len, 25);
         assert_eq!(metrics.ext_words, 7);
-        assert_eq!(metrics.padding_len, 3);
+        assert_eq!(metrics.padding_len, 1);
     }
 
     #[test]
     fn test_serialized_length() {
         let packet = packet();
-        assert_eq!(packet.serialized_len(), 1066);
-        assert_eq!(packet.header.serialized_len(), 42);
+        assert_eq!(packet.serialized_len(), 1064);
+        assert_eq!(packet.header.serialized_len(), 40);
         assert_eq!(packet.header.extensions.serialized_len(), 25);
     }
 
     #[test]
     fn test_serialize() {
         let mut buf = packet().serialize().try_into_mut().unwrap();
-        assert_eq!(buf.len(), 1066);
+        assert_eq!(buf.len(), 1064);
 
         // Base header
         assert_eq!(buf.get_u8(), 0xC); // Version 0, final, extension
@@ -234,9 +234,48 @@ mod tests {
         assert_eq!(buf.get_u8(), 8); // Length
         assert_eq!(buf.get_u64(), 0x4411221111118811);
 
-        assert_eq!(buf.copy_to_bytes(3), vec![0; 3]); // Padding
+        assert_eq!(buf.copy_to_bytes(1), vec![0; 1]); // Padding
         assert_eq!(buf.copy_to_bytes(1024), vec![0xFA; 1024]); // Payload
 
         assert_eq!(buf.remaining(), 0);
+    }
+
+    /// Demonstrates the ext_words encoding for E2EE-only (no user timestamp).
+    /// The Go server decodes: data_budget = (wire_ext_words + 1) * 4 - 2
+    /// The E2EE extension TLV is 15 bytes (tag=1 + len=1 + key_index=1 + iv=12).
+    #[test]
+    fn test_e2ee_only_ext_words_matches_server() {
+        use crate::packet::consts::{EXT_MARKER_LEN, EXT_WORDS_INDICATOR_SIZE};
+
+        let e2ee_only = Packet {
+            header: Header {
+                marker: FrameMarker::Single,
+                track_handle: 1u32.try_into().unwrap(),
+                sequence: 0,
+                frame_number: 0,
+                timestamp: Timestamp::from_ticks(0),
+                extensions: Extensions {
+                    user_timestamp: None,
+                    e2ee: E2eeExt { key_index: 0, iv: [0; 12] }.into(),
+                },
+            },
+            payload: vec![0xAB; 64].into(),
+        };
+
+        let metrics = e2ee_only.header.metrics();
+
+        let serialized = e2ee_only.serialize();
+        let wire_ext_words = u16::from_be_bytes([serialized[12], serialized[13]]);
+
+        // Go server computes: data_budget = (wire_ext_words + 1) * 4 - EXT_WORDS_INDICATOR_SIZE
+        let go_data_budget = (wire_ext_words as usize + 1) * 4 - EXT_WORDS_INDICATOR_SIZE;
+
+        let e2ee_tlv_size = EXT_MARKER_LEN + E2eeExt::LEN;
+
+        assert!(
+            go_data_budget >= e2ee_tlv_size,
+            "Go server data_budget ({}) < E2EE TLV size ({}). Wire ext_words={}, ext_len={}",
+            go_data_budget, e2ee_tlv_size, wire_ext_words, metrics.ext_len
+        );
     }
 }

--- a/livekit/tests/data_track_test.rs
+++ b/livekit/tests/data_track_test.rs
@@ -190,6 +190,7 @@ async fn test_e2ee() -> Result<()> {
     use livekit::E2eeOptions;
 
     const SHARED_SECRET: &[u8] = b"password";
+    const PAYLOAD: &[u8] = &[0xFA; 196_608];
 
     let key_provider1 =
         KeyProvider::with_shared_key(KeyProviderOptions::default(), SHARED_SECRET.to_vec());
@@ -214,31 +215,34 @@ async fn test_e2ee() -> Result<()> {
     sub_room.e2ee_manager().set_enabled(true);
 
     let publish = async move {
-        let track = pub_room.local_participant().publish_data_track("my_track").await?;
+        let track = pub_room.local_participant().publish_data_track("my_track").await.unwrap();
         assert!(track.info().uses_e2ee());
-
-        for index in 0..5 {
-            track.try_push(vec![index as u8; 196_608].into())?;
-            time::sleep(Duration::from_millis(25)).await;
+        loop {
+            _ = track.try_push(PAYLOAD.into());
+            time::sleep(Duration::from_millis(125)).await;
         }
-        Ok(())
     };
 
     let subscribe = async move {
-        let track = wait_for_remote_track(&mut sub_room_event_rx).await?;
+        let track = wait_for_remote_track(&mut sub_room_event_rx).await.unwrap();
 
         assert!(track.info().uses_e2ee());
-        let mut subscription = track.subscribe().await?;
+        let mut subscription = track.subscribe().await.unwrap();
 
+        let mut got_frame = false;
         while let Some(frame) = subscription.next().await {
-            let payload = frame.payload();
-            if let Some(first_byte) = payload.first() {
-                assert!(payload.iter().all(|byte| byte == first_byte));
-            }
+            assert_eq!(frame.payload(), PAYLOAD);
+            got_frame = true;
+            break;
         }
-        Ok(())
+        assert!(got_frame);
     };
-    timeout(Duration::from_secs(5), async { try_join!(publish, subscribe) }).await??;
+
+    let _ = timeout(Duration::from_secs(5), async {
+        tokio::select! { _ = publish => (), _ = subscribe => () };
+    })
+    .await?;
+
     Ok(())
 }
 


### PR DESCRIPTION
Addresses an issue with the packet encoding where the extension block length is encoded differently than what the SFU expected, leading to packets not being forwarded in some cases (e.g., E2EE is enabled). The spec is also updated for clarification.

Fix for JS: 
- https://github.com/livekit/client-sdk-js/pull/1911