### PR TITLE
fix race in download_webrtc to reduce flaky build

### DIFF
--- a/.changeset/fix_race_in_download_webrtc_to_reduce_flaky_build.md
+++ b/.changeset/fix_race_in_download_webrtc_to_reduce_flaky_build.md
@@ -1,0 +1,9 @@
+---
+libwebrtc: patch
+livekit: patch
+livekit-ffi: patch
+webrtc-sys: patch
+webrtc-sys-build: patch
+---
+
+fix race in download_webrtc to reduce flaky build - #1047 (@hechen-eng)

--- a/webrtc-sys/build/src/lib.rs
+++ b/webrtc-sys/build/src/lib.rs
@@ -225,9 +225,21 @@ pub fn download_webrtc() -> Result<()> {
         .context("Failed to create temporary file for WebRTC download")?;
     resp.copy_to(&mut file).context("Failed to write WebRTC download to temporary file")?;
 
+    // Extract into a sibling temp dir, then atomically rename into place so concurrent
+    // observers see either no `webrtc_dir` or a fully-populated one — never the partially-
+    // extracted state that made `fs::copy(webrtc_dir/LICENSE.md, …)` in callers flaky.
+    let tmp_extract = webrtc_dir.parent().unwrap().join(format!(".{}.tmp", webrtc_triple()));
+    let _ = fs::remove_dir_all(&tmp_extract); // clean up leftover from a crashed build
+    fs::create_dir_all(&tmp_extract).context("Failed to create temp extraction dir")?;
+
     let mut archive = zip::ZipArchive::new(file).context("Failed to open WebRTC zip archive")?;
-    archive.extract(webrtc_dir.parent().unwrap()).context("Failed to extract WebRTC archive")?;
+    archive.extract(&tmp_extract).context("Failed to extract WebRTC archive")?;
     drop(archive);
+
+    // The zip root is `{triple}/`, so extracted content sits at `tmp_extract/{triple}/`.
+    fs::rename(tmp_extract.join(webrtc_triple()), &webrtc_dir)
+        .context("Failed to move extracted WebRTC into place")?;
+    let _ = fs::remove_dir_all(&tmp_extract);
 
     fs::remove_file(&tmp_path).context("Failed to remove temporary WebRTC zip file")?;
     Ok(())


### PR DESCRIPTION
### Before you submit your PR

Make sure the following is true before submitting your PR:

- [x] I have read the [contributing guidelines](https://github.com/livekit/rust-sdks/blob/main/CONTRIBUTING.md) and validated that this PR will be accepted.
- [x] I have read and followed the principles regarding breaking changes, testing, and code quality.

### PR description

It seems we have a flaky [build](https://github.com/livekit/rust-sdks/actions/runs/24849766517/job/72746715362#step:11:1003).
`webrtc_sys_build::download_webrtc()` extracts the downloaded zip via:                                                                                                                                     
  
```rust
archive.extract(webrtc_dir.parent().unwrap())?;
```

Zip extraction creates webrtc_dir/ as soon as its first entry is written, but LICENSE.md and other files land in an arbitrary order over the next few hundred milliseconds. During that window, webrtc_dir.exists() returns true but the directory is only partially populated.                                                                                                                                                             

Concurrent build scripts (livekit-ffi/build.rs, webrtc-sys/build.rs) check webrtc_dir.exists() outside the flock as a fast-path, observe the half-extracted state, skip calling the locked downloader, and then fail when they try to read a specific file that hasn't been written yet.

**Fix:**

Make extraction atomic from observers' point of view: extract into a sibling temp directory, then fs::rename it into place as a single step. Same filesystem → rename is atomic. Observers now see webrtc_dir as either non-existent or fully populated, never mid-extraction.


