### PR TITLE
Add env var to set preferred encoder

### DIFF
--- a/.changeset/prefer_hardware_encoder_env.md
+++ b/.changeset/prefer_hardware_encoder_env.md
@@ -1,0 +1,8 @@
+---
+webrtc-sys: patch
+libwebrtc: patch
+livekit: patch
+livekit-ffi: patch
+---
+
+Add `PREFERRED_HW_ENCODER` to prefer `nvenc` or `vaapi` hardware video encoding when both are available.

--- a/.changeset/prefer_hardware_encoder_env.md
+++ b/.changeset/prefer_hardware_encoder_env.md
@@ -5,4 +5,4 @@ livekit: patch
 livekit-ffi: patch
 ---
 
-Add `PREFERRED_HW_ENCODER` to prefer `nvenc` or `vaapi` hardware video encoding when both are available.
+Add `LIVEKIT_PREFERRED_HW_ENCODER` to prefer `nvenc` or `vaapi` hardware video encoding when both are available.

--- a/README.md
+++ b/README.md
@@ -180,6 +180,17 @@ When building on MacOS, `-ObjC` linker flag is needed. LiveKit's WebRTC implemen
 *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[RTCVideoCodecInfo nativeSdpVideoFormat]: unrecognized selector sent to instance 0x600003bc6660'
 ```
 
+## Environment variables
+
+### `LIVEKIT_PREFERRED_HW_ENCODER`
+
+On Linux builds that include support for multiple hardware video encoders (NVENC and VAAPI), this variable selects which one is preferred when both are available at runtime. Accepted values:
+
+- `nvenc` — prefer the NVIDIA NVENC encoder.
+- `vaapi` — prefer the VAAPI encoder.
+
+If unset (the default), NVENC is preferred. If the requested encoder is not supported or not compiled in, the SDK logs a warning and falls back to the other available hardware encoder (or software encoders). Any other value is ignored with a warning.
+
 ## Motivation and Design Goals
 
 LiveKit aims to provide an open source, end-to-end WebRTC stack that works everywhere. We have two goals in mind with this SDK:

--- a/livekit-protocol/src/livekit.rs
+++ b/livekit-protocol/src/livekit.rs
@@ -4586,6 +4586,8 @@ pub struct Job {
     pub state: ::core::option::Option<JobState>,
     #[prost(bool, tag="10")]
     pub enable_recording: bool,
+    #[prost(string, tag="11")]
+    pub deployment: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -4706,6 +4708,8 @@ pub struct RegisterWorkerRequest {
     pub namespace: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, optional, tag="7")]
     pub allowed_permissions: ::core::option::Option<ParticipantPermission>,
+    #[prost(string, tag="9")]
+    pub deployment: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -4891,6 +4895,8 @@ pub struct CreateAgentDispatchRequest {
     /// cloud only
     #[prost(enumeration="JobRestartPolicy", tag="4")]
     pub restart_policy: i32,
+    #[prost(string, tag="5")]
+    pub deployment: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -4902,6 +4908,8 @@ pub struct RoomAgentDispatch {
     /// cloud only
     #[prost(enumeration="JobRestartPolicy", tag="3")]
     pub restart_policy: i32,
+    #[prost(string, tag="4")]
+    pub deployment: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -4943,6 +4951,8 @@ pub struct AgentDispatch {
     /// cloud only
     #[prost(enumeration="JobRestartPolicy", tag="6")]
     pub restart_policy: i32,
+    #[prost(string, tag="7")]
+    pub deployment: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -5782,6 +5792,26 @@ pub struct CreateSipTrunkRequest {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SipCodec {
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(uint32, tag="2")]
+    pub rate: u32,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SipMediaConfig {
+    /// if set, ignore the default codecs and use the list below.
+    #[prost(bool, tag="1")]
+    pub only_listed_codecs: bool,
+    /// List of allowed codecs. If only_listed_codecs is not set, this list is added to default codecs.
+    #[prost(message, repeated, tag="2")]
+    pub codecs: ::prost::alloc::vec::Vec<SipCodec>,
+    #[prost(enumeration="SipMediaEncryption", optional, tag="3")]
+    pub encryption: ::core::option::Option<i32>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ProviderInfo {
     #[prost(string, tag="1")]
     pub id: ::prost::alloc::string::String,
@@ -6329,8 +6359,11 @@ pub struct SipDispatchRuleInfo {
     /// RoomConfiguration to use if the participant initiates the room
     #[prost(message, optional, tag="10")]
     pub room_config: ::core::option::Option<RoomConfiguration>,
+    #[prost(message, optional, tag="16")]
+    pub media: ::core::option::Option<SipMediaConfig>,
     #[prost(bool, tag="11")]
     pub krisp_enabled: bool,
+    #[deprecated]
     #[prost(enumeration="SipMediaEncryption", tag="12")]
     pub media_encryption: i32,
     #[prost(message, optional, tag="14")]
@@ -6351,8 +6384,11 @@ pub struct SipDispatchRuleUpdate {
     pub metadata: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(map="string, string", tag="5")]
     pub attributes: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    #[deprecated]
     #[prost(enumeration="SipMediaEncryption", optional, tag="6")]
     pub media_encryption: ::core::option::Option<i32>,
+    #[prost(message, optional, tag="7")]
+    pub media: ::core::option::Option<SipMediaConfig>,
 }
 /// ListSIPDispatchRuleRequest lists dispatch rules for given filters. If no filters are set, all rules are listed.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -6475,8 +6511,11 @@ pub struct CreateSipParticipantRequest {
     /// Enable voice isolation for the callee.
     #[prost(bool, tag="14")]
     pub krisp_enabled: bool,
+    #[deprecated]
     #[prost(enumeration="SipMediaEncryption", tag="18")]
     pub media_encryption: i32,
+    #[prost(message, optional, tag="23")]
+    pub media: ::core::option::Option<SipMediaConfig>,
     /// Wait for the answer for the call before returning.
     #[prost(bool, tag="19")]
     pub wait_until_answered: bool,
@@ -6488,7 +6527,7 @@ pub struct CreateSipParticipantRequest {
     /// 3) Non-empty: Use the specified value as the display name.
     #[prost(string, optional, tag="21")]
     pub display_name: ::core::option::Option<::prost::alloc::string::String>,
-    /// NEXT ID: 23
+    /// NEXT ID: 24
     #[prost(message, optional, tag="22")]
     pub destination: ::core::option::Option<Destination>,
 }

--- a/livekit-protocol/src/livekit.serde.rs
+++ b/livekit-protocol/src/livekit.serde.rs
@@ -974,6 +974,9 @@ impl serde::Serialize for AgentDispatch {
         if self.restart_policy != 0 {
             len += 1;
         }
+        if !self.deployment.is_empty() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("livekit.AgentDispatch", len)?;
         if !self.id.is_empty() {
             struct_ser.serialize_field("id", &self.id)?;
@@ -995,6 +998,9 @@ impl serde::Serialize for AgentDispatch {
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.restart_policy)))?;
             struct_ser.serialize_field("restartPolicy", &v)?;
         }
+        if !self.deployment.is_empty() {
+            struct_ser.serialize_field("deployment", &self.deployment)?;
+        }
         struct_ser.end()
     }
 }
@@ -1013,6 +1019,7 @@ impl<'de> serde::Deserialize<'de> for AgentDispatch {
             "state",
             "restart_policy",
             "restartPolicy",
+            "deployment",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -1023,6 +1030,7 @@ impl<'de> serde::Deserialize<'de> for AgentDispatch {
             Metadata,
             State,
             RestartPolicy,
+            Deployment,
             __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -1051,6 +1059,7 @@ impl<'de> serde::Deserialize<'de> for AgentDispatch {
                             "metadata" => Ok(GeneratedField::Metadata),
                             "state" => Ok(GeneratedField::State),
                             "restartPolicy" | "restart_policy" => Ok(GeneratedField::RestartPolicy),
+                            "deployment" => Ok(GeneratedField::Deployment),
                             _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
@@ -1076,6 +1085,7 @@ impl<'de> serde::Deserialize<'de> for AgentDispatch {
                 let mut metadata__ = None;
                 let mut state__ = None;
                 let mut restart_policy__ = None;
+                let mut deployment__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Id => {
@@ -1114,6 +1124,12 @@ impl<'de> serde::Deserialize<'de> for AgentDispatch {
                             }
                             restart_policy__ = Some(map_.next_value::<JobRestartPolicy>()? as i32);
                         }
+                        GeneratedField::Deployment => {
+                            if deployment__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("deployment"));
+                            }
+                            deployment__ = Some(map_.next_value()?);
+                        }
                         GeneratedField::__SkipField__ => {
                             let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
@@ -1126,6 +1142,7 @@ impl<'de> serde::Deserialize<'de> for AgentDispatch {
                     metadata: metadata__.unwrap_or_default(),
                     state: state__,
                     restart_policy: restart_policy__.unwrap_or_default(),
+                    deployment: deployment__.unwrap_or_default(),
                 })
             }
         }
@@ -5112,6 +5129,9 @@ impl serde::Serialize for CreateAgentDispatchRequest {
         if self.restart_policy != 0 {
             len += 1;
         }
+        if !self.deployment.is_empty() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("livekit.CreateAgentDispatchRequest", len)?;
         if !self.agent_name.is_empty() {
             struct_ser.serialize_field("agentName", &self.agent_name)?;
@@ -5126,6 +5146,9 @@ impl serde::Serialize for CreateAgentDispatchRequest {
             let v = JobRestartPolicy::try_from(self.restart_policy)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.restart_policy)))?;
             struct_ser.serialize_field("restartPolicy", &v)?;
+        }
+        if !self.deployment.is_empty() {
+            struct_ser.serialize_field("deployment", &self.deployment)?;
         }
         struct_ser.end()
     }
@@ -5143,6 +5166,7 @@ impl<'de> serde::Deserialize<'de> for CreateAgentDispatchRequest {
             "metadata",
             "restart_policy",
             "restartPolicy",
+            "deployment",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -5151,6 +5175,7 @@ impl<'de> serde::Deserialize<'de> for CreateAgentDispatchRequest {
             Room,
             Metadata,
             RestartPolicy,
+            Deployment,
             __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -5177,6 +5202,7 @@ impl<'de> serde::Deserialize<'de> for CreateAgentDispatchRequest {
                             "room" => Ok(GeneratedField::Room),
                             "metadata" => Ok(GeneratedField::Metadata),
                             "restartPolicy" | "restart_policy" => Ok(GeneratedField::RestartPolicy),
+                            "deployment" => Ok(GeneratedField::Deployment),
                             _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
@@ -5200,6 +5226,7 @@ impl<'de> serde::Deserialize<'de> for CreateAgentDispatchRequest {
                 let mut room__ = None;
                 let mut metadata__ = None;
                 let mut restart_policy__ = None;
+                let mut deployment__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::AgentName => {
@@ -5226,6 +5253,12 @@ impl<'de> serde::Deserialize<'de> for CreateAgentDispatchRequest {
                             }
                             restart_policy__ = Some(map_.next_value::<JobRestartPolicy>()? as i32);
                         }
+                        GeneratedField::Deployment => {
+                            if deployment__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("deployment"));
+                            }
+                            deployment__ = Some(map_.next_value()?);
+                        }
                         GeneratedField::__SkipField__ => {
                             let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
@@ -5236,6 +5269,7 @@ impl<'de> serde::Deserialize<'de> for CreateAgentDispatchRequest {
                     room: room__.unwrap_or_default(),
                     metadata: metadata__.unwrap_or_default(),
                     restart_policy: restart_policy__.unwrap_or_default(),
+                    deployment: deployment__.unwrap_or_default(),
                 })
             }
         }
@@ -6381,6 +6415,9 @@ impl serde::Serialize for CreateSipParticipantRequest {
         if self.media_encryption != 0 {
             len += 1;
         }
+        if self.media.is_some() {
+            len += 1;
+        }
         if self.wait_until_answered {
             len += 1;
         }
@@ -6452,6 +6489,9 @@ impl serde::Serialize for CreateSipParticipantRequest {
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.media_encryption)))?;
             struct_ser.serialize_field("mediaEncryption", &v)?;
         }
+        if let Some(v) = self.media.as_ref() {
+            struct_ser.serialize_field("media", v)?;
+        }
         if self.wait_until_answered {
             struct_ser.serialize_field("waitUntilAnswered", &self.wait_until_answered)?;
         }
@@ -6506,6 +6546,7 @@ impl<'de> serde::Deserialize<'de> for CreateSipParticipantRequest {
             "krispEnabled",
             "media_encryption",
             "mediaEncryption",
+            "media",
             "wait_until_answered",
             "waitUntilAnswered",
             "display_name",
@@ -6534,6 +6575,7 @@ impl<'de> serde::Deserialize<'de> for CreateSipParticipantRequest {
             MaxCallDuration,
             KrispEnabled,
             MediaEncryption,
+            Media,
             WaitUntilAnswered,
             DisplayName,
             Destination,
@@ -6578,6 +6620,7 @@ impl<'de> serde::Deserialize<'de> for CreateSipParticipantRequest {
                             "maxCallDuration" | "max_call_duration" => Ok(GeneratedField::MaxCallDuration),
                             "krispEnabled" | "krisp_enabled" => Ok(GeneratedField::KrispEnabled),
                             "mediaEncryption" | "media_encryption" => Ok(GeneratedField::MediaEncryption),
+                            "media" => Ok(GeneratedField::Media),
                             "waitUntilAnswered" | "wait_until_answered" => Ok(GeneratedField::WaitUntilAnswered),
                             "displayName" | "display_name" => Ok(GeneratedField::DisplayName),
                             "destination" => Ok(GeneratedField::Destination),
@@ -6619,6 +6662,7 @@ impl<'de> serde::Deserialize<'de> for CreateSipParticipantRequest {
                 let mut max_call_duration__ = None;
                 let mut krisp_enabled__ = None;
                 let mut media_encryption__ = None;
+                let mut media__ = None;
                 let mut wait_until_answered__ = None;
                 let mut display_name__ = None;
                 let mut destination__ = None;
@@ -6742,6 +6786,12 @@ impl<'de> serde::Deserialize<'de> for CreateSipParticipantRequest {
                             }
                             media_encryption__ = Some(map_.next_value::<SipMediaEncryption>()? as i32);
                         }
+                        GeneratedField::Media => {
+                            if media__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("media"));
+                            }
+                            media__ = map_.next_value()?;
+                        }
                         GeneratedField::WaitUntilAnswered => {
                             if wait_until_answered__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("waitUntilAnswered"));
@@ -6785,6 +6835,7 @@ impl<'de> serde::Deserialize<'de> for CreateSipParticipantRequest {
                     max_call_duration: max_call_duration__,
                     krisp_enabled: krisp_enabled__.unwrap_or_default(),
                     media_encryption: media_encryption__.unwrap_or_default(),
+                    media: media__,
                     wait_until_answered: wait_until_answered__.unwrap_or_default(),
                     display_name: display_name__,
                     destination: destination__,
@@ -17599,6 +17650,9 @@ impl serde::Serialize for Job {
         if self.enable_recording {
             len += 1;
         }
+        if !self.deployment.is_empty() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("livekit.Job", len)?;
         if !self.id.is_empty() {
             struct_ser.serialize_field("id", &self.id)?;
@@ -17632,6 +17686,9 @@ impl serde::Serialize for Job {
         if self.enable_recording {
             struct_ser.serialize_field("enableRecording", &self.enable_recording)?;
         }
+        if !self.deployment.is_empty() {
+            struct_ser.serialize_field("deployment", &self.deployment)?;
+        }
         struct_ser.end()
     }
 }
@@ -17655,6 +17712,7 @@ impl<'de> serde::Deserialize<'de> for Job {
             "state",
             "enable_recording",
             "enableRecording",
+            "deployment",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -17669,6 +17727,7 @@ impl<'de> serde::Deserialize<'de> for Job {
             AgentName,
             State,
             EnableRecording,
+            Deployment,
             __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -17701,6 +17760,7 @@ impl<'de> serde::Deserialize<'de> for Job {
                             "agentName" | "agent_name" => Ok(GeneratedField::AgentName),
                             "state" => Ok(GeneratedField::State),
                             "enableRecording" | "enable_recording" => Ok(GeneratedField::EnableRecording),
+                            "deployment" => Ok(GeneratedField::Deployment),
                             _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
@@ -17730,6 +17790,7 @@ impl<'de> serde::Deserialize<'de> for Job {
                 let mut agent_name__ = None;
                 let mut state__ = None;
                 let mut enable_recording__ = None;
+                let mut deployment__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Id => {
@@ -17792,6 +17853,12 @@ impl<'de> serde::Deserialize<'de> for Job {
                             }
                             enable_recording__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::Deployment => {
+                            if deployment__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("deployment"));
+                            }
+                            deployment__ = Some(map_.next_value()?);
+                        }
                         GeneratedField::__SkipField__ => {
                             let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
@@ -17808,6 +17875,7 @@ impl<'de> serde::Deserialize<'de> for Job {
                     agent_name: agent_name__.unwrap_or_default(),
                     state: state__,
                     enable_recording: enable_recording__.unwrap_or_default(),
+                    deployment: deployment__.unwrap_or_default(),
                 })
             }
         }
@@ -28382,6 +28450,9 @@ impl serde::Serialize for RegisterWorkerRequest {
         if self.allowed_permissions.is_some() {
             len += 1;
         }
+        if !self.deployment.is_empty() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("livekit.RegisterWorkerRequest", len)?;
         if self.r#type != 0 {
             let v = JobType::try_from(self.r#type)
@@ -28403,6 +28474,9 @@ impl serde::Serialize for RegisterWorkerRequest {
         if let Some(v) = self.allowed_permissions.as_ref() {
             struct_ser.serialize_field("allowedPermissions", v)?;
         }
+        if !self.deployment.is_empty() {
+            struct_ser.serialize_field("deployment", &self.deployment)?;
+        }
         struct_ser.end()
     }
 }
@@ -28422,6 +28496,7 @@ impl<'de> serde::Deserialize<'de> for RegisterWorkerRequest {
             "namespace",
             "allowed_permissions",
             "allowedPermissions",
+            "deployment",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -28432,6 +28507,7 @@ impl<'de> serde::Deserialize<'de> for RegisterWorkerRequest {
             PingInterval,
             Namespace,
             AllowedPermissions,
+            Deployment,
             __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -28460,6 +28536,7 @@ impl<'de> serde::Deserialize<'de> for RegisterWorkerRequest {
                             "pingInterval" | "ping_interval" => Ok(GeneratedField::PingInterval),
                             "namespace" => Ok(GeneratedField::Namespace),
                             "allowedPermissions" | "allowed_permissions" => Ok(GeneratedField::AllowedPermissions),
+                            "deployment" => Ok(GeneratedField::Deployment),
                             _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
@@ -28485,6 +28562,7 @@ impl<'de> serde::Deserialize<'de> for RegisterWorkerRequest {
                 let mut ping_interval__ = None;
                 let mut namespace__ = None;
                 let mut allowed_permissions__ = None;
+                let mut deployment__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Type => {
@@ -28525,6 +28603,12 @@ impl<'de> serde::Deserialize<'de> for RegisterWorkerRequest {
                             }
                             allowed_permissions__ = map_.next_value()?;
                         }
+                        GeneratedField::Deployment => {
+                            if deployment__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("deployment"));
+                            }
+                            deployment__ = Some(map_.next_value()?);
+                        }
                         GeneratedField::__SkipField__ => {
                             let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
@@ -28537,6 +28621,7 @@ impl<'de> serde::Deserialize<'de> for RegisterWorkerRequest {
                     ping_interval: ping_interval__.unwrap_or_default(),
                     namespace: namespace__,
                     allowed_permissions: allowed_permissions__,
+                    deployment: deployment__.unwrap_or_default(),
                 })
             }
         }
@@ -29536,6 +29621,9 @@ impl serde::Serialize for RoomAgentDispatch {
         if self.restart_policy != 0 {
             len += 1;
         }
+        if !self.deployment.is_empty() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("livekit.RoomAgentDispatch", len)?;
         if !self.agent_name.is_empty() {
             struct_ser.serialize_field("agentName", &self.agent_name)?;
@@ -29547,6 +29635,9 @@ impl serde::Serialize for RoomAgentDispatch {
             let v = JobRestartPolicy::try_from(self.restart_policy)
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.restart_policy)))?;
             struct_ser.serialize_field("restartPolicy", &v)?;
+        }
+        if !self.deployment.is_empty() {
+            struct_ser.serialize_field("deployment", &self.deployment)?;
         }
         struct_ser.end()
     }
@@ -29563,6 +29654,7 @@ impl<'de> serde::Deserialize<'de> for RoomAgentDispatch {
             "metadata",
             "restart_policy",
             "restartPolicy",
+            "deployment",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -29570,6 +29662,7 @@ impl<'de> serde::Deserialize<'de> for RoomAgentDispatch {
             AgentName,
             Metadata,
             RestartPolicy,
+            Deployment,
             __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -29595,6 +29688,7 @@ impl<'de> serde::Deserialize<'de> for RoomAgentDispatch {
                             "agentName" | "agent_name" => Ok(GeneratedField::AgentName),
                             "metadata" => Ok(GeneratedField::Metadata),
                             "restartPolicy" | "restart_policy" => Ok(GeneratedField::RestartPolicy),
+                            "deployment" => Ok(GeneratedField::Deployment),
                             _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
@@ -29617,6 +29711,7 @@ impl<'de> serde::Deserialize<'de> for RoomAgentDispatch {
                 let mut agent_name__ = None;
                 let mut metadata__ = None;
                 let mut restart_policy__ = None;
+                let mut deployment__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::AgentName => {
@@ -29637,6 +29732,12 @@ impl<'de> serde::Deserialize<'de> for RoomAgentDispatch {
                             }
                             restart_policy__ = Some(map_.next_value::<JobRestartPolicy>()? as i32);
                         }
+                        GeneratedField::Deployment => {
+                            if deployment__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("deployment"));
+                            }
+                            deployment__ = Some(map_.next_value()?);
+                        }
                         GeneratedField::__SkipField__ => {
                             let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
@@ -29646,6 +29747,7 @@ impl<'de> serde::Deserialize<'de> for RoomAgentDispatch {
                     agent_name: agent_name__.unwrap_or_default(),
                     metadata: metadata__.unwrap_or_default(),
                     restart_policy: restart_policy__.unwrap_or_default(),
+                    deployment: deployment__.unwrap_or_default(),
                 })
             }
         }
@@ -32417,6 +32519,120 @@ impl<'de> serde::Deserialize<'de> for SipCallStatus {
         deserializer.deserialize_any(GeneratedVisitor)
     }
 }
+impl serde::Serialize for SipCodec {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.name.is_empty() {
+            len += 1;
+        }
+        if self.rate != 0 {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("livekit.SIPCodec", len)?;
+        if !self.name.is_empty() {
+            struct_ser.serialize_field("name", &self.name)?;
+        }
+        if self.rate != 0 {
+            struct_ser.serialize_field("rate", &self.rate)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for SipCodec {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "name",
+            "rate",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Name,
+            Rate,
+            __SkipField__,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "name" => Ok(GeneratedField::Name),
+                            "rate" => Ok(GeneratedField::Rate),
+                            _ => Ok(GeneratedField::__SkipField__),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = SipCodec;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct livekit.SIPCodec")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SipCodec, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut name__ = None;
+                let mut rate__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Name => {
+                            if name__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("name"));
+                            }
+                            name__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Rate => {
+                            if rate__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rate"));
+                            }
+                            rate__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
+                    }
+                }
+                Ok(SipCodec {
+                    name: name__.unwrap_or_default(),
+                    rate: rate__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("livekit.SIPCodec", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for SipDispatchRule {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -32961,6 +33177,9 @@ impl serde::Serialize for SipDispatchRuleInfo {
         if self.room_config.is_some() {
             len += 1;
         }
+        if self.media.is_some() {
+            len += 1;
+        }
         if self.krisp_enabled {
             len += 1;
         }
@@ -33007,6 +33226,9 @@ impl serde::Serialize for SipDispatchRuleInfo {
         if let Some(v) = self.room_config.as_ref() {
             struct_ser.serialize_field("roomConfig", v)?;
         }
+        if let Some(v) = self.media.as_ref() {
+            struct_ser.serialize_field("media", v)?;
+        }
         if self.krisp_enabled {
             struct_ser.serialize_field("krispEnabled", &self.krisp_enabled)?;
         }
@@ -33048,6 +33270,7 @@ impl<'de> serde::Deserialize<'de> for SipDispatchRuleInfo {
             "roomPreset",
             "room_config",
             "roomConfig",
+            "media",
             "krisp_enabled",
             "krispEnabled",
             "media_encryption",
@@ -33071,6 +33294,7 @@ impl<'de> serde::Deserialize<'de> for SipDispatchRuleInfo {
             Attributes,
             RoomPreset,
             RoomConfig,
+            Media,
             KrispEnabled,
             MediaEncryption,
             CreatedAt,
@@ -33108,6 +33332,7 @@ impl<'de> serde::Deserialize<'de> for SipDispatchRuleInfo {
                             "attributes" => Ok(GeneratedField::Attributes),
                             "roomPreset" | "room_preset" => Ok(GeneratedField::RoomPreset),
                             "roomConfig" | "room_config" => Ok(GeneratedField::RoomConfig),
+                            "media" => Ok(GeneratedField::Media),
                             "krispEnabled" | "krisp_enabled" => Ok(GeneratedField::KrispEnabled),
                             "mediaEncryption" | "media_encryption" => Ok(GeneratedField::MediaEncryption),
                             "createdAt" | "created_at" => Ok(GeneratedField::CreatedAt),
@@ -33142,6 +33367,7 @@ impl<'de> serde::Deserialize<'de> for SipDispatchRuleInfo {
                 let mut attributes__ = None;
                 let mut room_preset__ = None;
                 let mut room_config__ = None;
+                let mut media__ = None;
                 let mut krisp_enabled__ = None;
                 let mut media_encryption__ = None;
                 let mut created_at__ = None;
@@ -33216,6 +33442,12 @@ impl<'de> serde::Deserialize<'de> for SipDispatchRuleInfo {
                             }
                             room_config__ = map_.next_value()?;
                         }
+                        GeneratedField::Media => {
+                            if media__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("media"));
+                            }
+                            media__ = map_.next_value()?;
+                        }
                         GeneratedField::KrispEnabled => {
                             if krisp_enabled__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("krispEnabled"));
@@ -33257,6 +33489,7 @@ impl<'de> serde::Deserialize<'de> for SipDispatchRuleInfo {
                     attributes: attributes__.unwrap_or_default(),
                     room_preset: room_preset__.unwrap_or_default(),
                     room_config: room_config__,
+                    media: media__,
                     krisp_enabled: krisp_enabled__.unwrap_or_default(),
                     media_encryption: media_encryption__.unwrap_or_default(),
                     created_at: created_at__,
@@ -33293,6 +33526,9 @@ impl serde::Serialize for SipDispatchRuleUpdate {
         if self.media_encryption.is_some() {
             len += 1;
         }
+        if self.media.is_some() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("livekit.SIPDispatchRuleUpdate", len)?;
         if let Some(v) = self.trunk_ids.as_ref() {
             struct_ser.serialize_field("trunkIds", v)?;
@@ -33314,6 +33550,9 @@ impl serde::Serialize for SipDispatchRuleUpdate {
                 .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", *v)))?;
             struct_ser.serialize_field("mediaEncryption", &v)?;
         }
+        if let Some(v) = self.media.as_ref() {
+            struct_ser.serialize_field("media", v)?;
+        }
         struct_ser.end()
     }
 }
@@ -33332,6 +33571,7 @@ impl<'de> serde::Deserialize<'de> for SipDispatchRuleUpdate {
             "attributes",
             "media_encryption",
             "mediaEncryption",
+            "media",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -33342,6 +33582,7 @@ impl<'de> serde::Deserialize<'de> for SipDispatchRuleUpdate {
             Metadata,
             Attributes,
             MediaEncryption,
+            Media,
             __SkipField__,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -33370,6 +33611,7 @@ impl<'de> serde::Deserialize<'de> for SipDispatchRuleUpdate {
                             "metadata" => Ok(GeneratedField::Metadata),
                             "attributes" => Ok(GeneratedField::Attributes),
                             "mediaEncryption" | "media_encryption" => Ok(GeneratedField::MediaEncryption),
+                            "media" => Ok(GeneratedField::Media),
                             _ => Ok(GeneratedField::__SkipField__),
                         }
                     }
@@ -33395,6 +33637,7 @@ impl<'de> serde::Deserialize<'de> for SipDispatchRuleUpdate {
                 let mut metadata__ = None;
                 let mut attributes__ = None;
                 let mut media_encryption__ = None;
+                let mut media__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::TrunkIds => {
@@ -33435,6 +33678,12 @@ impl<'de> serde::Deserialize<'de> for SipDispatchRuleUpdate {
                             }
                             media_encryption__ = map_.next_value::<::std::option::Option<SipMediaEncryption>>()?.map(|x| x as i32);
                         }
+                        GeneratedField::Media => {
+                            if media__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("media"));
+                            }
+                            media__ = map_.next_value()?;
+                        }
                         GeneratedField::__SkipField__ => {
                             let _ = map_.next_value::<serde::de::IgnoredAny>()?;
                         }
@@ -33447,6 +33696,7 @@ impl<'de> serde::Deserialize<'de> for SipDispatchRuleUpdate {
                     metadata: metadata__,
                     attributes: attributes__.unwrap_or_default(),
                     media_encryption: media_encryption__,
+                    media: media__,
                 })
             }
         }
@@ -34225,6 +34475,138 @@ impl<'de> serde::Deserialize<'de> for SipInboundTrunkUpdate {
             }
         }
         deserializer.deserialize_struct("livekit.SIPInboundTrunkUpdate", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for SipMediaConfig {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.only_listed_codecs {
+            len += 1;
+        }
+        if !self.codecs.is_empty() {
+            len += 1;
+        }
+        if self.encryption.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("livekit.SIPMediaConfig", len)?;
+        if self.only_listed_codecs {
+            struct_ser.serialize_field("onlyListedCodecs", &self.only_listed_codecs)?;
+        }
+        if !self.codecs.is_empty() {
+            struct_ser.serialize_field("codecs", &self.codecs)?;
+        }
+        if let Some(v) = self.encryption.as_ref() {
+            let v = SipMediaEncryption::try_from(*v)
+                .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", *v)))?;
+            struct_ser.serialize_field("encryption", &v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for SipMediaConfig {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "only_listed_codecs",
+            "onlyListedCodecs",
+            "codecs",
+            "encryption",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            OnlyListedCodecs,
+            Codecs,
+            Encryption,
+            __SkipField__,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "onlyListedCodecs" | "only_listed_codecs" => Ok(GeneratedField::OnlyListedCodecs),
+                            "codecs" => Ok(GeneratedField::Codecs),
+                            "encryption" => Ok(GeneratedField::Encryption),
+                            _ => Ok(GeneratedField::__SkipField__),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = SipMediaConfig;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct livekit.SIPMediaConfig")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SipMediaConfig, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut only_listed_codecs__ = None;
+                let mut codecs__ = None;
+                let mut encryption__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::OnlyListedCodecs => {
+                            if only_listed_codecs__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("onlyListedCodecs"));
+                            }
+                            only_listed_codecs__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Codecs => {
+                            if codecs__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("codecs"));
+                            }
+                            codecs__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Encryption => {
+                            if encryption__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("encryption"));
+                            }
+                            encryption__ = map_.next_value::<::std::option::Option<SipMediaEncryption>>()?.map(|x| x as i32);
+                        }
+                        GeneratedField::__SkipField__ => {
+                            let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                        }
+                    }
+                }
+                Ok(SipMediaConfig {
+                    only_listed_codecs: only_listed_codecs__.unwrap_or_default(),
+                    codecs: codecs__.unwrap_or_default(),
+                    encryption: encryption__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("livekit.SIPMediaConfig", FIELDS, GeneratedVisitor)
     }
 }
 impl serde::Serialize for SipMediaEncryption {

--- a/webrtc-sys/src/video_encoder_factory.cpp
+++ b/webrtc-sys/src/video_encoder_factory.cpp
@@ -16,6 +16,9 @@
 
 #include "livekit/video_encoder_factory.h"
 
+#include <cstdlib>
+#include <string_view>
+
 #include "api/environment/environment_factory.h"
 #include "api/video_codecs/sdp_video_format.h"
 #include "api/video_codecs/video_encoder.h"
@@ -47,6 +50,86 @@
 
 namespace livekit_ffi {
 
+namespace {
+
+constexpr char kPreferredHwEncoderEnv[] = "PREFERRED_HW_ENCODER";
+
+enum class PreferredHwEncoder {
+  kNvenc,
+  kVaapi,
+};
+
+struct PreferredHwEncoderConfig {
+  PreferredHwEncoder encoder = PreferredHwEncoder::kNvenc;
+  bool explicitly_set = false;
+};
+
+PreferredHwEncoderConfig GetPreferredHwEncoderConfig() {
+  const char* preferred_encoder = std::getenv(kPreferredHwEncoderEnv);
+  if (!preferred_encoder) {
+    return {};
+  }
+
+  std::string_view preferred_encoder_view(preferred_encoder);
+  if (preferred_encoder_view == "nvenc") {
+    return {PreferredHwEncoder::kNvenc, true};
+  }
+  if (preferred_encoder_view == "vaapi") {
+    return {PreferredHwEncoder::kVaapi, true};
+  }
+
+  RTC_LOG(LS_WARNING) << "Ignoring invalid PREFERRED_HW_ENCODER=\""
+                      << preferred_encoder
+                      << "\"; expected \"nvenc\" or \"vaapi\".";
+  return {};
+}
+
+void AddNvencFactory(
+    std::vector<std::unique_ptr<webrtc::VideoEncoderFactory>>& factories,
+    bool preferred) {
+#if defined(USE_NVIDIA_VIDEO_CODEC)
+  if (webrtc::NvidiaVideoEncoderFactory::IsSupported()) {
+    factories.push_back(std::make_unique<webrtc::NvidiaVideoEncoderFactory>());
+    return;
+  }
+
+  if (preferred) {
+    RTC_LOG(LS_WARNING) << "PREFERRED_HW_ENCODER=nvenc requested, but NVENC "
+                           "is unavailable; falling back to other encoders.";
+  }
+#else
+  if (preferred) {
+    RTC_LOG(LS_WARNING)
+        << "PREFERRED_HW_ENCODER=nvenc requested, but NVENC support is not "
+           "compiled in; falling back to other encoders.";
+  }
+#endif
+}
+
+void AddVaapiFactory(
+    std::vector<std::unique_ptr<webrtc::VideoEncoderFactory>>& factories,
+    bool preferred) {
+#if defined(USE_VAAPI_VIDEO_CODEC)
+  if (webrtc::VAAPIVideoEncoderFactory::IsSupported()) {
+    factories.push_back(std::make_unique<webrtc::VAAPIVideoEncoderFactory>());
+    return;
+  }
+
+  if (preferred) {
+    RTC_LOG(LS_WARNING) << "PREFERRED_HW_ENCODER=vaapi requested, but VAAPI "
+                           "is unavailable; falling back to other encoders.";
+  }
+#else
+  if (preferred) {
+    RTC_LOG(LS_WARNING)
+        << "PREFERRED_HW_ENCODER=vaapi requested, but VAAPI support is not "
+           "compiled in; falling back to other encoders.";
+  }
+#endif
+}
+
+}  // namespace
+
 using Factory = webrtc::VideoEncoderFactoryTemplate<
     webrtc::LibvpxVp8EncoderTemplateAdapter,
 #if defined(WEBRTC_USE_H264)
@@ -66,21 +149,15 @@ VideoEncoderFactory::InternalFactory::InternalFactory() {
   factories_.push_back(CreateAndroidVideoEncoderFactory());
 #endif
 
-#if defined(USE_NVIDIA_VIDEO_CODEC)
-  if (webrtc::NvidiaVideoEncoderFactory::IsSupported()) {
-    factories_.push_back(std::make_unique<webrtc::NvidiaVideoEncoderFactory>());
+  const PreferredHwEncoderConfig preferred_hw_encoder =
+      GetPreferredHwEncoderConfig();
+  if (preferred_hw_encoder.encoder == PreferredHwEncoder::kVaapi) {
+    AddVaapiFactory(factories_, preferred_hw_encoder.explicitly_set);
+    AddNvencFactory(factories_, false);
   } else {
-#endif
-
-#if defined(USE_VAAPI_VIDEO_CODEC)
-    if (webrtc::VAAPIVideoEncoderFactory::IsSupported()) {
-      factories_.push_back(std::make_unique<webrtc::VAAPIVideoEncoderFactory>());
-    }
-#endif
-
-#if defined(USE_NVIDIA_VIDEO_CODEC)
+    AddNvencFactory(factories_, preferred_hw_encoder.explicitly_set);
+    AddVaapiFactory(factories_, false);
   }
-#endif
 }
 
 std::vector<webrtc::SdpVideoFormat>

--- a/webrtc-sys/src/video_encoder_factory.cpp
+++ b/webrtc-sys/src/video_encoder_factory.cpp
@@ -52,7 +52,7 @@ namespace livekit_ffi {
 
 namespace {
 
-constexpr char kPreferredHwEncoderEnv[] = "PREFERRED_HW_ENCODER";
+constexpr char kPreferredHwEncoderEnv[] = "LIVEKIT_PREFERRED_HW_ENCODER";
 
 enum class PreferredHwEncoder {
   kNvenc,
@@ -78,7 +78,7 @@ PreferredHwEncoderConfig GetPreferredHwEncoderConfig() {
     return {PreferredHwEncoder::kVaapi, true};
   }
 
-  RTC_LOG(LS_WARNING) << "Ignoring invalid PREFERRED_HW_ENCODER=\""
+  RTC_LOG(LS_WARNING) << "Ignoring invalid LIVEKIT_PREFERRED_HW_ENCODER=\""
                       << preferred_encoder
                       << "\"; expected \"nvenc\" or \"vaapi\".";
   return {};
@@ -94,14 +94,15 @@ void AddNvencFactory(
   }
 
   if (preferred) {
-    RTC_LOG(LS_WARNING) << "PREFERRED_HW_ENCODER=nvenc requested, but NVENC "
-                           "is unavailable; falling back to other encoders.";
+    RTC_LOG(LS_WARNING)
+        << "LIVEKIT_PREFERRED_HW_ENCODER=nvenc requested, but NVENC "
+           "is unavailable; falling back to other encoders.";
   }
 #else
   if (preferred) {
     RTC_LOG(LS_WARNING)
-        << "PREFERRED_HW_ENCODER=nvenc requested, but NVENC support is not "
-           "compiled in; falling back to other encoders.";
+        << "LIVEKIT_PREFERRED_HW_ENCODER=nvenc requested, but NVENC support "
+           "is not compiled in; falling back to other encoders.";
   }
 #endif
 }
@@ -116,14 +117,15 @@ void AddVaapiFactory(
   }
 
   if (preferred) {
-    RTC_LOG(LS_WARNING) << "PREFERRED_HW_ENCODER=vaapi requested, but VAAPI "
-                           "is unavailable; falling back to other encoders.";
+    RTC_LOG(LS_WARNING)
+        << "LIVEKIT_PREFERRED_HW_ENCODER=vaapi requested, but VAAPI "
+           "is unavailable; falling back to other encoders.";
   }
 #else
   if (preferred) {
     RTC_LOG(LS_WARNING)
-        << "PREFERRED_HW_ENCODER=vaapi requested, but VAAPI support is not "
-           "compiled in; falling back to other encoders.";
+        << "LIVEKIT_PREFERRED_HW_ENCODER=vaapi requested, but VAAPI support "
+           "is not compiled in; falling back to other encoders.";
   }
 #endif
 }


### PR DESCRIPTION
On system that have both a Nvidia GPU & an Intel or AMD processor with hardware video encoders, sometimes it's preferred to use the VAAPI hw encoder for video.  Currently, the SDK prefers NVENC if available and will bypass the VAAPI encoders.

This PR adds a check for a `PREFERRED_HW_ENCODER` env var that can be set to either `nvenc` or `vaapi` to explicitly set which encoder should take priority if it's available.