### PR TITLE
Always emit Disconnected on engine close

### DIFF
--- a/.changeset/always_emit_disconnected_on_engine_close.md
+++ b/.changeset/always_emit_disconnected_on_engine_close.md
@@ -1,0 +1,6 @@
+---
+livekit: patch
+livekit-ffi: patch
+---
+
+Bugfix: Always emit Disconnected on engine close - #1096 (@MaxHeimbrock)

--- a/livekit/src/rtc_engine/mod.rs
+++ b/livekit/src/rtc_engine/mod.rs
@@ -664,8 +664,13 @@ impl EngineInner {
             session.close(reason).await;
             let _ = close_tx.send(());
             let _ = engine_task.await;
-            let _ = self.engine_tx.send(EngineEvent::Disconnected { reason });
         }
+
+        // Always emit Disconnected, even when the engine_task was already taken by a
+        // prior failed `try_restart_connection`. Without this, a reconnect cycle that
+        // exhausts all attempts leaves the room stuck in Reconnecting forever because
+        // the room's task never sees the event that drives `handle_disconnected`.
+        let _ = self.engine_tx.send(EngineEvent::Disconnected { reason });
     }
 
     /// When waiting for reconnection, it ensures we're always using the latest session.


### PR DESCRIPTION
## Summary

`RtcEngineInner::close` only emitted `EngineEvent::Disconnected` from inside the `if let Some(engine_task)` block. Each failed `try_restart_connection` calls `running_handle.engine_task.take()` and does not restore it on error, so after the reconnect loop exhausts all attempts and calls `close(UnknownReason)`, `engine_task` is already `None` and the disconnect event is never sent. The room task never runs `handle_disconnected`, the connection state stays at Reconnecting, and `RoomEvent::Disconnected` is never dispatched — consumers see the room appear permanently stuck in reconnect after a network outage.

## Repro
Use Unity SDK Meet sample and lock the screen. Android will remove network access to the app and it will try 10 reconnects, until it fails eventually. In browser I can observe the Android participant being removed.
Unlock Android phone again and without the fix, I did not receive a Room.OnDisconnected event, the state is still `Reconnecting` and not disconnected.

## Changes

Move the emit outside the if-let so the event always fires on close. Duplicates are absorbed by `update_connection_state` on the room side.
