### PR TITLE
UniFFI: Swift release follow-ups

### DIFF
--- a/.github/workflows/uniffi-packages.yml
+++ b/.github/workflows/uniffi-packages.yml
@@ -32,8 +32,6 @@ env:
 jobs:
   resolve-tag:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     outputs:
       tag_name: ${{ steps.get-tag.outputs.tag_name }}
       version: ${{ steps.get-tag.outputs.version }}

--- a/.github/workflows/uniffi-swift.yml
+++ b/.github/workflows/uniffi-swift.yml
@@ -91,6 +91,7 @@ jobs:
             ${{ env.OUTPUT_DIR }}/Package@swift-6.2.swift:Package@swift-6.2.swift
             ${{ env.OUTPUT_DIR }}/${{ env.SPM_NAME }}.podspec:${{ env.SPM_NAME }}.podspec
             ${{ env.OUTPUT_DIR }}/LICENSE:LICENSE
+            ${{ env.OUTPUT_DIR }}/PrivacyInfo.xcprivacy:PrivacyInfo.xcprivacy
             ${{ env.OUTPUT_DIR }}/Sources/${{ env.SPM_NAME }}/livekit_uniffi.swift:Sources/${{ env.SPM_NAME }}/livekit_uniffi.swift
           token: ${{ secrets.UNIFFI_XCFRAMEWORK_PAT }}
           pr-body: |

--- a/.github/workflows/uniffi-swift.yml
+++ b/.github/workflows/uniffi-swift.yml
@@ -38,7 +38,7 @@ jobs:
     name: Build & publish Swift xcframework
     runs-on: macos-26
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/uniffi-swift.yml
+++ b/.github/workflows/uniffi-swift.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   build-and-publish:
     name: Build & publish Swift xcframework
-    runs-on: macos-26
+    runs-on: macos-26-xlarge
     permissions:
       contents: read
     steps:

--- a/livekit-uniffi/AGENTS.md
+++ b/livekit-uniffi/AGENTS.md
@@ -1,0 +1,1 @@
+README.md

--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -251,7 +251,9 @@ run_task = "node-package-flow"
 SWIFT_RELEASE_FLAG = { value = "--release", condition = { profiles = ["release"] } }
 # `--debug-symbols` embeds .dSYM bundles into the xcframework; only meaningful
 # alongside --release where the dylib is stripped and a sidecar carries DWARF.
-SWIFT_DEBUG_SYMBOLS_FLAG = { value = "--debug-symbols", condition = { profiles = ["release"] } }
+# (Named SWIFT_DSYMS_* rather than SWIFT_DEBUG_SYMBOLS_* because tera-cli's
+# --env mode warns on any env var matching SWIFT_DEBUG_*.)
+SWIFT_DSYMS_FLAG = { value = "--debug-symbols", condition = { profiles = ["release"] } }
 # Apple-only debug-info knobs. Cargo treats these env vars as profile.release
 # overrides. Scoped to this task so other release builds (FFI, node bindings,
 # Linux/Windows/Android) remain on the lean Cargo.toml profile.
@@ -285,7 +287,7 @@ cargo swift package \
 --privacy-manifest ${SUPPORT_DIR}/swift/PrivacyInfo.xcprivacy \
 --exclude-arch x86_64-apple-tvos \
 ${SWIFT_RELEASE_FLAG} \
-${SWIFT_DEBUG_SYMBOLS_FLAG}
+${SWIFT_DSYMS_FLAG}
 """
 
 # Zip the xcframework and stash the SHA256 next to it so swift-generate-manifest

--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -253,7 +253,7 @@ SWIFT_RELEASE_FLAG = { value = "--release", condition = { profiles = ["release"]
 [tasks.swift-xcframework]
 private = true
 install_crate = { crate_name = "cargo-swift", binary = "cargo-swift", test_arg = "--help" }
-install_crate_args = ["--git", "https://github.com/livekit/cargo-swift.git", "--branch", "feature/framework-wrapping"]
+install_crate_args = ["--git", "https://github.com/antoniusnaumann/cargo-swift.git", "--rev", "fe7becfcfe377c014902719165b6a834b427e072"]
 script_runner = "@shell"
 script = """
 export IPHONEOS_DEPLOYMENT_TARGET=13.0

--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -253,7 +253,7 @@ SWIFT_RELEASE_FLAG = { value = "--release", condition = { profiles = ["release"]
 [tasks.swift-xcframework]
 private = true
 install_crate = { crate_name = "cargo-swift", binary = "cargo-swift", test_arg = "--help" }
-install_crate_args = ["--git", "https://github.com/livekit/cargo-swift.git", "--branch", "feature/framework-wrapping", "--force"]
+install_crate_args = ["--git", "https://github.com/livekit/cargo-swift.git", "--branch", "feature/framework-wrapping"]
 script_runner = "@shell"
 script = """
 export IPHONEOS_DEPLOYMENT_TARGET=13.0

--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -290,6 +290,43 @@ ${SWIFT_RELEASE_FLAG} \
 ${SWIFT_DSYMS_FLAG}
 """
 
+# Enforce a size budget on the framework binary an iPhone user actually
+# downloads. The ios-arm64 slice is single-arch and matches App Store Connect's
+# thinning output for ~95% of consumers, so it's the most meaningful proxy
+# for "how much does this dep cost an end user". Universal/simulator slices
+# are ~2× larger by construction (two archs in one Mach-O) and shouldn't be
+# the metric. Override the limit per release with SPM_SIZE_LIMIT_BYTES.
+[tasks.swift-check-size.env]
+SPM_SIZE_LIMIT_BYTES = { value = "1048576", condition = { env_not_set = ["SPM_SIZE_LIMIT_BYTES"] } }
+
+[tasks.swift-check-size]
+private = true
+condition = { profiles = ["release"] }
+script_runner = "@shell"
+script = """
+binary="${SPM_NAME}/Rust${SPM_NAME}.xcframework/ios-arm64/Rust${SPM_NAME}.framework/Rust${SPM_NAME}"
+
+if [ ! -f "${binary}" ]; then
+  echo "swift-check-size: framework binary not found at ${binary}" >&2
+  exit 1
+fi
+
+bytes=$(stat -f%z "${binary}")
+limit=${SPM_SIZE_LIMIT_BYTES}
+
+# Trailing decimal trick avoids depending on numfmt (not in macOS base).
+kib=$((bytes / 1024))
+limit_kib=$((limit / 1024))
+
+if [ "${bytes}" -gt "${limit}" ]; then
+  echo "swift-check-size: Rust${SPM_NAME} (ios-arm64) is ${kib} KiB (${bytes} bytes), exceeds limit ${limit_kib} KiB (${limit} bytes)." >&2
+  echo "  Either land the size regression intentionally and bump SPM_SIZE_LIMIT_BYTES, or investigate (cargo bloat, panic = abort, opt-level)." >&2
+  exit 1
+fi
+
+echo "Rust${SPM_NAME} (ios-arm64) ${kib} KiB / ${limit_kib} KiB budget"
+"""
+
 # Zip the xcframework and stash the SHA256 next to it so swift-generate-manifest
 # can pick it up. Only runs in release profile — local dev points at the
 # unzipped xcframework directly.
@@ -347,6 +384,7 @@ mv "${SPM_NAME}" "${out_dir}"
 private = true
 dependencies = [
     "swift-xcframework",
+    "swift-check-size",
     "swift-zip-xcframework",
     "swift-generate-manifest",
     "swift-move-to-packages"

--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -290,6 +290,41 @@ ${SWIFT_RELEASE_FLAG} \
 ${SWIFT_DSYMS_FLAG}
 """
 
+# Print a size breakdown of the iPhone-arm64 framework binary (the slice that
+# actually ships to end users) using bloaty. Runs right before the size gate
+# so a failing gate ends with the diagnostic already in the log — no need to
+# rerun anything to find out who got fat. Uses the .dSYM we just embedded for
+# per-crate attribution; without it bloaty still prints sections + symbols.
+[tasks.swift-bloat]
+private = true
+condition = { profiles = ["release"] }
+script_runner = "@shell"
+script = """
+bin="${SPM_NAME}/Rust${SPM_NAME}.xcframework/ios-arm64/Rust${SPM_NAME}.framework/Rust${SPM_NAME}"
+dsym="${SPM_NAME}/Rust${SPM_NAME}.xcframework/ios-arm64/dSYMs/Rust${SPM_NAME}.framework.dSYM/Contents/Resources/DWARF/Rust${SPM_NAME}"
+
+if ! command -v bloaty >/dev/null 2>&1; then
+  if command -v brew >/dev/null 2>&1; then
+    echo "swift-bloat: installing bloaty via brew..."
+    brew install --quiet bloaty >/dev/null || true
+  fi
+fi
+if ! command -v bloaty >/dev/null 2>&1; then
+  echo "swift-bloat: bloaty unavailable, skipping size breakdown (brew install bloaty)."
+  exit 0
+fi
+
+dsym_arg=""
+[ -f "${dsym}" ] && dsym_arg="--debug-file=${dsym}"
+
+for view in sections compileunits symbols; do
+  echo
+  echo "=== Rust${SPM_NAME} (ios-arm64) — bloaty -d ${view} ==="
+  bloaty "${bin}" ${dsym_arg} -d "${view}" -n 15 || true
+done
+echo
+"""
+
 # Enforce a size budget on the framework binary an iPhone user actually
 # downloads. The ios-arm64 slice is single-arch and matches App Store Connect's
 # thinning output for ~95% of consumers, so it's the most meaningful proxy
@@ -384,6 +419,7 @@ mv "${SPM_NAME}" "${out_dir}"
 private = true
 dependencies = [
     "swift-xcframework",
+    "swift-bloat",
     "swift-check-size",
     "swift-zip-xcframework",
     "swift-generate-manifest",

--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -249,6 +249,9 @@ run_task = "node-package-flow"
 
 [tasks.swift-xcframework.env]
 SWIFT_RELEASE_FLAG = { value = "--release", condition = { profiles = ["release"] } }
+# `--debug-symbols` embeds .dSYM bundles into the xcframework; only meaningful
+# alongside --release where the dylib is stripped and a sidecar carries DWARF.
+SWIFT_DEBUG_SYMBOLS_FLAG = { value = "--debug-symbols", condition = { profiles = ["release"] } }
 # Apple-only debug-info knobs. Cargo treats these env vars as profile.release
 # overrides. Scoped to this task so other release builds (FFI, node bindings,
 # Linux/Windows/Android) remain on the lean Cargo.toml profile.
@@ -260,7 +263,7 @@ CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO = { value = "packed", condition = { profil
 [tasks.swift-xcframework]
 private = true
 install_crate = { crate_name = "cargo-swift", binary = "cargo-swift", test_arg = "--help" }
-install_crate_args = ["--git", "https://github.com/antoniusnaumann/cargo-swift.git", "--rev", "fe7becfcfe377c014902719165b6a834b427e072"]
+install_crate_args = ["--git", "https://github.com/livekit/cargo-swift.git", "--rev", "f94e76675b9524e71be028c4b03a51163d6a5c28"]
 script_runner = "@shell"
 script = """
 export IPHONEOS_DEPLOYMENT_TARGET=13.0
@@ -281,7 +284,8 @@ cargo swift package \
 --lib-type dynamic \
 --privacy-manifest ${SUPPORT_DIR}/swift/PrivacyInfo.xcprivacy \
 --exclude-arch x86_64-apple-tvos \
-${SWIFT_RELEASE_FLAG}
+${SWIFT_RELEASE_FLAG} \
+${SWIFT_DEBUG_SYMBOLS_FLAG}
 """
 
 # Zip the xcframework and stash the SHA256 next to it so swift-generate-manifest

--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -249,6 +249,13 @@ run_task = "node-package-flow"
 
 [tasks.swift-xcframework.env]
 SWIFT_RELEASE_FLAG = { value = "--release", condition = { profiles = ["release"] } }
+# Apple-only debug-info knobs. Cargo treats these env vars as profile.release
+# overrides. Scoped to this task so other release builds (FFI, node bindings,
+# Linux/Windows/Android) remain on the lean Cargo.toml profile.
+# `split-debuginfo = "packed"` triggers dsymutil → produces .dSYM bundles next
+# to each per-arch .dylib at target/<arch>/release/deps/lib<name>.dylib.dSYM.
+CARGO_PROFILE_RELEASE_DEBUG = { value = "limited", condition = { profiles = ["release"] } }
+CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO = { value = "packed", condition = { profiles = ["release"] } }
 
 [tasks.swift-xcframework]
 private = true

--- a/livekit-uniffi/README.md
+++ b/livekit-uniffi/README.md
@@ -15,33 +15,12 @@ Binding generation and multi-platform builds are handled by [_cargo-make_](https
 
 ### Swift
 
-Generate Swift bindings and build a multi-platform XCFramework. The task supports two modes:
-
-**Local development** — default profile, produces a `Package.swift` that points at the unzipped xcframework via a relative `path:` so it can be consumed directly from `./packages/swift/LiveKitUniFFI/`:
-
+Generate Swift bindings and build a multi-platform XCFramework:
 ```
 cargo make swift-package
 ```
 
-**Release** — produces a zipped xcframework, computes its SHA256, and renders `Package.swift` / `Package@swift-6.2.swift` / podspec with a remote `url:` + `checksum:` pointing at the hosting repo release. Used by CI (`.github/workflows/uniffi-swift.yml`) to publish to [_livekit-uniffi-xcframework_](https://github.com/livekit/livekit-uniffi-xcframework):
-
-```
-SPM_VERSION=0.1.0 cargo make --profile release swift-package
-```
-
-`SPM_HOSTING_REPO` defaults to `livekit/livekit-uniffi-xcframework`; override it if forking. Both modes write to `./packages/swift/LiveKitUniFFI/`.
-
-**Local dependencies** (in addition to `cargo-make`):
-
-- Xcode + Command Line Tools (for `xcodebuild`, `lipo`, the iOS/macOS SDKs)
-- Rust stable with these Apple targets: `aarch64-apple-ios`, `aarch64-apple-ios-sim`, `x86_64-apple-ios`, `aarch64-apple-ios-macabi`, `x86_64-apple-ios-macabi`, `aarch64-apple-darwin`, `x86_64-apple-darwin`
-- Rust nightly + `rust-src` component (cargo-swift falls back to `cargo +nightly -Zbuild-std` for tier-3 Apple targets — currently tvOS and visionOS):
-
-  ```
-  rustup toolchain install nightly --component rust-src
-  ```
-
-[_cargo-swift_](https://github.com/antoniusnaumann/cargo-swift) and [_tera-cli_](https://github.com/chevdor/tera-cli) are installed automatically by `cargo make` on first run.
+See [support/swift/README.md](./support/swift/README.md) for local vs. release modes, consumer integration, and prerequisites (Xcode, Rust Apple targets).
 
 ### Node
 

--- a/livekit-uniffi/README.md
+++ b/livekit-uniffi/README.md
@@ -15,10 +15,33 @@ Binding generation and multi-platform builds are handled by [_cargo-make_](https
 
 ### Swift
 
-Generate Swift bindings and build a multi-platform XCFramework:
+Generate Swift bindings and build a multi-platform XCFramework. The task supports two modes:
+
+**Local development** — default profile, produces a `Package.swift` that points at the unzipped xcframework via a relative `path:` so it can be consumed directly from `./packages/swift/LiveKitUniFFI/`:
+
 ```
 cargo make swift-package
 ```
+
+**Release** — produces a zipped xcframework, computes its SHA256, and renders `Package.swift` / `Package@swift-6.2.swift` / podspec with a remote `url:` + `checksum:` pointing at the hosting repo release. Used by CI (`.github/workflows/uniffi-swift.yml`) to publish to [_livekit-uniffi-xcframework_](https://github.com/livekit/livekit-uniffi-xcframework):
+
+```
+SPM_VERSION=0.1.0 cargo make --profile release swift-package
+```
+
+`SPM_HOSTING_REPO` defaults to `livekit/livekit-uniffi-xcframework`; override it if forking. Both modes write to `./packages/swift/LiveKitUniFFI/`.
+
+**Local dependencies** (in addition to `cargo-make`):
+
+- Xcode + Command Line Tools (for `xcodebuild`, `lipo`, the iOS/macOS SDKs)
+- Rust stable with these Apple targets: `aarch64-apple-ios`, `aarch64-apple-ios-sim`, `x86_64-apple-ios`, `aarch64-apple-ios-macabi`, `x86_64-apple-ios-macabi`, `aarch64-apple-darwin`, `x86_64-apple-darwin`
+- Rust nightly + `rust-src` component (cargo-swift falls back to `cargo +nightly -Zbuild-std` for tier-3 Apple targets — currently tvOS and visionOS):
+
+  ```
+  rustup toolchain install nightly --component rust-src
+  ```
+
+[_cargo-swift_](https://github.com/antoniusnaumann/cargo-swift) and [_tera-cli_](https://github.com/chevdor/tera-cli) are installed automatically by `cargo make` on first run.
 
 ### Node
 

--- a/livekit-uniffi/support/swift/Package.swift.tera
+++ b/livekit-uniffi/support/swift/Package.swift.tera
@@ -22,19 +22,19 @@ let package = Package(
             name: "{{ SPM_NAME }}",
             dependencies: ["Rust{{ SPM_NAME }}"]
         ),
-        {% if CARGO_MAKE_PROFILE == "development" -%}
+{%- if CARGO_MAKE_PROFILE == "development" %}
         .binaryTarget(
             name: "Rust{{ SPM_NAME }}",
             path: "./Rust{{ SPM_NAME }}.xcframework"
         )
-        {%- elif CARGO_MAKE_PROFILE == "release" %}
+{%- elif CARGO_MAKE_PROFILE == "release" %}
         .binaryTarget(
             name: "Rust{{ SPM_NAME }}",
             url: "{{ SPM_URL }}",
             checksum: "{{ SPM_CHECKSUM }}"
         )
-        {%- else %}
+{%- else %}
         {{ throw(message="Unsupported CARGO_MAKE_PROFILE") }}
-        {%- endif %}
+{%- endif %}
     ]
 )

--- a/livekit-uniffi/support/swift/Package.swift.tera
+++ b/livekit-uniffi/support/swift/Package.swift.tera
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 // Generated from Rust template
 
 import PackageDescription

--- a/livekit-uniffi/support/swift/Package@swift-6.2.swift.tera
+++ b/livekit-uniffi/support/swift/Package@swift-6.2.swift.tera
@@ -23,19 +23,19 @@ let package = Package(
             name: "{{ SPM_NAME }}",
             dependencies: ["Rust{{ SPM_NAME }}"]
         ),
-        {% if CARGO_MAKE_PROFILE == "development" -%}
+{%- if CARGO_MAKE_PROFILE == "development" %}
         .binaryTarget(
             name: "Rust{{ SPM_NAME }}",
             path: "./Rust{{ SPM_NAME }}.xcframework"
         )
-        {%- elif CARGO_MAKE_PROFILE == "release" %}
+{%- elif CARGO_MAKE_PROFILE == "release" %}
         .binaryTarget(
             name: "Rust{{ SPM_NAME }}",
             url: "{{ SPM_URL }}",
             checksum: "{{ SPM_CHECKSUM }}"
         )
-        {%- else %}
+{%- else %}
         {{ throw(message="Unsupported CARGO_MAKE_PROFILE") }}
-        {%- endif %}
+{%- endif %}
     ]
 )

--- a/livekit-uniffi/support/swift/README.md
+++ b/livekit-uniffi/support/swift/README.md
@@ -1,0 +1,41 @@
+# Swift packaging
+
+Details for the `cargo make swift-package` task. Both modes write to `./packages/swift/LiveKitUniFFI/`.
+
+## Modes
+
+**Local development** — default profile, produces a `Package.swift` that points at the unzipped xcframework via a relative `path:` so it can be consumed directly from `./packages/swift/LiveKitUniFFI/`:
+
+```
+cargo make swift-package
+```
+
+To consume it from a Swift project (e.g. `client-sdk-swift`), add this dependency entry to its `Package.swift` (and `Package@swift-6.2.swift`):
+
+```swift
+.package(name: "livekit-uniffi-xcframework", path: "../rust-sdks/livekit-uniffi/packages/swift/LiveKitUniFFI"),
+```
+
+Adjust the relative path to match your checkout layout. Don't commit this change — it's purely for local iteration.
+
+**Release** — produces a zipped xcframework, computes its SHA256, and renders `Package.swift` / `Package@swift-6.2.swift` / podspec with a remote `url:` + `checksum:` pointing at the hosting repo release. Used by CI (`.github/workflows/uniffi-swift.yml`) to publish to [_livekit-uniffi-xcframework_](https://github.com/livekit/livekit-uniffi-xcframework):
+
+```
+SPM_VERSION=0.1.0 cargo make --profile release swift-package
+```
+
+`SPM_HOSTING_REPO` defaults to `livekit/livekit-uniffi-xcframework`; override it if forking.
+
+## Local dependencies
+
+In addition to `cargo-make`:
+
+- Xcode + Command Line Tools (for `xcodebuild`, `lipo`, the iOS/macOS SDKs)
+- Rust stable with these Apple targets: `aarch64-apple-ios`, `aarch64-apple-ios-sim`, `x86_64-apple-ios`, `aarch64-apple-ios-macabi`, `x86_64-apple-ios-macabi`, `aarch64-apple-darwin`, `x86_64-apple-darwin`
+- Rust nightly + `rust-src` component (cargo-swift falls back to `cargo +nightly -Zbuild-std` for tier-3 Apple targets — currently tvOS and visionOS):
+
+  ```
+  rustup toolchain install nightly --component rust-src
+  ```
+
+[_cargo-swift_](https://github.com/antoniusnaumann/cargo-swift) and [_tera-cli_](https://github.com/chevdor/tera-cli) are installed automatically by `cargo make` on first run.


### PR DESCRIPTION
Follow-up fixes surfaced while validating the publish pipeline against livekit/livekit-uniffi-xcframework#12.

**Workflow**
- drop nested-job `contents: write` (blocked startup after the CodeQL autofix in #1078)
- drop duplicate `--force` arg now that cargo-make adds its own
- repin cargo-swift to upstream main (`antoniusnaumann/cargo-swift@fe7becf` — fork retired)
- switch to `macos-26-xlarge` for ~½ wall-clock

**Build output**
- bump `Package.swift` to swift-tools 6.0
- clean tera whitespace so no stray blank line lands in `.binaryTarget`
- include `PrivacyInfo.xcprivacy` in the publish set
- inject `CARGO_PROFILE_RELEASE_{DEBUG=limited,SPLIT_DEBUGINFO=packed}` into the swift-xcframework task so each per-arch dylib gets a sidecar `.dSYM` (~8.5 MB × 11 targets, ~94 MB raw) without touching the workspace's lean Cargo.toml profile

**Docs**
- document the dev-vs-release modes + local deps
- symlink `AGENTS.md → README.md`

**After merge:** re-dispatch `UniFFI packages` with `dry_run=false` on a fresh test version to confirm end-to-end.