### PR TITLE
Fix WebRTC download cache issue

### DIFF
--- a/livekit-ffi/build.rs
+++ b/livekit-ffi/build.rs
@@ -20,17 +20,10 @@ fn main() {
     if env::var("DOCS_RS").is_ok() {
         return;
     }
-    download_webrtc();
+    webrtc_sys_build::download_webrtc().expect("Failed to download WebRTC binaries");
     copy_webrtc_license();
     configure_linker();
     generate_protobuf();
-}
-
-fn download_webrtc() {
-    let webrtc_dir = webrtc_sys_build::webrtc_dir();
-    if !webrtc_dir.exists() {
-        webrtc_sys_build::download_webrtc().unwrap();
-    }
 }
 
 /// Copy the webrtc license to `CARGO_MANIFEST_DIR`, used by the FFI release action.
@@ -39,7 +32,7 @@ fn copy_webrtc_license() {
     let license = webrtc_dir.join("LICENSE.md");
     let target_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let out_file = Path::new(&target_dir).join("WEBRTC_LICENSE.md");
-    std::fs::copy(license, out_file).unwrap();
+    std::fs::copy(license, out_file).expect("Failed to copy license file");
 }
 
 fn configure_linker() {

--- a/webrtc-sys/build.rs
+++ b/webrtc-sys/build.rs
@@ -101,9 +101,7 @@ fn main() {
     let webrtc_include = webrtc_dir.join("include");
     let webrtc_lib = webrtc_dir.join("lib");
 
-    if !webrtc_dir.exists() {
-        webrtc_sys_build::download_webrtc().unwrap();
-    }
+    webrtc_sys_build::download_webrtc().expect("Failed to download WebRTC binaries");
 
     builder.includes(&[
         path::PathBuf::from("./include"),

--- a/webrtc-sys/build/src/lib.rs
+++ b/webrtc-sys/build/src/lib.rs
@@ -196,6 +196,9 @@ pub fn configure_jni_symbols() -> Result<()> {
     Ok(())
 }
 
+/// Marker file written into `webrtc_dir` after a successful download + extraction.
+const DOWNLOAD_COMPLETE_MARKER: &str = ".download_complete";
+
 pub fn download_webrtc() -> Result<()> {
     let dir = scratch::path(SCRATH_PATH);
     // temporary fix to avoid github workflow issue
@@ -205,8 +208,15 @@ pub fn download_webrtc() -> Result<()> {
     flock.lock_exclusive().context("Failed to acquire exclusive lock for WebRTC download")?;
 
     let webrtc_dir = webrtc_dir();
-    if webrtc_dir.exists() {
+    if webrtc_dir.join(DOWNLOAD_COMPLETE_MARKER).exists() {
         return Ok(());
+    }
+
+    // A previous run was interrupted mid-extraction (or otherwise left a partial
+    // tree behind). Wipe it so we get a clean download.
+    if webrtc_dir.exists() {
+        fs::remove_dir_all(&webrtc_dir)
+            .with_context(|| format!("Failed to remove stale WebRTC dir {webrtc_dir:?}"))?;
     }
 
     let mut resp = reqwest::blocking::get(download_url())
@@ -221,6 +231,7 @@ pub fn download_webrtc() -> Result<()> {
         .write(true)
         .read(true)
         .create(true)
+        .truncate(true)
         .open(&tmp_path)
         .context("Failed to create temporary file for WebRTC download")?;
     resp.copy_to(&mut file).context("Failed to write WebRTC download to temporary file")?;
@@ -230,6 +241,13 @@ pub fn download_webrtc() -> Result<()> {
     drop(archive);
 
     fs::remove_file(&tmp_path).context("Failed to remove temporary WebRTC zip file")?;
+
+    // Only mark the directory complete once everything above succeeded so that an
+    // interrupted run cannot leave a half-extracted directory that future builds
+    // would mistake for a valid cache.
+    File::create(webrtc_dir.join(DOWNLOAD_COMPLETE_MARKER))
+        .with_context(|| format!("Failed to write WebRTC download marker in {webrtc_dir:?}"))?;
+
     Ok(())
 }
 


### PR DESCRIPTION
Flaky builds in CI produce the following error, usually for Android:
```
error: failed to run custom build command for `livekit-ffi v0.12.53 (/home/runner/work/rust-sdks/rust-sdks/livekit-ffi)`
Caused by:
  process didn't exit successfully: `/home/runner/work/rust-sdks/rust-sdks/target/release/build/livekit-ffi-bfeefcb6773d60f1/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' (9992) panicked at livekit-ffi/build.rs:42:38:
  called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```