### PR TITLE
FFI logging improvements

### DIFF
--- a/.changeset/ffi_logging_improvements.md
+++ b/.changeset/ffi_logging_improvements.md
@@ -1,0 +1,5 @@
+---
+livekit-ffi: minor
+---
+
+# FFI logging improvements

--- a/livekit-ffi/src/cabi.rs
+++ b/livekit-ffi/src/cabi.rs
@@ -47,7 +47,7 @@ pub unsafe extern "C" fn livekit_ffi_initialize(
         sdk_version: CStr::from_ptr(sdk_version).to_string_lossy().into_owned(),
     });
 
-    log::info!("initializing ffi server v{}", env!("CARGO_PKG_VERSION"));
+    log::debug!("initializing ffi server v{}", env!("CARGO_PKG_VERSION"));
 }
 
 /// # Safety

--- a/livekit-ffi/src/server/mod.rs
+++ b/livekit-ffi/src/server/mod.rs
@@ -151,7 +151,7 @@ impl FfiServer {
         *self.config.lock() = Some(config.clone());
         self.logger.set_capture_logs(config.capture_logs);
 
-        log::info!("initializing ffi server v{}", env!("CARGO_PKG_VERSION")); // TODO: Move this log
+        log::debug!("initializing ffi server v{}", env!("CARGO_PKG_VERSION")); // TODO: Move this log
     }
 
     /// Returns whether the server has been setup.
@@ -161,7 +161,7 @@ impl FfiServer {
 
     pub async fn dispose(&'static self) {
         self.logger.set_capture_logs(false);
-        log::info!("disposing ffi server");
+        log::debug!("disposing ffi server");
 
         // Close all rooms
         let mut rooms = Vec::new();

--- a/livekit-ffi/src/server/mod.rs
+++ b/livekit-ffi/src/server/mod.rs
@@ -255,6 +255,9 @@ impl FfiServer {
     pub fn drop_handle(&self, id: FfiHandleId) -> bool {
         let existed = self.ffi_handles.remove(&id).is_some();
         self.handle_dropped_txs.remove(&id);
+        if !existed {
+            log::warn!("Attempted to drop unknown FFI handle: {id}");
+        }
         return existed;
     }
 

--- a/livekit-ffi/src/server/mod.rs
+++ b/livekit-ffi/src/server/mod.rs
@@ -160,7 +160,6 @@ impl FfiServer {
     }
 
     pub async fn dispose(&'static self) {
-        self.logger.set_capture_logs(false);
         log::debug!("disposing ffi server");
 
         // Close all rooms
@@ -174,6 +173,8 @@ impl FfiServer {
         for room in rooms {
             room.close(self, DisconnectReason::ClientInitiated).await;
         }
+
+        self.logger.set_capture_logs(false);
 
         // Drop all handles
         *self.config.lock() = None; // Invalidate the config


### PR DESCRIPTION
Summary of changes:
- Make some logs debug level
- Log warning when attempting to drop an unknown handle
- Disable capture logs after teardown completes