### PR TITLE
Reword audio filter logs to be less confusing

### DIFF
--- a/.changeset/reword_audio_filter_logs_to_be_less_confusing.md
+++ b/.changeset/reword_audio_filter_logs_to_be_less_confusing.md
@@ -1,0 +1,5 @@
+---
+livekit-ffi: patch
+---
+
+Reword audio filter logs to be less confusing - #1092 (@1egoman)

--- a/livekit-ffi/src/server/room.rs
+++ b/livekit-ffi/src/server/room.rs
@@ -153,9 +153,9 @@ impl FfiRoom {
                         .map_err(|e| e.to_string());
                     match result {
                         Err(e) | Ok(Err(e)) => {
-                            log::debug!("error while initializing audio filter: {}", e);
+                            log::warn!("error while initializing audio filter: {}", e);
                             log::error!(
-                                "audio filter cannot be enabled: LiveKit Cloud is required"
+                                "audio filter cannot be enabled: ensure you are connecting to LiveKit Cloud and that the filter is properly configured"
                             );
                             // Skip returning an error here to keep the rtc session alive
                             // But in this case, the filter isn't enabled in the session.


### PR DESCRIPTION
This log can occur in potentially multiple cases, and it's not super clear exactly all of them. So, increase the log verbosity of the `debug!` log to `warn!`, and make the main message a little less definitively communicate "connecting to livekit cloud is the problem".