### PR TITLE
Modify release name and adjust release creation command

### DIFF
--- a/.github/workflows/webrtc-builds.yml
+++ b/.github/workflows/webrtc-builds.yml
@@ -174,7 +174,7 @@ jobs:
           path: ${{ steps.setup.outputs.ZIP }}
 
   release:
-    name: Release to GH (Draft)
+    name: Release to GH
     runs-on: ubuntu-latest
     needs: build
     permissions:
@@ -194,5 +194,4 @@ jobs:
 
       - name: Create draft release
         run: |
-          gh release create ${{ github.ref_name }} --draft --title "${{ github.ref_name }}"
           gh release upload ${{ github.ref_name }} ${{ github.workspace }}/webrtc-builds/*


### PR DESCRIPTION
Since this workflow will only be triggered on the release page, the tag already exists, so there is no need to create a draft again.
```
if: startsWith(github.ref, 'refs/tags/webrtc-')
```