### PR TITLE
Resolve room handle synchronously in on_disconnect

### DIFF
--- a/.changeset/resolve_room_handle_synchronously_in_on_disconnect.md
+++ b/.changeset/resolve_room_handle_synchronously_in_on_disconnect.md
@@ -1,0 +1,5 @@
+---
+livekit-ffi: patch
+---
+
+Resolve room handle synchronously in on_disconnect - #1066 (@MaxHeimbrock)

--- a/livekit-ffi/src/server/requests.rs
+++ b/livekit-ffi/src/server/requests.rs
@@ -70,10 +70,13 @@ fn on_disconnect(
         .and_then(|r| proto::DisconnectReason::try_from(r).ok())
         .map(DisconnectReason::from)
         .unwrap_or(DisconnectReason::ClientInitiated);
+    // Resolve the handle synchronously, before returning. The spawned task
+    // owns its Arc clone, so the close completes correctly even if the foreign
+    // side drops the room handle the moment this request returns. A missing
+    // handle now surfaces as a proper FfiResult error instead of an unwrap
+    // panic that would abort the process.
+    let ffi_room = server.retrieve_handle::<room::FfiRoom>(disconnect.room_handle)?.clone();
     let handle = server.async_runtime.spawn(async move {
-        let ffi_room =
-            server.retrieve_handle::<room::FfiRoom>(disconnect.room_handle).unwrap().clone();
-
         ffi_room.close(server, reason).await;
 
         let _ = server.send_event(proto::DisconnectCallback { async_id }.into());


### PR DESCRIPTION
## Summary
`on_disconnect` spawned an async task that retrieved the `FfiRoom` via the DashMap inside the spawn body and `unwrap()`'d the result. The synchronous `DisconnectResponse` returned to the foreign-language client before the spawn was scheduled, so a client that disposed its room handle as soon as the request returned would race the tokio scheduler. When the spawn finally polled, `retrieve_handle` saw the entry already removed by `drop_handle` and the unwrap aborted the process via `SIGABRT` inside the runtime worker. On iOS the race lost roughly half the time.

Move the `retrieve_handle + clone` before the spawn. The spawn now owns its `Arc<FfiRoom>` clone, so the close runs even if the foreign side has already removed the DashMap entry. Also replace the `unwrap` with `?` so a genuinely missing handle surfaces as a proper `FfiResult` error rather than an abort.

Surfaced in the Unity SDK after a separate change started disposing the room handle synchronously on disconnect (rather than waiting for the `Disconnected` event + GC of the SafeHandle). Either change is reasonable on the foreign side; the FFI server should be robust to it.

## Test plan
- [x] Reproduced the SIGABRT on iOS by disposing the room handle immediately after the request returns; ~50% crash rate before fix, 0 crashes after fix across multiple connect/disconnect cycles.
- [x] macOS still works.
- [ ] CI tests pass.

## Unity

Found in this Unity PR:
https://github.com/livekit/client-sdk-unity/pull/278