### PR TITLE
Data track send queue improvement

### DIFF
--- a/.changeset/improve_data_track_sender_queue.md
+++ b/.changeset/improve_data_track_sender_queue.md
@@ -1,0 +1,5 @@
+---
+livekit: patch
+---
+
+Fix unbound send queue that can cause latency in data track messages - #1032 (@chenosaurus)

--- a/.changeset/improve_data_track_sender_queue.md
+++ b/.changeset/improve_data_track_sender_queue.md
@@ -1,5 +1,6 @@
 ---
 livekit: patch
+livekit-ffi: patch
 ---
 
 Fix unbound send queue that can cause latency in data track messages - #1032 (@chenosaurus)

--- a/livekit/src/rtc_engine/dc_sender.rs
+++ b/livekit/src/rtc_engine/dc_sender.rs
@@ -18,6 +18,14 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use tokio::sync::{mpsc, watch, Notify};
 
+/// A single application-level frame's worth of serialized packets.
+///
+/// One frame may serialize into multiple MTU-sized packets; the receiver needs
+/// all of them to reassemble the frame. We therefore keep the group together
+/// as an atomic unit all the way down to the DC send path so eviction never
+/// leaves a partially queued frame.
+pub type DataTrackFramePackets = Vec<Bytes>;
+
 /// Options for constructing a [`DataChannelSender`].
 pub struct DataChannelSenderOptions {
     pub low_buffer_threshold: u64,
@@ -27,16 +35,19 @@ pub struct DataChannelSenderOptions {
 
 /// Bounded, drop-oldest send queue for the [`DataChannelSender`] task.
 ///
-/// When full, the oldest payload is evicted in favour of the newer arrival —
-/// preferring freshness over completeness for latency-sensitive data-track
-/// publishing. Cloneable so producers and the sender task can share it.
+/// Each queue slot holds a [`DataTrackFramePackets`] — the full set of packets
+/// for one application frame. When full, the oldest *frame* is evicted in
+/// favour of the newer arrival; partial frames are never queued, which keeps
+/// reassembly on the receiver side intact.
+///
+/// Cloneable so producers and the sender task can share it.
 #[derive(Clone)]
 pub struct DataTrackSendQueue {
     inner: Arc<DataTrackSendQueueInner>,
 }
 
 struct DataTrackSendQueueInner {
-    queue: Mutex<VecDeque<Bytes>>,
+    queue: Mutex<VecDeque<DataTrackFramePackets>>,
     notify: Notify,
     capacity: usize,
 }
@@ -53,38 +64,41 @@ impl DataTrackSendQueue {
         }
     }
 
-    /// Enqueue a payload, returning the evicted oldest payload if the queue
-    /// was at capacity.
-    pub fn send(&self, payload: Bytes) -> Option<Bytes> {
+    /// Enqueue all packets for a single frame, returning the evicted oldest
+    /// frame if the queue was at capacity.
+    pub fn send(&self, packets: DataTrackFramePackets) -> Option<DataTrackFramePackets> {
+        if packets.is_empty() {
+            return None;
+        }
         let mut queue = self.inner.queue.lock().expect("send queue mutex poisoned");
         let dropped = if queue.len() >= self.inner.capacity { queue.pop_front() } else { None };
-        queue.push_back(payload);
+        queue.push_back(packets);
         drop(queue);
         self.inner.notify.notify_one();
         dropped
     }
 
-    fn try_pop(&self) -> Option<Bytes> {
+    fn try_pop(&self) -> Option<DataTrackFramePackets> {
         self.inner.queue.lock().expect("send queue mutex poisoned").pop_front()
     }
 
-    fn drain(&self) -> VecDeque<Bytes> {
+    fn drain(&self) -> VecDeque<DataTrackFramePackets> {
         std::mem::take(&mut *self.inner.queue.lock().expect("send queue mutex poisoned"))
     }
 
-    /// Awaits the next queued payload. Cancel-safe: dropping the future
-    /// leaves any queued payload in place.
-    async fn recv(&self) -> Bytes {
+    /// Awaits the next queued frame. Cancel-safe: dropping the future leaves
+    /// any queued frame in place.
+    async fn recv(&self) -> DataTrackFramePackets {
         loop {
-            if let Some(payload) = self.try_pop() {
-                return payload;
+            if let Some(packets) = self.try_pop() {
+                return packets;
             }
             // Register for wake-up before rechecking to avoid a missed notify.
             let notified = self.inner.notify.notified();
             tokio::pin!(notified);
             notified.as_mut().enable();
-            if let Some(payload) = self.try_pop() {
-                return payload;
+            if let Some(packets) = self.try_pop() {
+                return packets;
             }
             notified.await;
         }
@@ -94,14 +108,20 @@ impl DataTrackSendQueue {
 /// Sender task for the `_data_track` RTC data channel, with
 /// buffered-amount backpressure.
 ///
-/// Forwards opaque `Bytes` verbatim (no encoding, sequencing, or retries)
-/// and holds only the freshest pending payload via [`DataTrackSendQueue`].
+/// Forwards opaque packets verbatim (no encoding, sequencing, or retries) and
+/// holds only the freshest pending frame via [`DataTrackSendQueue`]. A frame's
+/// packets are dispatched in order and never interleaved with, or evicted in
+/// favour of, another frame — partial frames are never left on the wire.
 /// Not used for reliable/lossy data packets, which go through
 /// `SessionInner::data_channel_task` since they need unbounded queueing,
 /// retries, and per-kind sequencing.
 pub struct DataChannelSender {
-    /// Drop-oldest queue of payloads waiting for the DC to drain.
+    /// Drop-oldest queue of whole frames waiting for the DC to drain.
     queue: DataTrackSendQueue,
+
+    /// Packets from the frame currently being dispatched, in FIFO order.
+    /// Non-empty only while a frame is still being drained to the DC.
+    in_flight: VecDeque<Bytes>,
 
     /// Channel for receiving events from the data channel.
     dc_event_rx: mpsc::UnboundedReceiver<DataChannelEvent>,
@@ -121,15 +141,15 @@ pub struct DataChannelSender {
 }
 
 impl DataChannelSender {
-    /// Queue capacity. Set to 1 so only the freshest pending payload is
-    /// held; any older queued payload is evicted on the next send.
+    /// Queue capacity in frames. Set to 1 so only the freshest pending frame
+    /// is held; older queued frames are evicted on the next send.
     const QUEUE_CAPACITY: usize = 1;
 
     /// Creates a new sender.
     ///
     /// Returns a tuple containing the following:
     /// - The sender itself to be spawned by the caller (see [`DataChannelSender::run`]).
-    /// - A cloneable queue handle for producers to push payloads onto.
+    /// - A cloneable queue handle for producers to push frames onto.
     pub fn new(options: DataChannelSenderOptions) -> (Self, DataTrackSendQueue) {
         let queue = DataTrackSendQueue::new(Self::QUEUE_CAPACITY);
         let (dc_event_tx, dc_event_rx) = mpsc::unbounded_channel();
@@ -138,6 +158,7 @@ impl DataChannelSender {
             low_buffer_threshold: options.low_buffer_threshold,
             dc: options.dc,
             queue: queue.clone(),
+            in_flight: VecDeque::new(),
             dc_event_rx,
             dc_event_tx,
             close_rx: options.close_rx,
@@ -158,11 +179,14 @@ impl DataChannelSender {
                 Some(event) = self.dc_event_rx.recv() => {
                     let DataChannelEvent::BytesSent(bytes_sent) = event;
                     self.handle_bytes_sent(bytes_sent);
+                    self.drain_in_flight();
                 }
-                payload = self.queue.recv(),
-                    if self.buffered_amount <= self.low_buffer_threshold =>
+                packets = self.queue.recv(),
+                    if self.in_flight.is_empty()
+                        && self.buffered_amount <= self.low_buffer_threshold =>
                 {
-                    self.dispatch(payload);
+                    self.in_flight.extend(packets);
+                    self.drain_in_flight();
                 }
                 _ = self.close_rx.changed() => break
             }
@@ -170,10 +194,21 @@ impl DataChannelSender {
 
         let remaining = self.queue.drain();
         if !remaining.is_empty() {
-            let unsent_bytes: usize = remaining.iter().map(|p| p.len()).sum();
+            let unsent_bytes: usize =
+                remaining.iter().flat_map(|frame| frame.iter()).map(|p| p.len()).sum();
             log::info!("{} byte(s) remain in queue", unsent_bytes);
         }
         log::debug!("Send task ended for data channel '{}'", self.dc.label());
+    }
+
+    /// Dispatch as many in-flight packets as possible without exceeding the
+    /// buffered-amount low threshold, so each frame's packets go out in order
+    /// while still respecting DC backpressure between them.
+    fn drain_in_flight(&mut self) {
+        while self.buffered_amount <= self.low_buffer_threshold {
+            let Some(packet) = self.in_flight.pop_front() else { break };
+            self.dispatch(packet);
+        }
     }
 
     fn dispatch(&mut self, payload: Bytes) {
@@ -218,4 +253,71 @@ fn on_buffered_amount_change(
         let Some(event_tx) = event_tx.upgrade() else { return };
         _ = event_tx.send(DataChannelEvent::BytesSent(bytes_sent));
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn packet(byte: u8, len: usize) -> Bytes {
+        Bytes::from(vec![byte; len])
+    }
+
+    fn frame(byte: u8, packet_count: usize, packet_len: usize) -> DataTrackFramePackets {
+        (0..packet_count).map(|_| packet(byte, packet_len)).collect()
+    }
+
+    #[test]
+    fn send_empty_frame_is_noop() {
+        let q = DataTrackSendQueue::new(1);
+        assert!(q.send(Vec::new()).is_none());
+        assert!(q.try_pop().is_none());
+    }
+
+    #[test]
+    fn send_keeps_multi_packet_frame_intact() {
+        let q = DataTrackSendQueue::new(1);
+        let f = frame(0xAA, 13, 16_000);
+        assert!(q.send(f.clone()).is_none());
+        let got = q.try_pop().expect("frame should be queued");
+        assert_eq!(got.len(), 13, "all packets for the frame must remain together");
+        assert!(got.iter().all(|p| p.len() == 16_000 && p[0] == 0xAA));
+    }
+
+    #[test]
+    fn send_drops_oldest_whole_frame_when_full() {
+        let q = DataTrackSendQueue::new(1);
+        let older = frame(0x01, 4, 128);
+        let newer = frame(0x02, 3, 128);
+
+        assert!(q.send(older.clone()).is_none());
+
+        // Pushing a second frame while at capacity evicts the entire older
+        // frame, not just a prefix of it.
+        let evicted = q.send(newer.clone()).expect("older frame should be evicted");
+        assert_eq!(evicted.len(), older.len());
+        assert!(evicted.iter().all(|p| p[0] == 0x01));
+
+        // The queue now holds only the newer frame, fully intact.
+        let got = q.try_pop().expect("newer frame should remain");
+        assert_eq!(got.len(), newer.len());
+        assert!(got.iter().all(|p| p[0] == 0x02));
+        assert!(q.try_pop().is_none());
+    }
+
+    #[tokio::test]
+    async fn recv_returns_whole_frame() {
+        let q = DataTrackSendQueue::new(1);
+        let f = frame(0x33, 5, 64);
+
+        let q_send = q.clone();
+        let f_sent = f.clone();
+        tokio::spawn(async move {
+            q_send.send(f_sent);
+        });
+
+        let got = q.recv().await;
+        assert_eq!(got.len(), f.len());
+        assert!(got.iter().all(|p| p[0] == 0x33));
+    }
 }

--- a/livekit/src/rtc_engine/dc_sender.rs
+++ b/livekit/src/rtc_engine/dc_sender.rs
@@ -15,7 +15,8 @@
 use bytes::Bytes;
 use libwebrtc::{self as rtc, data_channel::DataChannel};
 use std::collections::VecDeque;
-use tokio::sync::{mpsc, watch};
+use std::sync::{Arc, Mutex};
+use tokio::sync::{mpsc, watch, Notify};
 
 /// Options for constructing a [`DataChannelSender`].
 pub struct DataChannelSenderOptions {
@@ -24,22 +25,114 @@ pub struct DataChannelSenderOptions {
     pub close_rx: watch::Receiver<bool>,
 }
 
-/// A task responsible for sending payloads over a single RTC data channel.
+/// Bounded, drop-oldest send queue handed to the [`DataChannelSender`] task.
 ///
-/// This implements the same backpressure logic used by `SessionInner::data_channel_task`,
-/// but is decoupled from message encoding and retry logic specific to data packets.
+/// When the queue is at capacity, [`DataTrackSendQueue::send`] evicts the
+/// *oldest* payload to make room for the newer arrival. This policy favours
+/// freshness over completeness, which is the desired behaviour for
+/// latency-sensitive data-track publishing: a stale sample queued behind a
+/// congested DC is always less useful than the freshest one, so we'd rather
+/// drop the stale one and get the latest datum on the wire as soon as
+/// possible.
 ///
-/// It was originally introduced to support sending data track packets; however, the
-/// implementation is generic and works with arbitrary payloads.
+/// The queue is cloneable: producers hold one clone, the sender task holds
+/// another.
+#[derive(Clone)]
+pub struct DataTrackSendQueue {
+    inner: Arc<DataTrackSendQueueInner>,
+}
+
+struct DataTrackSendQueueInner {
+    queue: Mutex<VecDeque<Bytes>>,
+    notify: Notify,
+    capacity: usize,
+}
+
+impl DataTrackSendQueue {
+    fn new(capacity: usize) -> Self {
+        debug_assert!(capacity >= 1);
+        Self {
+            inner: Arc::new(DataTrackSendQueueInner {
+                queue: Mutex::new(VecDeque::with_capacity(capacity)),
+                notify: Notify::new(),
+                capacity,
+            }),
+        }
+    }
+
+    /// Enqueue a payload. Always accepts the new payload; if the queue was
+    /// already at capacity, the oldest payload is evicted and returned so
+    /// callers can observe drops (e.g. for logging/metrics).
+    pub fn send(&self, payload: Bytes) -> Option<Bytes> {
+        let mut queue = self.inner.queue.lock().expect("send queue mutex poisoned");
+        let dropped = if queue.len() >= self.inner.capacity { queue.pop_front() } else { None };
+        queue.push_back(payload);
+        drop(queue);
+        self.inner.notify.notify_one();
+        dropped
+    }
+
+    fn try_pop(&self) -> Option<Bytes> {
+        self.inner.queue.lock().expect("send queue mutex poisoned").pop_front()
+    }
+
+    fn drain(&self) -> VecDeque<Bytes> {
+        std::mem::take(&mut *self.inner.queue.lock().expect("send queue mutex poisoned"))
+    }
+
+    /// Awaits and returns the next queued payload.
+    ///
+    /// The future is cancel-safe: dropping it without completion leaves any
+    /// still-queued payload in place for the next call.
+    async fn recv(&self) -> Bytes {
+        loop {
+            if let Some(payload) = self.try_pop() {
+                return payload;
+            }
+            // Register interest *before* rechecking the queue to avoid a
+            // missed wake if `send` runs between our pop and our await.
+            let notified = self.inner.notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            if let Some(payload) = self.try_pop() {
+                return payload;
+            }
+            notified.await;
+        }
+    }
+}
+
+/// A task responsible for sending data-track payloads over a single RTC data
+/// channel.
+///
+/// This implements buffered-amount-based backpressure similar to
+/// `SessionInner::data_channel_task`, but is specialised for the data-track
+/// DC (`_data_track`):
+///
+/// - The producer-facing queue ([`DataTrackSendQueue`]) is bounded to
+///   [`Self::QUEUE_CAPACITY`] with drop-oldest semantics, so only the freshest
+///   pending payload is ever held. This is appropriate for latency-sensitive
+///   data tracks, where a stale sample queued behind a congested DC is worse
+///   than simply dropping it in favour of a newer one.
+/// - There is no encoding, sequencing, or retry layer; the sender forwards
+///   opaque `Bytes` payloads verbatim.
+///
+/// It is intentionally *not* used for reliable/lossy data-packet publishing
+/// (chat, transcription, DTMF, RPC, user packets, streams, etc.) — that path
+/// has different requirements (unbounded queueing, retries, per-kind
+/// sequencing) and continues to live in `SessionInner::data_channel_task`.
 ///
 /// In a future refactor, it would be worth revisiting how the logic in
-/// `SessionInner::data_channel_task` can be decoupled from session likely by reusing this
-/// sender and moving encoding and retry concerns into a separate layer
-/// (see the `livekit-datatrack` crate for an example of this approach).
+/// `SessionInner::data_channel_task` can be decoupled from session likely by
+/// reusing a generalised version of this sender and moving encoding and retry
+/// concerns into a separate layer (see the `livekit-datatrack` crate for an
+/// example of this approach). Doing that would require making the queue
+/// capacity / eviction policy configurable rather than hardcoded to
+/// drop-oldest, capacity 1.
 ///
 pub struct DataChannelSender {
-    /// Channel for receiving payloads to be enqueued for sending.
-    send_rx: mpsc::Receiver<Bytes>,
+    /// Drop-oldest queue of payloads waiting for the DC to drain.
+    queue: DataTrackSendQueue,
 
     /// Channel for receiving events from the data channel.
     dc_event_rx: mpsc::UnboundedReceiver<DataChannelEvent>,
@@ -56,36 +149,37 @@ pub struct DataChannelSender {
 
     /// Number of bytes in the data channel's internal buffer.
     buffered_amount: u64,
-
-    /// Payloads enqueued for sending.
-    send_queue: VecDeque<Bytes>,
 }
 
 impl DataChannelSender {
-    /// Buffer size of the channel used to sending events to the task.
-    const CHANNEL_BUFFER_SIZE: usize = 128;
+    /// Maximum number of payloads held in [`DataTrackSendQueue`] waiting to be
+    /// handed to the DC.
+    ///
+    /// Kept at 1 so we only ever hold the single freshest pending payload.
+    /// When a newer payload arrives while the DC is still draining an older
+    /// queued one, the older one is evicted.
+    const QUEUE_CAPACITY: usize = 1;
 
     /// Creates a new sender.
     ///
     /// Returns a tuple containing the following:
     /// - The sender itself to be spawned by the caller (see [`DataChannelSender::run`]).
-    /// - Channel for sending payloads over the data channel.
+    /// - A cloneable queue handle for producers to push payloads onto.
     ///
-    pub fn new(options: DataChannelSenderOptions) -> (Self, mpsc::Sender<Bytes>) {
-        let (send_tx, send_rx) = mpsc::channel(Self::CHANNEL_BUFFER_SIZE);
+    pub fn new(options: DataChannelSenderOptions) -> (Self, DataTrackSendQueue) {
+        let queue = DataTrackSendQueue::new(Self::QUEUE_CAPACITY);
         let (dc_event_tx, dc_event_rx) = mpsc::unbounded_channel();
 
         let sender = Self {
             low_buffer_threshold: options.low_buffer_threshold,
             dc: options.dc,
-            send_rx,
+            queue: queue.clone(),
             dc_event_rx,
             dc_event_tx,
             close_rx: options.close_rx,
             buffered_amount: 0,
-            send_queue: VecDeque::default(),
         };
-        (sender, send_tx)
+        (sender, queue)
     }
 
     /// Run the sender task, consuming self.
@@ -101,37 +195,29 @@ impl DataChannelSender {
                     let DataChannelEvent::BytesSent(bytes_sent) = event;
                     self.handle_bytes_sent(bytes_sent);
                 }
-                Some(payload) = self.send_rx.recv() => {
-                    self.handle_enqueue_for_send(payload)
+                payload = self.queue.recv(),
+                    if self.buffered_amount <= self.low_buffer_threshold =>
+                {
+                    self.dispatch(payload);
                 }
                 _ = self.close_rx.changed() => break
             }
         }
 
-        if !self.send_queue.is_empty() {
-            let unsent_bytes: usize =
-                self.send_queue.into_iter().map(|payload| payload.len()).sum();
+        let remaining = self.queue.drain();
+        if !remaining.is_empty() {
+            let unsent_bytes: usize = remaining.iter().map(|p| p.len()).sum();
             log::info!("{} byte(s) remain in queue", unsent_bytes);
         }
         log::debug!("Send task ended for data channel '{}'", self.dc.label());
     }
 
-    fn send_until_threshold(&mut self) {
-        while self.buffered_amount <= self.low_buffer_threshold {
-            let Some(payload) = self.send_queue.pop_front() else {
-                break;
-            };
-            self.buffered_amount += payload.len() as u64;
-            _ = self
-                .dc
-                .send(&payload, true)
-                .inspect_err(|err| log::error!("Failed to send data: {}", err));
-        }
-    }
-
-    fn handle_enqueue_for_send(&mut self, payload: Bytes) {
-        self.send_queue.push_back(payload);
-        self.send_until_threshold();
+    fn dispatch(&mut self, payload: Bytes) {
+        self.buffered_amount += payload.len() as u64;
+        _ = self
+            .dc
+            .send(&payload, true)
+            .inspect_err(|err| log::error!("Failed to send data: {}", err));
     }
 
     fn handle_bytes_sent(&mut self, bytes_sent: u64) {
@@ -141,7 +227,6 @@ impl DataChannelSender {
             return;
         }
         self.buffered_amount -= bytes_sent;
-        self.send_until_threshold();
     }
 
     fn register_dc_callbacks(&self) {

--- a/livekit/src/rtc_engine/dc_sender.rs
+++ b/livekit/src/rtc_engine/dc_sender.rs
@@ -23,7 +23,7 @@ use tokio::sync::{mpsc, watch, Notify};
 /// One frame may serialize into multiple MTU-sized packets; the receiver needs
 /// all of them to reassemble the frame. We therefore keep the group together
 /// as an atomic unit all the way down to the DC send path so eviction never
-/// leaves a partially queued frame.
+/// leaves partially queued frame.
 pub type DataTrackFramePackets = Vec<Bytes>;
 
 /// Options for constructing a [`DataChannelSender`].

--- a/livekit/src/rtc_engine/dc_sender.rs
+++ b/livekit/src/rtc_engine/dc_sender.rs
@@ -25,18 +25,11 @@ pub struct DataChannelSenderOptions {
     pub close_rx: watch::Receiver<bool>,
 }
 
-/// Bounded, drop-oldest send queue handed to the [`DataChannelSender`] task.
+/// Bounded, drop-oldest send queue for the [`DataChannelSender`] task.
 ///
-/// When the queue is at capacity, [`DataTrackSendQueue::send`] evicts the
-/// *oldest* payload to make room for the newer arrival. This policy favours
-/// freshness over completeness, which is the desired behaviour for
-/// latency-sensitive data-track publishing: a stale sample queued behind a
-/// congested DC is always less useful than the freshest one, so we'd rather
-/// drop the stale one and get the latest datum on the wire as soon as
-/// possible.
-///
-/// The queue is cloneable: producers hold one clone, the sender task holds
-/// another.
+/// When full, the oldest payload is evicted in favour of the newer arrival —
+/// preferring freshness over completeness for latency-sensitive data-track
+/// publishing. Cloneable so producers and the sender task can share it.
 #[derive(Clone)]
 pub struct DataTrackSendQueue {
     inner: Arc<DataTrackSendQueueInner>,
@@ -60,9 +53,8 @@ impl DataTrackSendQueue {
         }
     }
 
-    /// Enqueue a payload. Always accepts the new payload; if the queue was
-    /// already at capacity, the oldest payload is evicted and returned so
-    /// callers can observe drops (e.g. for logging/metrics).
+    /// Enqueue a payload, returning the evicted oldest payload if the queue
+    /// was at capacity.
     pub fn send(&self, payload: Bytes) -> Option<Bytes> {
         let mut queue = self.inner.queue.lock().expect("send queue mutex poisoned");
         let dropped = if queue.len() >= self.inner.capacity { queue.pop_front() } else { None };
@@ -80,17 +72,14 @@ impl DataTrackSendQueue {
         std::mem::take(&mut *self.inner.queue.lock().expect("send queue mutex poisoned"))
     }
 
-    /// Awaits and returns the next queued payload.
-    ///
-    /// The future is cancel-safe: dropping it without completion leaves any
-    /// still-queued payload in place for the next call.
+    /// Awaits the next queued payload. Cancel-safe: dropping the future
+    /// leaves any queued payload in place.
     async fn recv(&self) -> Bytes {
         loop {
             if let Some(payload) = self.try_pop() {
                 return payload;
             }
-            // Register interest *before* rechecking the queue to avoid a
-            // missed wake if `send` runs between our pop and our await.
+            // Register for wake-up before rechecking to avoid a missed notify.
             let notified = self.inner.notify.notified();
             tokio::pin!(notified);
             notified.as_mut().enable();
@@ -102,34 +91,14 @@ impl DataTrackSendQueue {
     }
 }
 
-/// A task responsible for sending data-track payloads over a single RTC data
-/// channel.
+/// Sender task for the `_data_track` RTC data channel, with
+/// buffered-amount backpressure.
 ///
-/// This implements buffered-amount-based backpressure similar to
-/// `SessionInner::data_channel_task`, but is specialised for the data-track
-/// DC (`_data_track`):
-///
-/// - The producer-facing queue ([`DataTrackSendQueue`]) is bounded to
-///   [`Self::QUEUE_CAPACITY`] with drop-oldest semantics, so only the freshest
-///   pending payload is ever held. This is appropriate for latency-sensitive
-///   data tracks, where a stale sample queued behind a congested DC is worse
-///   than simply dropping it in favour of a newer one.
-/// - There is no encoding, sequencing, or retry layer; the sender forwards
-///   opaque `Bytes` payloads verbatim.
-///
-/// It is intentionally *not* used for reliable/lossy data-packet publishing
-/// (chat, transcription, DTMF, RPC, user packets, streams, etc.) — that path
-/// has different requirements (unbounded queueing, retries, per-kind
-/// sequencing) and continues to live in `SessionInner::data_channel_task`.
-///
-/// In a future refactor, it would be worth revisiting how the logic in
-/// `SessionInner::data_channel_task` can be decoupled from session likely by
-/// reusing a generalised version of this sender and moving encoding and retry
-/// concerns into a separate layer (see the `livekit-datatrack` crate for an
-/// example of this approach). Doing that would require making the queue
-/// capacity / eviction policy configurable rather than hardcoded to
-/// drop-oldest, capacity 1.
-///
+/// Forwards opaque `Bytes` verbatim (no encoding, sequencing, or retries)
+/// and holds only the freshest pending payload via [`DataTrackSendQueue`].
+/// Not used for reliable/lossy data packets, which go through
+/// `SessionInner::data_channel_task` since they need unbounded queueing,
+/// retries, and per-kind sequencing.
 pub struct DataChannelSender {
     /// Drop-oldest queue of payloads waiting for the DC to drain.
     queue: DataTrackSendQueue,
@@ -152,12 +121,8 @@ pub struct DataChannelSender {
 }
 
 impl DataChannelSender {
-    /// Maximum number of payloads held in [`DataTrackSendQueue`] waiting to be
-    /// handed to the DC.
-    ///
-    /// Kept at 1 so we only ever hold the single freshest pending payload.
-    /// When a newer payload arrives while the DC is still draining an older
-    /// queued one, the older one is evicted.
+    /// Queue capacity. Set to 1 so only the freshest pending payload is
+    /// held; any older queued payload is evicted on the next send.
     const QUEUE_CAPACITY: usize = 1;
 
     /// Creates a new sender.
@@ -165,7 +130,6 @@ impl DataChannelSender {
     /// Returns a tuple containing the following:
     /// - The sender itself to be spawned by the caller (see [`DataChannelSender::run`]).
     /// - A cloneable queue handle for producers to push payloads onto.
-    ///
     pub fn new(options: DataChannelSenderOptions) -> (Self, DataTrackSendQueue) {
         let queue = DataTrackSendQueue::new(Self::QUEUE_CAPACITY);
         let (dc_event_tx, dc_event_rx) = mpsc::unbounded_channel();

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -74,17 +74,12 @@ pub const RELIABLE_RECEIVED_STATE_TTL: Duration = Duration::from_secs(30);
 pub const PUBLISHER_NEGOTIATION_FREQUENCY: Duration = Duration::from_millis(150);
 pub const INITIAL_BUFFERED_AMOUNT_LOW_THRESHOLD: u64 = 2 * 1024 * 1024;
 
-/// Buffered-amount low threshold for the data-track DC (`_data_track`).
+/// Buffered-amount low threshold for the `_data_track` DC.
 ///
-/// Sized small (vs. the 2 MiB default used for the reliable/lossy DCs) because
-/// data tracks are latency-sensitive: callers prefer dropping packets over
-/// buffering them when the underlying transport cannot keep up.
-///
-/// Note: WebRTC's `bufferedAmount` only reflects bytes queued *before* SCTP
-/// accepts them. Once SCTP and the kernel UDP send buffer accept data, further
-/// queueing happens below our visibility and is bounded by OS/qdisc config.
-/// Kept intentionally small so that we only hand over a single in-flight SCTP
-/// message at a time, limiting how deeply SCTP can itself buffer.
+/// Kept small (vs. the 2 MiB default for reliable/lossy) so we hand at most
+/// one in-flight message to SCTP at a time; data tracks prefer dropping
+/// packets over queueing. Note that `bufferedAmount` only covers bytes
+/// before SCTP accepts them — queueing below that is bounded by OS/qdisc.
 pub const DATA_TRACK_BUFFERED_AMOUNT_LOW_THRESHOLD: u64 = 8 * 1024;
 
 #[derive(Debug)]
@@ -749,10 +744,8 @@ impl RtcSession {
     ///
     fn try_send_data_track_packets(&self, packets: Vec<Bytes>) {
         for packet in packets {
-            // Drop-oldest semantics: if the queue is already at capacity, the
-            // stalest payload is evicted in favour of this newer one. This
-            // keeps end-to-end latency low by always preferring fresh data
-            // over stale data when the DC cannot keep up.
+            // Drop-oldest: if full, the stalest payload is evicted so we
+            // always send the freshest data.
             if let Some(stale) = self.inner.dt_packet_tx.send(packet) {
                 log::trace!(
                     "evicted oldest queued data-track payload ({} bytes) in favor of newer arrival",

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -739,19 +739,22 @@ impl RtcSession {
 
     /// Try to send data track packets over the transport.
     ///
-    /// Packets will be sent until the first error, at which point the rest of
-    /// the batch will be dropped.
-    ///
+    /// All packets belong to one application frame and are enqueued atomically
+    /// so a partial frame is never queued or evicted; drop-oldest applies at
+    /// whole-frame granularity.
     fn try_send_data_track_packets(&self, packets: Vec<Bytes>) {
-        for packet in packets {
-            // Drop-oldest: if full, the stalest payload is evicted so we
-            // always send the freshest data.
-            if let Some(stale) = self.inner.dt_packet_tx.send(packet) {
-                log::trace!(
-                    "evicted oldest queued data-track payload ({} bytes) in favor of newer arrival",
-                    stale.len()
-                );
-            }
+        if packets.is_empty() {
+            return;
+        }
+        let packet_count = packets.len();
+        if let Some(stale) = self.inner.dt_packet_tx.send(packets) {
+            let stale_bytes: usize = stale.iter().map(|p| p.len()).sum();
+            log::trace!(
+                "evicted oldest queued data-track frame ({} packets / {} total bytes) in favor of newer {}-packet frame",
+                stale.len(),
+                stale_bytes,
+                packet_count,
+            );
         }
     }
 

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -44,7 +44,7 @@ use tokio::sync::{
 use super::{rtc_events, EngineError, EngineOptions, EngineResult, SimulateScenario};
 use crate::{
     id::ParticipantIdentity,
-    rtc_engine::dc_sender::{DataChannelSender, DataChannelSenderOptions},
+    rtc_engine::dc_sender::{DataChannelSender, DataChannelSenderOptions, DataTrackSendQueue},
     utils::{
         ttl_map::TtlMap,
         tx_queue::{TxQueue, TxQueueItem},
@@ -73,6 +73,19 @@ pub const DATA_TRACK_DC_LABEL: &str = "_data_track";
 pub const RELIABLE_RECEIVED_STATE_TTL: Duration = Duration::from_secs(30);
 pub const PUBLISHER_NEGOTIATION_FREQUENCY: Duration = Duration::from_millis(150);
 pub const INITIAL_BUFFERED_AMOUNT_LOW_THRESHOLD: u64 = 2 * 1024 * 1024;
+
+/// Buffered-amount low threshold for the data-track DC (`_data_track`).
+///
+/// Sized small (vs. the 2 MiB default used for the reliable/lossy DCs) because
+/// data tracks are latency-sensitive: callers prefer dropping packets over
+/// buffering them when the underlying transport cannot keep up.
+///
+/// Note: WebRTC's `bufferedAmount` only reflects bytes queued *before* SCTP
+/// accepts them. Once SCTP and the kernel UDP send buffer accept data, further
+/// queueing happens below our visibility and is bounded by OS/qdisc config.
+/// Kept intentionally small so that we only hand over a single in-flight SCTP
+/// message at a time, limiting how deeply SCTP can itself buffer.
+pub const DATA_TRACK_BUFFERED_AMOUNT_LOW_THRESHOLD: u64 = 8 * 1024;
 
 #[derive(Debug)]
 enum NegotiationState {
@@ -377,8 +390,8 @@ struct SessionInner {
     sub_reliable_dc: Mutex<Option<DataChannel>>,
     sub_data_track_dc: Mutex<Option<DataChannel>>,
 
-    /// Channel for sending data track packets.
-    dt_packet_tx: mpsc::Sender<Bytes>,
+    /// Drop-oldest queue for handing data-track packets to the sender task.
+    dt_packet_tx: DataTrackSendQueue,
 
     closed: AtomicBool,
     emitter: SessionEmitter,
@@ -511,7 +524,7 @@ impl RtcSession {
         let (close_tx, close_rx) = watch::channel(false);
 
         let dt_sender_options = DataChannelSenderOptions {
-            low_buffer_threshold: INITIAL_BUFFERED_AMOUNT_LOW_THRESHOLD,
+            low_buffer_threshold: DATA_TRACK_BUFFERED_AMOUNT_LOW_THRESHOLD,
             dc: data_track_dc.clone(),
             close_rx: close_rx.clone(),
         };
@@ -736,9 +749,15 @@ impl RtcSession {
     ///
     fn try_send_data_track_packets(&self, packets: Vec<Bytes>) {
         for packet in packets {
-            if self.inner.dt_packet_tx.try_send(packet).is_err() {
-                log::error!("Failed to enqueue data track packet");
-                break;
+            // Drop-oldest semantics: if the queue is already at capacity, the
+            // stalest payload is evicted in favour of this newer one. This
+            // keeps end-to-end latency low by always preferring fresh data
+            // over stale data when the DC cannot keep up.
+            if let Some(stale) = self.inner.dt_packet_tx.send(packet) {
+                log::trace!(
+                    "evicted oldest queued data-track payload ({} bytes) in favor of newer arrival",
+                    stale.len()
+                );
             }
         }
     }


### PR DESCRIPTION
the unbounded send queue in `dc_sender.rs` can continue to grow when there is congestion, causing linearly increasing latency to build up.  This PR changes the queue behavior to be bounded and will drop oldest packets if buffer is full.