### PR TITLE
Add missing description to device-info crate

### DIFF
--- a/device-info/Cargo.toml
+++ b/device-info/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "device-info"
 version = "0.1.1"
+description = "Cross-platform device information"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
Missing description prevents crate upload.