### PR TITLE
fix: update node@20 -> node@24

### DIFF
--- a/.github/workflows/node-builds.yml
+++ b/.github/workflows/node-builds.yml
@@ -50,7 +50,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
             build_image: quay.io/pypa/manylinux_2_28_aarch64
 
-    name: stable - ${{ matrix.target }} - node@20
+    name: stable - ${{ matrix.target }} - node@24
     runs-on: ${{ matrix.os }}
     env:
       RUST_BACKTRACE: full


### PR DESCRIPTION
### PR description

In looking through the github actions to see how they worked, I noticed a github action name contained "node@20" as part of the name. But, the action actually uses node 24:
```yaml
      - name: Setup node
        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
        with:
          node-version: 24  # <- HERE
```

So, update the name to be "node@24" instead.