### PR TITLE
fix: derive `simulcasted` from non-deprecated TrackInfo fields

### DIFF
--- a/.changeset/fix_derive_simulcasted_from_non_deprecated_trackinfo_fields.md
+++ b/.changeset/fix_derive_simulcasted_from_non_deprecated_trackinfo_fields.md
@@ -1,0 +1,6 @@
+---
+livekit: patch
+livekit-ffi: patch
+---
+
+fix: derive `simulcasted` from non-deprecated TrackInfo fields - #1052 (@cloudwebrtc)

--- a/livekit/src/room/publication/mod.rs
+++ b/livekit/src/room/publication/mod.rs
@@ -121,9 +121,7 @@ pub(super) struct TrackPublicationInner {
 /// `TrackInfo.codecs[*].layers`. We still consult the deprecated fields so
 /// older servers continue to work.
 fn is_simulcasted(info: &proto::TrackInfo) -> bool {
-    info.simulcast
-        || info.layers.len() > 1
-        || info.codecs.iter().any(|c| c.layers.len() > 1)
+    info.simulcast || info.layers.len() > 1 || info.codecs.iter().any(|c| c.layers.len() > 1)
 }
 
 pub(super) fn new_inner(

--- a/livekit/src/room/publication/mod.rs
+++ b/livekit/src/room/publication/mod.rs
@@ -114,19 +114,31 @@ pub(super) struct TrackPublicationInner {
     events: Arc<PublicationEvents>,
 }
 
+/// Returns whether a `TrackInfo` represents a simulcasted publication.
+///
+/// `TrackInfo.simulcast` and `TrackInfo.layers` are deprecated and modern
+/// LiveKit servers no longer populate them; the authoritative source is
+/// `TrackInfo.codecs[*].layers`. We still consult the deprecated fields so
+/// older servers continue to work.
+fn is_simulcasted(info: &proto::TrackInfo) -> bool {
+    info.simulcast
+        || info.layers.len() > 1
+        || info.codecs.iter().any(|c| c.layers.len() > 1)
+}
+
 pub(super) fn new_inner(
     info: proto::TrackInfo,
     track: Option<Track>,
 ) -> Arc<TrackPublicationInner> {
     let info = PublicationInfo {
         track,
+        simulcasted: is_simulcasted(&info),
         proto_info: info.clone(),
         source: info.source().into(),
         kind: info.r#type().try_into().unwrap(),
         encryption_type: info.encryption().into(),
         name: info.clone().name,
         sid: info.sid.clone().try_into().unwrap(),
-        simulcasted: info.simulcast,
         dimension: TrackDimension(info.width, info.height),
         mime_type: info.mime_type.clone(),
         muted: info.muted,
@@ -159,7 +171,7 @@ pub(super) fn update_info(
     info.sid = new_info.sid.clone().try_into().unwrap();
     info.dimension = TrackDimension(new_info.width, new_info.height);
     info.mime_type = new_info.mime_type.clone();
-    info.simulcasted = new_info.simulcast;
+    info.simulcasted = is_simulcasted(&new_info);
     info.audio_features = new_info.audio_features().collect();
     info.packet_trailer_features = new_info
         .packet_trailer_features


### PR DESCRIPTION
Fixed a bug where the `is_simulcasted` in the `set_video_quality` directive failed, causing the video layer to be unselectable. This bug was found in the `test_change_video_quality` test of the Python SDK.

