### PR TITLE
fix(signal-client): carry access token on validate() fallback

### DIFF
--- a/.changeset/fix_signal_client_validate_missing_auth.md
+++ b/.changeset/fix_signal_client_validate_missing_auth.md
@@ -1,0 +1,5 @@
+---
+livekit-api: patch
+---
+
+fix(signal-client): carry access token on validate() fallback - #1044 (@abhisheksingh-R41)

--- a/livekit-api/src/http_client.rs
+++ b/livekit-api/src/http_client.rs
@@ -14,11 +14,19 @@
 
 #[cfg(any(feature = "services-tokio", feature = "signal-client-tokio"))]
 mod tokio {
-    #[cfg(feature = "signal-client-tokio")]
-    pub use reqwest::get;
-
     #[cfg(feature = "services-tokio")]
     pub use reqwest::Client;
+
+    /// GET with an `Authorization: Bearer <token>` header attached.
+    ///
+    /// `reqwest::get(url)` (the free function) constructs a fresh default
+    /// `Client` and attaches no auth, which is why `SignalInner::validate` —
+    /// the sole caller — uses this helper: the access token must reach the
+    /// server or the server returns 401 regardless of the underlying error.
+    #[cfg(feature = "signal-client-tokio")]
+    pub async fn get_with_token(url: &str, token: &str) -> reqwest::Result<reqwest::Response> {
+        reqwest::Client::new().get(url).bearer_auth(token).send().await
+    }
 }
 
 #[cfg(any(feature = "services-tokio", feature = "signal-client-tokio"))]
@@ -56,8 +64,18 @@ mod async_std {
             }
         }
 
-        pub async fn get(url: &str) -> io::Result<Response> {
-            let response = isahc::get_async(url).await?;
+        /// GET with an `Authorization: Bearer <token>` header attached.
+        ///
+        /// `isahc::get_async(url)` attaches no auth, which is why
+        /// `SignalInner::validate` — the sole caller — uses this helper: the
+        /// access token must reach the server or the server returns 401
+        /// regardless of the underlying error. Mirrors the tokio variant.
+        pub async fn get_with_token(url: &str, token: &str) -> io::Result<Response> {
+            let request = isahc::Request::get(url)
+                .header("Authorization", format!("Bearer {}", token))
+                .body(())
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            let response = isahc::send_async(request).await?;
             Ok(Response(response))
         }
     }

--- a/livekit-api/src/signal_client/mod.rs
+++ b/livekit-api/src/signal_client/mod.rs
@@ -316,13 +316,13 @@ impl SignalInner {
                                 if let SignalError::TokenFormat = err {
                                     return Err(err);
                                 }
-                                Self::validate(lk_url_v0).await?;
+                                Self::validate(lk_url_v0, token).await?;
                                 return Err(err);
                             }
                         }
                     } else {
                         // Connection failed, try to retrieve more information
-                        Self::validate(lk_url).await?;
+                        Self::validate(lk_url, token).await?;
                         return Err(err);
                     }
                 }
@@ -346,12 +346,21 @@ impl SignalInner {
         Ok((inner, join_response, events))
     }
 
-    /// Validate the connection by calling rtc/validate
-    async fn validate(ws_url: url::Url) -> SignalResult<()> {
+    /// Validate the connection by calling rtc/validate.
+    ///
+    /// This is called from `connect()` when the primary WebSocket upgrade fails
+    /// with a non-404 status, to surface a clearer HTTP-level error than the WS
+    /// upgrade error. The access token is sent as `Authorization: Bearer <token>`
+    /// so the server can actually authenticate the request; without it, the
+    /// server returns 401 "no permissions to access the room" regardless of
+    /// what the original error was, masking the real cause (e.g. a 503 from a
+    /// saturated node becomes a fabricated 401 to the caller). See
+    /// https://github.com/livekit/rust-sdks/issues/1042.
+    async fn validate(ws_url: url::Url, token: &str) -> SignalResult<()> {
         let validate_url = get_validate_url(ws_url);
 
         let validate_fut = async {
-            if let Ok(res) = http_client::get(validate_url.as_str()).await {
+            if let Ok(res) = http_client::get_with_token(validate_url.as_str(), token).await {
                 let status = res.status();
                 let body = res.text().await.ok().unwrap_or_default();
 
@@ -791,6 +800,58 @@ mod tests {
         // Should be /rtc/validate, not /rtc/rtc/validate
         assert_eq!(validate_url.path(), "/rtc/validate");
         assert_eq!(validate_url.scheme(), "https");
+    }
+
+    /// Regression test for https://github.com/livekit/rust-sdks/issues/1042.
+    ///
+    /// Prior to the fix, `SignalInner::validate` issued an auth-less GET to
+    /// `/rtc/validate`, so a server performing the standard auth check (claims
+    /// parsing) would return 401 regardless of the real reason the WebSocket
+    /// upgrade had failed. That 401 then masked the original error (e.g. a
+    /// 503 from a saturated node) at the caller.
+    ///
+    /// This test binds a TCP listener, calls `validate()`, captures the first
+    /// request sent to that listener, and asserts the request carries an
+    /// `Authorization: Bearer <token>` header.
+    #[cfg(feature = "signal-client-tokio")]
+    #[tokio::test]
+    async fn validate_sends_bearer_token() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let (tx, rx) = tokio::sync::oneshot::channel::<Vec<u8>>();
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 4096];
+            let n = socket.read(&mut buf).await.unwrap();
+            buf.truncate(n);
+            let _ = tx.send(buf);
+
+            // Respond 200 OK so `validate()` returns Ok() rather than
+            // surfacing a synthetic client/server error. The purpose of this
+            // test is the request side, not the response side.
+            let response = b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+            let _ = socket.write_all(response).await;
+        });
+
+        let ws_url = url::Url::parse(&format!("ws://127.0.0.1:{}/rtc", addr.port())).unwrap();
+        let result = SignalInner::validate(ws_url, "test-bearer-token").await;
+        assert!(result.is_ok(), "expected Ok from validate, got: {:?}", result);
+
+        let request = rx.await.expect("server task never received a request");
+        let request = String::from_utf8_lossy(&request);
+
+        // Header names are case-insensitive per RFC 9110; reqwest emits the
+        // canonical `Authorization` but we normalise both for robustness.
+        assert!(
+            request.to_lowercase().contains("authorization: bearer test-bearer-token"),
+            "validate() must attach the access token as a Bearer header; request was:\n{}",
+            request
+        );
     }
 
     #[cfg(feature = "signal-client-tokio")]


### PR DESCRIPTION
### Before you submit your PR

- [x] I have read the [contributing guidelines](https://github.com/livekit/rust-sdks/blob/main/CONTRIBUTING.md) and validated that this PR will be accepted.
- [x] I have read and followed the principles regarding breaking changes, testing, and code quality.

### PR description

Fixes #1042.

When `SignalInner::connect`'s primary WS upgrade fails with any non-404 error, the code calls `Self::validate(lk_url)` "to retrieve more information" ([mod.rs:319](https://github.com/livekit/rust-sdks/blob/main/livekit-api/src/signal_client/mod.rs#L319), [:325](https://github.com/livekit/rust-sdks/blob/main/livekit-api/src/signal_client/mod.rs#L325)). `validate()` then issues `http_client::get(url)` — which on tokio is a bare `reqwest::get` re-export ([http_client.rs:18](https://github.com/livekit/rust-sdks/blob/main/livekit-api/src/http_client.rs#L18)) and on async-std is `isahc::get_async`. Neither attaches auth.

The access token is only ever written to the WS handshake as an `Authorization: Bearer` header inside [`signal_stream.rs:105-107`](https://github.com/livekit/rust-sdks/blob/main/livekit-api/src/signal_client/signal_stream.rs#L105-L107) — never into the URL. So the validate GET arrives at the server with no credentials, the server's claims check returns 401 "no permissions to access the room", and `validate()` surfaces that 401 as the terminal error. In effect: any non-404 failure on the primary path — including a 503 from a saturated node — gets rewritten into a fabricated 401 at the caller.

#### What this PR does

1. Thread `token: &str` through `SignalInner::validate` and pass it from both call sites in `connect()`.
2. Add `http_client::get_with_token(url, token)` in both the tokio (reqwest `.bearer_auth()`) and async-std (isahc `Authorization` header) branches of `http_client.rs`.
3. Switch `validate()` from `http_client::get` to `get_with_token`.
4. Remove the now-unused `http_client::get` exports — `grep -rn 'http_client::get\b' livekit-api/src/` returns zero other callers.

Auth is sent as `Authorization: Bearer <token>`, matching the precedent in `signal_stream.rs` (WS handshake), `region::fetch_from_endpoint` ([region.rs:54](https://github.com/livekit/rust-sdks/blob/main/livekit-api/src/signal_client/region.rs#L54)), and the Twirp clients in `services/*`. The access token is a JWT; keeping it out of request URLs avoids leaking it into any log that records paths (LB access logs, proxies, `jsonPayload.path` in server error logs, etc.).

### Testing

New regression test `validate_sends_bearer_token` in the existing `signal_client::tests` module. It:

- Binds a `tokio::net::TcpListener` on an ephemeral port (matches the existing `signal_stream_connect_timeout` / `region_fetch_parses_response` test pattern).
- Captures the first request bytes sent to that port via a `oneshot` channel.
- Calls `SignalInner::validate(ws_url, "test-bearer-token").await`.
- Asserts the captured request contains `authorization: bearer test-bearer-token` (case-insensitive per RFC 9110).

The assertion checks the **value** of the token, not just presence of the header — catches both "no auth" and "wrong auth" regressions.

Verified locally:
- Before applying the fix (restored `http_client::get(validate_url)` without the token), the new test **FAILS** with the captured request body showing no `authorization` header.
- With the fix applied, the new test **PASSES** and all existing tests (12/12) continue to pass: `cargo +nightly test --lib --features signal-client-tokio`.
- `cargo +nightly-2023-12-30 fmt -- --check` clean (the toolchain used by the format CI job).
- Clippy surfaces no new warnings on changed code.

A reproducer outside the test harness (stdlib HTTP server + Python `livekit` SDK) is attached to issue #1042 for anyone who wants to see the 503 → fabricated-401 cascade end-to-end against a real client.

### Breaking changes

None. `SignalInner::validate` is a private async method on a private struct — the added `token: &str` parameter is not observable outside the crate. `http_client` is declared `mod http_client;` (not `pub mod`), so the removed `get` exports weren't reachable from outside either.

### MSRV

No MSRV change. `reqwest::RequestBuilder::bearer_auth` has been available since reqwest 0.3; `isahc::Request::get().header().body()` is standard since isahc 1.0.
