### PR TITLE
Expose data track subscribe error message for FFI

### DIFF
--- a/.changeset/expose_error_message_on_eos_for_data_track_subscriptions.md
+++ b/.changeset/expose_error_message_on_eos_for_data_track_subscriptions.md
@@ -1,0 +1,5 @@
+---
+livekit-ffi: minor
+---
+
+# Expose error message on EOS for data track subscriptions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,7 +2031,7 @@ dependencies = [
  "livekit-api",
  "log",
  "polars",
- "rand 0.9.2",
+ "rand 0.9.3",
  "tokio",
 ]
 
@@ -6242,7 +6242,7 @@ dependencies = [
  "polars-buffer",
  "polars-error",
  "polars-utils",
- "rand 0.9.2",
+ "rand 0.9.3",
  "serde",
  "strength_reduce",
  "strum_macros",
@@ -6276,7 +6276,7 @@ dependencies = [
  "polars-row",
  "polars-schema",
  "polars-utils",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_distr 0.5.1",
  "rayon",
  "regex",
@@ -6336,7 +6336,7 @@ dependencies = [
  "polars-row",
  "polars-time",
  "polars-utils",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rayon",
  "recursive",
  "regex",
@@ -6622,7 +6622,7 @@ dependencies = [
  "polars-plan",
  "polars-time",
  "polars-utils",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rayon",
  "recursive",
  "slotmap",
@@ -6675,7 +6675,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "polars-error",
- "rand 0.9.2",
+ "rand 0.9.3",
  "raw-cpuid",
  "rayon",
  "regex",
@@ -7181,7 +7181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
 ]
 
 [[package]]

--- a/livekit-ffi-node-bindings/proto/data_track_pb.d.ts
+++ b/livekit-ffi-node-bindings/proto/data_track_pb.d.ts
@@ -1020,12 +1020,12 @@ export declare class DataTrackStreamFrameReceived extends Message<DataTrackStrea
  */
 export declare class DataTrackStreamEOS extends Message<DataTrackStreamEOS> {
   /**
-   * If the track could not be subscribed to, a message describing the error.
-   * Absent if the stream ended normally.
+   * Present if stream ended before any frames were emitted due to subscription establishment failing.
+   * Absent if the stream ended normally (i.e., due to the track being unpublished).
    *
-   * @generated from field: optional string error = 1;
+   * @generated from field: optional livekit.proto.SubscribeDataTrackError error = 1;
    */
-  error?: string;
+  error?: SubscribeDataTrackError;
 
   constructor(data?: PartialMessage<DataTrackStreamEOS>);
 

--- a/livekit-ffi-node-bindings/proto/data_track_pb.js
+++ b/livekit-ffi-node-bindings/proto/data_track_pb.js
@@ -428,7 +428,7 @@ const DataTrackStreamFrameReceived = /*@__PURE__*/ proto2.makeMessageType(
 const DataTrackStreamEOS = /*@__PURE__*/ proto2.makeMessageType(
   "livekit.proto.DataTrackStreamEOS",
   () => [
-    { no: 1, name: "error", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+    { no: 1, name: "error", kind: "message", T: SubscribeDataTrackError, opt: true },
   ],
 );
 

--- a/livekit-ffi/protocol/data_track.proto
+++ b/livekit-ffi/protocol/data_track.proto
@@ -224,7 +224,7 @@ message DataTrackStreamFrameReceived {
 
 // Stream has ended.
 message DataTrackStreamEOS {
-  // If the track could not be subscribed to, a message describing the error.
-  // Absent if the stream ended normally.
-  optional string error = 1;
+  // Present if stream ended before any frames were emitted due to subscription establishment failing.
+  // Absent if the stream ended normally (i.e., due to the track being unpublished).
+  optional SubscribeDataTrackError error = 1;
 }

--- a/livekit-ffi/src/server/data_track.rs
+++ b/livekit-ffi/src/server/data_track.rs
@@ -16,7 +16,8 @@ use super::{FfiHandle, FfiServer};
 use crate::{proto, FfiHandleId, FfiResult};
 use futures_util::StreamExt;
 use livekit::data_track::{
-    DataTrackFrame, DataTrackStream, DataTrackSubscribeOptions, LocalDataTrack, RemoteDataTrack,
+    DataTrackFrame, DataTrackStream, DataTrackSubscribeError, DataTrackSubscribeOptions,
+    LocalDataTrack, RemoteDataTrack,
 };
 use std::sync::Arc;
 use tokio::sync::{oneshot, Notify};
@@ -176,7 +177,7 @@ impl SubscriptionTask {
             result = track.subscribe_with_options(options) => match result {
                 Ok(stream) => Some(stream),
                 Err(err) => {
-                    self.send_eos(Some(err.to_string()));
+                    self.send_eos(Some(err));
                     None
                 }
             },
@@ -198,7 +199,8 @@ impl SubscriptionTask {
         let _ = self.server.send_event(event.into());
     }
 
-    fn send_eos(&self, error: Option<String>) {
+    fn send_eos(&self, error: Option<DataTrackSubscribeError>) {
+        let error: Option<proto::SubscribeDataTrackError> = error.map(|err| err.into());
         let event = proto::DataTrackStreamEvent {
             stream_handle: self.handle_id,
             detail: Some(proto::DataTrackStreamEos { error }.into()),


### PR DESCRIPTION
Exposes the previously unused `SubscribeDataTrackError` message added in #981 and clarifies behavior for FFI implementors.

Resolves BOT-341