### PR TITLE
fix Android PlatformAudio

### DIFF
--- a/.changeset/android_platform_audio_context_init.md
+++ b/.changeset/android_platform_audio_context_init.md
@@ -1,0 +1,19 @@
+---
+livekit-ffi: minor
+livekit: patch
+libwebrtc: patch
+webrtc-sys: patch
+---
+
+feat: add Android application context initialization for PlatformAudio support.
+
+Android requires `ContextUtils.initialize(applicationContext)` before WebRTC audio components can be created. This change:
+
+- Adds `livekit_ffi_initialize_android_context()` C FFI function for Unity and other FFI consumers
+- Uses `CreateAndroidAudioDeviceModule()` instead of generic `CreateAudioDeviceModule()` on Android
+- Handles empty device GUIDs on Android (falls back to index 0)
+- Documents Android-specific limitations: single default device, no app-level device selection
+
+Platform notes:
+- Android device enumeration returns only one "default" device with empty name/GUID
+- Audio routing (speaker/earpiece/Bluetooth) is controlled by Android's AudioManager, not WebRTC

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -441,6 +441,8 @@ pub mod android {
         );
 
         log::info!("JNI_OnLoad, initializing LiveKit");
+        // Early JVM init for video/data. PlatformAudio requires additional context init
+        // via initializeContextNative() - see Java_io_livekit_rustexample_App_initializeContextNative.
         livekit::webrtc::android::initialize_android(&vm);
         JNI_VERSION_1_6
     }
@@ -448,6 +450,9 @@ pub mod android {
     /// Initialize the Android application context for WebRTC audio (PlatformAudio).
     /// This should be called from Application.onCreate() or Activity.onCreate()
     /// with the application context.
+    ///
+    /// This function handles both JVM and context initialization, so it's safe to call
+    /// even if JNI_OnLoad already ran (idempotent).
     ///
     /// Note: This is only required if you want to use PlatformAudio (microphone/speaker
     /// via WebRTC ADM). If you only use NativeAudioSource (custom audio buffers),

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -423,12 +423,15 @@ pub mod ios {
 pub mod android {
     use android_logger::Config;
     use jni::{
-        objects::{JClass, JShortArray, JString},
+        objects::{JClass, JObject, JShortArray, JString},
         sys::{jboolean, jint, JNI_VERSION_1_6},
         JNIEnv, JavaVM,
     };
     use log::LevelFilter;
     use std::os::raw::c_void;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    static CONTEXT_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
     #[allow(non_snake_case)]
     #[no_mangle]
@@ -440,6 +443,46 @@ pub mod android {
         log::info!("JNI_OnLoad, initializing LiveKit");
         livekit::webrtc::android::initialize_android(&vm);
         JNI_VERSION_1_6
+    }
+
+    /// Initialize the Android application context for WebRTC audio (PlatformAudio).
+    /// This should be called from Application.onCreate() or Activity.onCreate()
+    /// with the application context.
+    ///
+    /// Note: This is only required if you want to use PlatformAudio (microphone/speaker
+    /// via WebRTC ADM). If you only use NativeAudioSource (custom audio buffers),
+    /// this is not needed.
+    #[allow(non_snake_case)]
+    #[no_mangle]
+    pub extern "C" fn Java_io_livekit_rustexample_App_initializeContextNative(
+        env: JNIEnv,
+        _: JClass,
+        context: JObject,
+    ) -> jboolean {
+        // Only initialize once
+        if CONTEXT_INITIALIZED.swap(true, Ordering::SeqCst) {
+            log::info!("Android context already initialized");
+            return 1; // true
+        }
+
+        let vm = match env.get_java_vm() {
+            Ok(vm) => vm,
+            Err(e) => {
+                log::error!("Failed to get JavaVM: {:?}", e);
+                CONTEXT_INITIALIZED.store(false, Ordering::SeqCst);
+                return 0;
+            }
+        };
+
+        let result = livekit::webrtc::android::initialize_android_context(&vm, &context);
+        if result {
+            log::info!("Android context initialized successfully");
+            1
+        } else {
+            log::error!("Failed to initialize Android context");
+            CONTEXT_INITIALIZED.store(false, Ordering::SeqCst);
+            0
+        }
     }
 
     /// Connect to a LiveKit room

--- a/libwebrtc/src/native/android.rs
+++ b/libwebrtc/src/native/android.rs
@@ -12,10 +12,43 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use jni::objects::JObject;
 use webrtc_sys::android::ffi as sys_android;
 
+/// Initialize Android WebRTC with the JVM.
+/// This must be called before any WebRTC operations on Android.
 pub fn initialize_android(vm: &jni::JavaVM) {
     unsafe {
         sys_android::init_android(vm.get_java_vm_pointer() as *mut _);
+    }
+}
+
+/// Initialize the Android application context for WebRTC audio.
+/// This must be called before using PlatformAudio on Android.
+///
+/// # Arguments
+/// * `vm` - The JavaVM instance
+/// * `context` - The Android application context
+///
+/// # Returns
+/// true if initialization was successful, false otherwise
+///
+/// # Example
+/// ```ignore
+/// use jni::JavaVM;
+/// use livekit::webrtc::android::{initialize_android, initialize_android_context};
+///
+/// // In JNI_OnLoad or similar:
+/// fn init(vm: JavaVM, context: JObject) {
+///     initialize_android(&vm);
+///     initialize_android_context(&vm, &context);
+/// }
+/// ```
+pub fn initialize_android_context(vm: &jni::JavaVM, context: &JObject) -> bool {
+    unsafe {
+        sys_android::init_android_context(
+            vm.get_java_vm_pointer() as *mut _,
+            context.as_raw() as usize,
+        )
     }
 }

--- a/libwebrtc/src/native/android.rs
+++ b/libwebrtc/src/native/android.rs
@@ -16,31 +16,42 @@ use jni::objects::JObject;
 use webrtc_sys::android::ffi as sys_android;
 
 /// Initialize Android WebRTC with the JVM.
-/// This must be called before any WebRTC operations on Android.
+///
+/// This is automatically called by [`initialize_android_context`], so you only
+/// need to call this directly if you don't have access to an Android Context
+/// (e.g., in `JNI_OnLoad`).
+///
+/// This function is idempotent - safe to call multiple times.
 pub fn initialize_android(vm: &jni::JavaVM) {
     unsafe {
         sys_android::init_android(vm.get_java_vm_pointer() as *mut _);
     }
 }
 
-/// Initialize the Android application context for WebRTC audio.
-/// This must be called before using PlatformAudio on Android.
+/// Initialize Android WebRTC with the application context.
+///
+/// This is the main initialization function for Android. It performs both:
+/// 1. JVM initialization (same as [`initialize_android`])
+/// 2. Context initialization (required for PlatformAudio)
+///
+/// This function is idempotent - safe to call multiple times.
 ///
 /// # Arguments
 /// * `vm` - The JavaVM instance
 /// * `context` - The Android application context
 ///
 /// # Returns
-/// true if initialization was successful, false otherwise
+/// `true` if context initialization succeeded, `false` otherwise.
+/// Note: JVM initialization always happens regardless of return value.
 ///
 /// # Example
 /// ```ignore
 /// use jni::JavaVM;
-/// use livekit::webrtc::android::{initialize_android, initialize_android_context};
+/// use jni::objects::JObject;
+/// use livekit::webrtc::android::initialize_android_context;
 ///
-/// // In JNI_OnLoad or similar:
 /// fn init(vm: JavaVM, context: JObject) {
-///     initialize_android(&vm);
+///     // Just one call needed - handles both JVM and context init
 ///     initialize_android_context(&vm, &context);
 /// }
 /// ```

--- a/livekit-ffi-node-bindings/proto/audio_frame_pb.d.ts
+++ b/livekit-ffi-node-bindings/proto/audio_frame_pb.d.ts
@@ -1837,6 +1837,12 @@ export declare class NewPlatformAudioResponse extends Message<NewPlatformAudioRe
  *
  * Returns lists of available recording (microphone) and playout (speaker) devices.
  *
+ * # Platform Notes
+ *
+ * - Desktop (Windows/macOS/Linux): Returns all available devices with names and GUIDs.
+ * - Mobile (iOS/Android): Returns only one "default" device with empty name and GUID.
+ *   Device enumeration is not meaningful on mobile - use for device count only.
+ *
  * @generated from message livekit.proto.GetAudioDevicesRequest
  */
 export declare class GetAudioDevicesRequest extends Message<GetAudioDevicesRequest> {
@@ -1908,6 +1914,12 @@ export declare class GetAudioDevicesResponse extends Message<GetAudioDevicesResp
  * Call this before creating audio tracks to select which microphone to use.
  * Use the GUID from AudioDeviceInfo for stable device selection across hot-plug events.
  *
+ * # Platform Notes
+ *
+ * - Desktop: Works as expected - selects from enumerated devices.
+ * - Mobile (iOS/Android): No-op. Mobile platforms handle microphone selection at the
+ *   system level. This will succeed but has no effect. Skip calling on mobile.
+ *
  * @generated from message livekit.proto.SetRecordingDeviceRequest
  */
 export declare class SetRecordingDeviceRequest extends Message<SetRecordingDeviceRequest> {
@@ -1945,10 +1957,8 @@ export declare class SetRecordingDeviceRequest extends Message<SetRecordingDevic
  */
 export declare class SetRecordingDeviceResponse extends Message<SetRecordingDeviceResponse> {
   /**
-   * Error message if the operation failed:
-   * - "Device not found" if GUID doesn't match any device
-   * - Other platform-specific errors
-   * Empty/absent on success.
+   * Error message if the operation failed.
+   * Empty/absent on success (including no-op success on mobile).
    *
    * @generated from field: optional string error = 1;
    */
@@ -1974,6 +1984,14 @@ export declare class SetRecordingDeviceResponse extends Message<SetRecordingDevi
  *
  * Call this before connecting to select which speaker to use for audio output.
  * Use the GUID from AudioDeviceInfo for stable device selection across hot-plug events.
+ *
+ * # Platform Notes
+ *
+ * - Desktop: Works as expected - selects from enumerated devices.
+ * - Mobile (iOS/Android): No-op. Mobile platforms handle audio routing at the system level.
+ *   This will succeed but has no effect. For audio routing on mobile:
+ *   - iOS: Use AVAudioSession to control speaker/earpiece/Bluetooth routing
+ *   - Android: Use AudioManager.setSpeakerphoneOn() to switch outputs
  *
  * @generated from message livekit.proto.SetPlayoutDeviceRequest
  */
@@ -2012,10 +2030,8 @@ export declare class SetPlayoutDeviceRequest extends Message<SetPlayoutDeviceReq
  */
 export declare class SetPlayoutDeviceResponse extends Message<SetPlayoutDeviceResponse> {
   /**
-   * Error message if the operation failed:
-   * - "Device not found" if GUID doesn't match any device
-   * - Other platform-specific errors
-   * Empty/absent on success.
+   * Error message if the operation failed.
+   * Empty/absent on success (including no-op success on mobile).
    *
    * @generated from field: optional string error = 1;
    */

--- a/livekit-ffi-node-bindings/proto/audio_frame_pb.js
+++ b/livekit-ffi-node-bindings/proto/audio_frame_pb.js
@@ -688,6 +688,12 @@ const NewPlatformAudioResponse = /*@__PURE__*/ proto2.makeMessageType(
  *
  * Returns lists of available recording (microphone) and playout (speaker) devices.
  *
+ * # Platform Notes
+ *
+ * - Desktop (Windows/macOS/Linux): Returns all available devices with names and GUIDs.
+ * - Mobile (iOS/Android): Returns only one "default" device with empty name and GUID.
+ *   Device enumeration is not meaningful on mobile - use for device count only.
+ *
  * @generated from message livekit.proto.GetAudioDevicesRequest
  */
 const GetAudioDevicesRequest = /*@__PURE__*/ proto2.makeMessageType(
@@ -715,6 +721,12 @@ const GetAudioDevicesResponse = /*@__PURE__*/ proto2.makeMessageType(
  * Call this before creating audio tracks to select which microphone to use.
  * Use the GUID from AudioDeviceInfo for stable device selection across hot-plug events.
  *
+ * # Platform Notes
+ *
+ * - Desktop: Works as expected - selects from enumerated devices.
+ * - Mobile (iOS/Android): No-op. Mobile platforms handle microphone selection at the
+ *   system level. This will succeed but has no effect. Skip calling on mobile.
+ *
  * @generated from message livekit.proto.SetRecordingDeviceRequest
  */
 const SetRecordingDeviceRequest = /*@__PURE__*/ proto2.makeMessageType(
@@ -740,6 +752,14 @@ const SetRecordingDeviceResponse = /*@__PURE__*/ proto2.makeMessageType(
  *
  * Call this before connecting to select which speaker to use for audio output.
  * Use the GUID from AudioDeviceInfo for stable device selection across hot-plug events.
+ *
+ * # Platform Notes
+ *
+ * - Desktop: Works as expected - selects from enumerated devices.
+ * - Mobile (iOS/Android): No-op. Mobile platforms handle audio routing at the system level.
+ *   This will succeed but has no effect. For audio routing on mobile:
+ *   - iOS: Use AVAudioSession to control speaker/earpiece/Bluetooth routing
+ *   - Android: Use AudioManager.setSpeakerphoneOn() to switch outputs
  *
  * @generated from message livekit.proto.SetPlayoutDeviceRequest
  */

--- a/livekit-ffi/protocol/audio_frame.proto
+++ b/livekit-ffi/protocol/audio_frame.proto
@@ -426,6 +426,12 @@ message NewPlatformAudioResponse {
 // Get available audio devices.
 //
 // Returns lists of available recording (microphone) and playout (speaker) devices.
+//
+// # Platform Notes
+//
+// - Desktop (Windows/macOS/Linux): Returns all available devices with names and GUIDs.
+// - Mobile (iOS/Android): Returns only one "default" device with empty name and GUID.
+//   Device enumeration is not meaningful on mobile - use for device count only.
 message GetAudioDevicesRequest {
   // The PlatformAudio handle.
   required uint64 platform_audio_handle = 1;
@@ -444,6 +450,12 @@ message GetAudioDevicesResponse {
 //
 // Call this before creating audio tracks to select which microphone to use.
 // Use the GUID from AudioDeviceInfo for stable device selection across hot-plug events.
+//
+// # Platform Notes
+//
+// - Desktop: Works as expected - selects from enumerated devices.
+// - Mobile (iOS/Android): No-op. Mobile platforms handle microphone selection at the
+//   system level. This will succeed but has no effect. Skip calling on mobile.
 message SetRecordingDeviceRequest {
   // The PlatformAudio handle.
   required uint64 platform_audio_handle = 1;
@@ -452,10 +464,8 @@ message SetRecordingDeviceRequest {
 }
 
 message SetRecordingDeviceResponse {
-  // Error message if the operation failed:
-  // - "Device not found" if GUID doesn't match any device
-  // - Other platform-specific errors
-  // Empty/absent on success.
+  // Error message if the operation failed.
+  // Empty/absent on success (including no-op success on mobile).
   optional string error = 1;
 }
 
@@ -463,6 +473,14 @@ message SetRecordingDeviceResponse {
 //
 // Call this before connecting to select which speaker to use for audio output.
 // Use the GUID from AudioDeviceInfo for stable device selection across hot-plug events.
+//
+// # Platform Notes
+//
+// - Desktop: Works as expected - selects from enumerated devices.
+// - Mobile (iOS/Android): No-op. Mobile platforms handle audio routing at the system level.
+//   This will succeed but has no effect. For audio routing on mobile:
+//   - iOS: Use AVAudioSession to control speaker/earpiece/Bluetooth routing
+//   - Android: Use AudioManager.setSpeakerphoneOn() to switch outputs
 message SetPlayoutDeviceRequest {
   // The PlatformAudio handle.
   required uint64 platform_audio_handle = 1;
@@ -471,10 +489,8 @@ message SetPlayoutDeviceRequest {
 }
 
 message SetPlayoutDeviceResponse {
-  // Error message if the operation failed:
-  // - "Device not found" if GUID doesn't match any device
-  // - Other platform-specific errors
-  // Empty/absent on success.
+  // Error message if the operation failed.
+  // Empty/absent on success (including no-op success on mobile).
   optional string error = 1;
 }
 

--- a/livekit-ffi/src/cabi.rs
+++ b/livekit-ffi/src/cabi.rs
@@ -116,99 +116,32 @@ pub extern "C" fn livekit_ffi_dispose() {
 #[cfg(target_os = "android")]
 pub mod android {
     use jni::{
-        objects::{JObject, JValue},
+        objects::JObject,
         sys::{jint, jobject, JNI_VERSION_1_6},
         JavaVM,
     };
     use std::os::raw::c_void;
     use std::sync::atomic::{AtomicBool, Ordering};
 
-    /// Track whether Android WebRTC has been initialized to prevent double-initialization.
-    /// WebRTC's InitAndroid() will crash if called twice (g_jvm check fails).
-    static ANDROID_INITIALIZED: AtomicBool = AtomicBool::new(false);
+    /// Track whether device_info has been initialized.
+    /// WebRTC init is handled by C++ with its own idempotency.
+    static DEVICE_INFO_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
-    /// Track whether ContextUtils has been initialized.
-    static CONTEXT_INITIALIZED: AtomicBool = AtomicBool::new(false);
-
-    /// Internal function to initialize Android WebRTC. Returns true if initialization
-    /// was performed, false if already initialized.
-    fn do_android_init(vm: &JavaVM) -> bool {
-        // Use compare_exchange to ensure only one thread can initialize
-        if ANDROID_INITIALIZED
+    /// Initialize device_info with the JVM. Called once.
+    fn init_device_info(vm: &JavaVM) {
+        if DEVICE_INFO_INITIALIZED
             .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
             .is_ok()
         {
-            livekit::webrtc::android::initialize_android(vm);
             device_info::android::init_vm(vm);
-            true
-        } else {
-            false
-        }
-    }
-
-    /// Initialize WebRTC ContextUtils with the Android application context.
-    /// This is required for Android audio (microphone/speaker) to work.
-    ///
-    /// # Arguments
-    /// * `vm` - The JavaVM instance
-    /// * `context` - The Android application context (must be a global reference or
-    ///               guaranteed to be valid for the duration of the call)
-    ///
-    /// # Returns
-    /// true if initialization was successful, false otherwise
-    fn do_context_init(vm: &JavaVM, context: JObject) -> bool {
-        // Only initialize once
-        if CONTEXT_INITIALIZED
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .is_err()
-        {
-            return true; // Already initialized
-        }
-
-        let mut env = match vm.attach_current_thread() {
-            Ok(env) => env,
-            Err(e) => {
-                log::error!("Failed to attach thread to JVM: {:?}", e);
-                CONTEXT_INITIALIZED.store(false, Ordering::SeqCst);
-                return false;
-            }
-        };
-
-        // Call livekit.org.webrtc.ContextUtils.initialize(context)
-        // The class is prefixed with "livekit" because WebRTC JNI is built with
-        // android_package_prefix="livekit" to avoid conflicts with other WebRTC builds.
-        let class_name = "livekit/org/webrtc/ContextUtils";
-        let class = match env.find_class(class_name) {
-            Ok(c) => c,
-            Err(e) => {
-                log::error!("Failed to find class {}: {:?}", class_name, e);
-                CONTEXT_INITIALIZED.store(false, Ordering::SeqCst);
-                return false;
-            }
-        };
-
-        match env.call_static_method(
-            class,
-            "initialize",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&context)],
-        ) {
-            Ok(_) => {
-                log::info!("Android WebRTC ContextUtils initialized successfully");
-                true
-            }
-            Err(e) => {
-                log::error!("Failed to call ContextUtils.initialize: {:?}", e);
-                CONTEXT_INITIALIZED.store(false, Ordering::SeqCst);
-                false
-            }
         }
     }
 
     #[allow(non_snake_case)]
     #[no_mangle]
     pub extern "C" fn JNI_OnLoad(vm: JavaVM, _: *mut c_void) -> jint {
-        do_android_init(&vm);
+        livekit::webrtc::android::initialize_android(&vm);
+        init_device_info(&vm);
         JNI_VERSION_1_6
     }
 
@@ -225,9 +158,10 @@ pub mod android {
     /// Initialize Android WebRTC with the application context.
     /// This is required for Android audio (microphone/speaker) to work.
     ///
-    /// This function performs two initializations:
-    /// 1. JVM initialization (WebRTC's InitAndroid)
-    /// 2. ContextUtils initialization with the application context
+    /// This function performs:
+    /// 1. JVM initialization (WebRTC's InitAndroid) - idempotent
+    /// 2. ContextUtils initialization with the application context - idempotent
+    /// 3. device_info initialization - idempotent
     ///
     /// # Safety
     /// * `vm_ptr` must be a valid pointer to a JavaVM
@@ -259,12 +193,12 @@ pub mod android {
             }
         };
 
-        // Initialize the JVM first
-        do_android_init(&vm);
+        // Initialize device_info (Rust-only, separate from WebRTC)
+        init_device_info(&vm);
 
-        // Initialize ContextUtils with the application context
+        // Initialize WebRTC JVM + ContextUtils (handled by C++ layer, idempotent)
         // Safety: context_ptr is guaranteed to be valid by the caller
         let context = JObject::from_raw(context_ptr);
-        do_context_init(&vm, context)
+        livekit::webrtc::android::initialize_android_context(&vm, &context)
     }
 }

--- a/livekit-ffi/src/cabi.rs
+++ b/livekit-ffi/src/cabi.rs
@@ -116,17 +116,155 @@ pub extern "C" fn livekit_ffi_dispose() {
 #[cfg(target_os = "android")]
 pub mod android {
     use jni::{
-        sys::{jint, JNI_VERSION_1_6},
+        objects::{JObject, JValue},
+        sys::{jint, jobject, JNI_VERSION_1_6},
         JavaVM,
     };
     use std::os::raw::c_void;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// Track whether Android WebRTC has been initialized to prevent double-initialization.
+    /// WebRTC's InitAndroid() will crash if called twice (g_jvm check fails).
+    static ANDROID_INITIALIZED: AtomicBool = AtomicBool::new(false);
+
+    /// Track whether ContextUtils has been initialized.
+    static CONTEXT_INITIALIZED: AtomicBool = AtomicBool::new(false);
+
+    /// Internal function to initialize Android WebRTC. Returns true if initialization
+    /// was performed, false if already initialized.
+    fn do_android_init(vm: &JavaVM) -> bool {
+        // Use compare_exchange to ensure only one thread can initialize
+        if ANDROID_INITIALIZED
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            livekit::webrtc::android::initialize_android(vm);
+            device_info::android::init_vm(vm);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Initialize WebRTC ContextUtils with the Android application context.
+    /// This is required for Android audio (microphone/speaker) to work.
+    ///
+    /// # Arguments
+    /// * `vm` - The JavaVM instance
+    /// * `context` - The Android application context (must be a global reference or
+    ///               guaranteed to be valid for the duration of the call)
+    ///
+    /// # Returns
+    /// true if initialization was successful, false otherwise
+    fn do_context_init(vm: &JavaVM, context: JObject) -> bool {
+        // Only initialize once
+        if CONTEXT_INITIALIZED
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return true; // Already initialized
+        }
+
+        let mut env = match vm.attach_current_thread() {
+            Ok(env) => env,
+            Err(e) => {
+                log::error!("Failed to attach thread to JVM: {:?}", e);
+                CONTEXT_INITIALIZED.store(false, Ordering::SeqCst);
+                return false;
+            }
+        };
+
+        // Call livekit.org.webrtc.ContextUtils.initialize(context)
+        // The class is prefixed with "livekit" because WebRTC JNI is built with
+        // android_package_prefix="livekit" to avoid conflicts with other WebRTC builds.
+        let class_name = "livekit/org/webrtc/ContextUtils";
+        let class = match env.find_class(class_name) {
+            Ok(c) => c,
+            Err(e) => {
+                log::error!("Failed to find class {}: {:?}", class_name, e);
+                CONTEXT_INITIALIZED.store(false, Ordering::SeqCst);
+                return false;
+            }
+        };
+
+        match env.call_static_method(
+            class,
+            "initialize",
+            "(Landroid/content/Context;)V",
+            &[JValue::Object(&context)],
+        ) {
+            Ok(_) => {
+                log::info!("Android WebRTC ContextUtils initialized successfully");
+                true
+            }
+            Err(e) => {
+                log::error!("Failed to call ContextUtils.initialize: {:?}", e);
+                CONTEXT_INITIALIZED.store(false, Ordering::SeqCst);
+                false
+            }
+        }
+    }
 
     #[allow(non_snake_case)]
     #[no_mangle]
     pub extern "C" fn JNI_OnLoad(vm: JavaVM, _: *mut c_void) -> jint {
-        println!("JNI_OnLoad, initializing LiveKit");
-        livekit::webrtc::android::initialize_android(&vm);
-        device_info::android::init_vm(&vm);
+        do_android_init(&vm);
         JNI_VERSION_1_6
+    }
+
+    // TODO(CLT-xxxx): Add JNI entry point for C++/Python SDKs when they support Android.
+    // This would allow Java/Kotlin code to call:
+    //   System.loadLibrary("livekit_ffi");
+    //   LiveKitFfi.initializeContext(getApplicationContext());
+    //
+    // The native method would be:
+    //   #[allow(non_snake_case)]
+    //   #[no_mangle]
+    //   pub extern "C" fn Java_livekit_ffi_LiveKitFfi_initializeContext(...)
+
+    /// Initialize Android WebRTC with the application context.
+    /// This is required for Android audio (microphone/speaker) to work.
+    ///
+    /// This function performs two initializations:
+    /// 1. JVM initialization (WebRTC's InitAndroid)
+    /// 2. ContextUtils initialization with the application context
+    ///
+    /// # Safety
+    /// * `vm_ptr` must be a valid pointer to a JavaVM
+    /// * `context_ptr` must be a valid jobject pointing to an Android Context
+    ///
+    /// # Arguments
+    /// * `vm_ptr` - Pointer to the JavaVM
+    /// * `context_ptr` - The Android application context (jobject)
+    ///
+    /// # Returns
+    /// true if context initialization was successful, false otherwise.
+    /// Note: JVM initialization always happens regardless of return value.
+    #[no_mangle]
+    pub unsafe extern "C" fn livekit_ffi_initialize_android_context(
+        vm_ptr: *mut c_void,
+        context_ptr: jobject,
+    ) -> bool {
+        if vm_ptr.is_null() || context_ptr.is_null() {
+            log::error!("livekit_ffi_initialize_android_context: null pointer provided");
+            return false;
+        }
+
+        // Safety: vm_ptr must be a valid JavaVM pointer
+        let vm = match JavaVM::from_raw(vm_ptr as *mut _) {
+            Ok(vm) => vm,
+            Err(e) => {
+                log::error!("Failed to get JavaVM from pointer: {:?}", e);
+                return false;
+            }
+        };
+
+        // Initialize the JVM first
+        do_android_init(&vm);
+
+        // Initialize ContextUtils with the application context
+        // Safety: context_ptr is guaranteed to be valid by the caller
+        let context = JObject::from_raw(context_ptr);
+        do_context_init(&vm, context)
     }
 }

--- a/livekit-ffi/src/server/platform_audio.rs
+++ b/livekit-ffi/src/server/platform_audio.rs
@@ -30,12 +30,22 @@ pub fn on_new_platform_audio(
     server: &'static FfiServer,
     _req: proto::NewPlatformAudioRequest,
 ) -> FfiResult<proto::NewPlatformAudioResponse> {
+    log::info!("[PLATFORM_AUDIO_FFI] on_new_platform_audio() called");
+
     match PlatformAudio::new() {
         Ok(audio) => {
             let handle_id = server.next_id();
+            let recording_count = audio.recording_devices().count() as i32;
+            let playout_count = audio.playout_devices().count() as i32;
+
+            log::info!(
+                "[PLATFORM_AUDIO_FFI] PlatformAudio created successfully: handle_id={}, recording_devices={}, playout_devices={}",
+                handle_id, recording_count, playout_count
+            );
+
             let info = proto::PlatformAudioInfo {
-                recording_device_count: audio.recording_devices().count() as i32,
-                playout_device_count: audio.playout_devices().count() as i32,
+                recording_device_count: recording_count,
+                playout_device_count: playout_count,
             };
 
             server.store_handle(handle_id, FfiPlatformAudio { audio });
@@ -49,9 +59,19 @@ pub fn on_new_platform_audio(
                 )),
             })
         }
-        Err(e) => Ok(proto::NewPlatformAudioResponse {
-            message: Some(proto::new_platform_audio_response::Message::Error(e.to_string())),
-        }),
+        Err(e) => {
+            log::error!(
+                "[PLATFORM_AUDIO_FFI] PlatformAudio::new() failed: {}. This typically means: \
+                (1) Android JNI not initialized (init_android not called), \
+                (2) RECORD_AUDIO permission not granted, \
+                (3) No audio devices available, or \
+                (4) Another app has exclusive audio focus.",
+                e
+            );
+            Ok(proto::NewPlatformAudioResponse {
+                message: Some(proto::new_platform_audio_response::Message::Error(e.to_string())),
+            })
+        }
     }
 }
 

--- a/livekit/src/platform_audio/mod.rs
+++ b/livekit/src/platform_audio/mod.rs
@@ -648,33 +648,24 @@ impl PlatformAudio {
     ///
     /// **Desktop:** Works as expected - select from enumerated devices.
     ///
-    /// **Android:** Device selection has no effect. Android only reports one "default"
-    /// device, and the system controls microphone selection based on audio mode.
-    /// Calling this method on Android is a no-op (will succeed but does nothing).
+    /// **Mobile (iOS/Android):** Device selection is a no-op. Both platforms handle
+    /// microphone selection at the system level. This method will succeed but has no effect.
+    /// - iOS: VPIO AudioUnit handles input selection
+    /// - Android: System selects best input source based on audio mode
     ///
     /// # Arguments
     ///
     /// * `id` - Device identifier from [`RecordingDeviceInfo::id`]
-    ///
-    /// # Errors
-    ///
-    /// - [`AudioError::DeviceNotFound`] if the device is no longer available
     ///
     /// # Example
     ///
     /// ```rust,ignore
     /// let audio = PlatformAudio::new()?;
     ///
-    /// // Get the first microphone
+    /// // Get the first microphone (desktop only - on mobile this is a no-op)
     /// if let Some(device) = audio.recording_devices().next() {
     ///     audio.set_recording_device(&device.id)?;
     /// }
-    ///
-    /// // Or save the ID for later use
-    /// let devices: Vec<_> = audio.recording_devices().collect();
-    /// let preferred_id = devices[0].id.clone();
-    /// // ... later ...
-    /// audio.set_recording_device(&preferred_id)?;
     /// ```
     pub fn set_recording_device(&self, id: &RecordingDeviceId) -> AudioResult<()> {
         if self.handle.runtime.set_recording_device_by_guid(id.as_str()) {
@@ -693,26 +684,21 @@ impl PlatformAudio {
     ///
     /// **Desktop:** Works as expected - select from enumerated devices.
     ///
-    /// **Android:** Device selection has no effect. Android handles audio routing
-    /// (speaker, earpiece, Bluetooth) at the system level via `AudioManager`.
-    /// To switch outputs on Android, use the Android `AudioManager` API instead:
-    /// - `audioManager.setSpeakerphoneOn(true/false)`
-    /// - `audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION)`
+    /// **Mobile (iOS/Android):** Device selection is a no-op. Both platforms handle
+    /// audio routing at the system level. This method will succeed but has no effect.
+    /// - iOS: Use `AVAudioSession` to control routing (speaker, earpiece, Bluetooth)
+    /// - Android: Use `AudioManager.setSpeakerphoneOn()` to switch outputs
     ///
     /// # Arguments
     ///
     /// * `id` - Device identifier from [`PlayoutDeviceInfo::id`]
-    ///
-    /// # Errors
-    ///
-    /// - [`AudioError::DeviceNotFound`] if the device is no longer available
     ///
     /// # Example
     ///
     /// ```rust,ignore
     /// let audio = PlatformAudio::new()?;
     ///
-    /// // Get the first speaker
+    /// // Get the first speaker (desktop only - on mobile this is a no-op)
     /// if let Some(device) = audio.playout_devices().next() {
     ///     audio.set_playout_device(&device.id)?;
     /// }

--- a/livekit/src/platform_audio/mod.rs
+++ b/livekit/src/platform_audio/mod.rs
@@ -97,9 +97,15 @@
 //!
 //! - **iOS**: Creates a VPIO (Voice Processing IO) AudioUnit. Only one VPIO
 //!   can exist per process. Drop all `PlatformAudio` instances to release it.
-//! - **macOS**: Uses CoreAudio.
-//! - **Windows**: Uses WASAPI.
-//! - **Linux**: Uses PulseAudio or ALSA.
+//! - **macOS**: Uses CoreAudio. Full device enumeration and selection supported.
+//! - **Windows**: Uses WASAPI. Full device enumeration and selection supported.
+//! - **Linux**: Uses PulseAudio or ALSA. Full device enumeration and selection supported.
+//! - **Android**: Uses Java AudioRecord/AudioTrack via WebRTC's `JavaAudioDeviceModule`.
+//!   **Important:** Device enumeration and selection are NOT meaningful on Android.
+//!   Android only reports a single "default" device with no name or ID. Audio routing
+//!   (speaker, earpiece, Bluetooth, wired headset) is handled by the system via
+//!   `AudioManager`, not through WebRTC device selection. To switch outputs on Android,
+//!   use Android's `AudioManager.setSpeakerphoneOn()` API instead.
 //!
 //! [`NativeAudioSource`]: crate::webrtc::audio_source::native::NativeAudioSource
 
@@ -122,7 +128,14 @@ use std::sync::{Arc, Weak};
 /// Unique identifier for a recording (microphone) device.
 ///
 /// This is a type-safe wrapper around the platform-specific device GUID.
-/// Obtain this from [`AudioDeviceInfo`] returned by [`PlatformAudio::recording_devices()`].
+/// Obtain this from [`RecordingDeviceInfo`] returned by [`PlatformAudio::recording_devices()`].
+///
+/// # Platform Notes
+///
+/// - **Desktop (Windows, macOS, Linux):** Contains a unique GUID that persists across
+///   device hot-plug events. Use this for reliable device selection.
+/// - **Android:** Always empty. Android doesn't provide device GUIDs and only reports
+///   a single "default" device. Device selection on Android is not meaningful.
 ///
 /// # Example
 ///
@@ -130,7 +143,7 @@ use std::sync::{Arc, Weak};
 /// let audio = PlatformAudio::new()?;
 /// for device in audio.recording_devices() {
 ///     println!("{}: {}", device.name, device.id);
-///     // Save device.id for later use
+///     // Save device.id for later use (desktop only)
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -158,7 +171,15 @@ impl fmt::Display for RecordingDeviceId {
 /// Unique identifier for a playout (speaker) device.
 ///
 /// This is a type-safe wrapper around the platform-specific device GUID.
-/// Obtain this from [`AudioDeviceInfo`] returned by [`PlatformAudio::playout_devices()`].
+/// Obtain this from [`PlayoutDeviceInfo`] returned by [`PlatformAudio::playout_devices()`].
+///
+/// # Platform Notes
+///
+/// - **Desktop (Windows, macOS, Linux):** Contains a unique GUID that persists across
+///   device hot-plug events. Use this for reliable device selection.
+/// - **Android:** Always empty. Android doesn't provide device GUIDs and only reports
+///   a single "default" device. Audio routing (speaker, earpiece, Bluetooth) is handled
+///   by the system via `AudioManager`, not through WebRTC device selection.
 ///
 /// # Example
 ///
@@ -166,7 +187,7 @@ impl fmt::Display for RecordingDeviceId {
 /// let audio = PlatformAudio::new()?;
 /// for device in audio.playout_devices() {
 ///     println!("{}: {}", device.name, device.id);
-///     // Save device.id for later use
+///     // Save device.id for later use (desktop only)
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -191,11 +212,19 @@ impl fmt::Display for PlayoutDeviceId {
     }
 }
 
-/// Information about an audio device.
+/// Information about a recording (microphone) device.
 ///
 /// This struct contains the device's unique identifier, human-readable name,
 /// and index. Use the `id` field with [`PlatformAudio::set_recording_device()`]
-/// or [`PlatformAudio::set_playout_device()`] for type-safe device selection.
+/// for type-safe device selection.
+///
+/// # Platform Notes
+///
+/// - **Desktop (Windows, macOS, Linux):** Full device information is available.
+///   The `id` is a unique GUID, and `name` is a descriptive string (e.g., "MacBook Pro Microphone").
+/// - **Android:** Only a single device is reported with an empty `id` and `name`.
+///   Android does not support app-level microphone selection - the system automatically
+///   selects the best input source. This struct is not useful for device pickers on Android.
 ///
 /// # Example
 ///
@@ -207,9 +236,9 @@ impl fmt::Display for PlayoutDeviceId {
 /// ```
 #[derive(Debug, Clone)]
 pub struct RecordingDeviceInfo {
-    /// The unique identifier for this device (stable across hot-plug events).
+    /// The unique identifier for this device (stable across hot-plug events on desktop; empty on Android).
     pub id: RecordingDeviceId,
-    /// Human-readable device name.
+    /// Human-readable device name (empty on Android).
     pub name: String,
     /// Device index (may change when devices are added/removed).
     pub index: usize,
@@ -220,11 +249,29 @@ pub struct RecordingDeviceInfo {
 /// This struct contains the device's unique identifier, human-readable name,
 /// and index. Use the `id` field with [`PlatformAudio::set_playout_device()`]
 /// for type-safe device selection.
+///
+/// # Platform Notes
+///
+/// - **Desktop (Windows, macOS, Linux):** Full device information is available.
+///   The `id` is a unique GUID, and `name` is a descriptive string (e.g., "MacBook Pro Speakers").
+/// - **Android:** Only a single device is reported with an empty `id` and `name`.
+///   Audio routing (speaker, earpiece, Bluetooth, wired headset) is handled by the system
+///   via `AudioManager`, not through WebRTC. Use `AudioManager.setSpeakerphoneOn()` to
+///   switch between speaker and earpiece on Android.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let audio = PlatformAudio::new()?;
+/// for device in audio.playout_devices() {
+///     println!("[{}] {} (ID: {})", device.index, device.name, device.id);
+/// }
+/// ```
 #[derive(Debug, Clone)]
 pub struct PlayoutDeviceInfo {
-    /// The unique identifier for this device (stable across hot-plug events).
+    /// The unique identifier for this device (stable across hot-plug events on desktop; empty on Android).
     pub id: PlayoutDeviceId,
-    /// Human-readable device name.
+    /// Human-readable device name (empty on Android).
     pub name: String,
     /// Device index (may change when devices are added/removed).
     pub index: usize,
@@ -477,6 +524,20 @@ impl PlatformAudio {
     /// Each [`RecordingDeviceInfo`] contains the device's unique ID, name, and index.
     /// Use the `id` field with [`set_recording_device()`] for type-safe device selection.
     ///
+    /// # Platform Notes
+    ///
+    /// **Desktop (Windows, macOS, Linux):** Full device enumeration is supported.
+    /// You can enumerate USB microphones, built-in mics, audio interfaces, etc.
+    /// Each device has a unique ID (GUID) and descriptive name.
+    ///
+    /// **Android:** Only a single "default" device is reported with an empty name and ID.
+    /// Android does not support app-level microphone selection - the system automatically
+    /// selects the best input source based on the audio mode and connected accessories.
+    /// Device enumeration on Android is not meaningful for user-facing device pickers.
+    ///
+    /// **iOS:** Similar to desktop - devices can be enumerated, though typically only
+    /// the built-in microphone and any connected accessories are available.
+    ///
     /// # Example
     ///
     /// ```rust,ignore
@@ -499,6 +560,24 @@ impl PlatformAudio {
     ///
     /// Each [`PlayoutDeviceInfo`] contains the device's unique ID, name, and index.
     /// Use the `id` field with [`set_playout_device()`] for type-safe device selection.
+    ///
+    /// # Platform Notes
+    ///
+    /// **Desktop (Windows, macOS, Linux):** Full device enumeration is supported.
+    /// You can enumerate speakers, headphones, USB audio devices, HDMI outputs, etc.
+    /// Each device has a unique ID (GUID) and descriptive name.
+    ///
+    /// **Android:** Only a single "default" device is reported with an empty name and ID.
+    /// Android handles audio routing (speaker, earpiece, Bluetooth, wired headset) at the
+    /// system level via `AudioManager`, not through WebRTC device selection. To switch
+    /// between speaker and earpiece on Android, use the Android `AudioManager` API:
+    /// - `audioManager.setSpeakerphoneOn(true/false)`
+    /// - `audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION)`
+    ///
+    /// Device enumeration on Android is not meaningful for user-facing device pickers.
+    ///
+    /// **iOS:** Similar to desktop - devices can be enumerated and selected, including
+    /// built-in speaker, receiver, and connected Bluetooth/wired accessories.
     ///
     /// # Example
     ///
@@ -565,6 +644,14 @@ impl PlatformAudio {
     /// This is the preferred method for device selection as IDs are stable
     /// across device hot-plug events, unlike indices which can change.
     ///
+    /// # Platform Notes
+    ///
+    /// **Desktop:** Works as expected - select from enumerated devices.
+    ///
+    /// **Android:** Device selection has no effect. Android only reports one "default"
+    /// device, and the system controls microphone selection based on audio mode.
+    /// Calling this method on Android is a no-op (will succeed but does nothing).
+    ///
     /// # Arguments
     ///
     /// * `id` - Device identifier from [`RecordingDeviceInfo::id`]
@@ -601,6 +688,16 @@ impl PlatformAudio {
     ///
     /// This is the preferred method for device selection as IDs are stable
     /// across device hot-plug events, unlike indices which can change.
+    ///
+    /// # Platform Notes
+    ///
+    /// **Desktop:** Works as expected - select from enumerated devices.
+    ///
+    /// **Android:** Device selection has no effect. Android handles audio routing
+    /// (speaker, earpiece, Bluetooth) at the system level via `AudioManager`.
+    /// To switch outputs on Android, use the Android `AudioManager` API instead:
+    /// - `audioManager.setSpeakerphoneOn(true/false)`
+    /// - `audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION)`
     ///
     /// # Arguments
     ///

--- a/webrtc-sys/include/livekit/adm_proxy.h
+++ b/webrtc-sys/include/livekit/adm_proxy.h
@@ -227,6 +227,13 @@ class AdmProxy : public webrtc::AudioDeviceModule {
   // Must be called with mutex_ held.
   void SwitchRecordingAdmIfNeeded();
 
+#if defined(__ANDROID__)
+  // Lazily creates the Platform ADM on Android.
+  // Must be called with mutex_ held.
+  // Returns true if ADM is available after the call.
+  bool EnsurePlatformAdmCreated();
+#endif
+
   const webrtc::Environment env_;
   webrtc::Thread* worker_thread_;
 

--- a/webrtc-sys/include/livekit/android.h
+++ b/webrtc-sys/include/livekit/android.h
@@ -18,6 +18,7 @@
 
 #include <jni.h>
 
+#include <cstdint>
 #include <memory>
 
 #include "api/video_codecs/video_decoder_factory.h"
@@ -30,6 +31,14 @@ typedef JavaVM JavaVM;
 
 namespace livekit_ffi {
 void init_android(JavaVM* jvm);
+
+/// Initialize the Android application context for WebRTC audio.
+/// This must be called before using PlatformAudio on Android.
+///
+/// @param jvm The JavaVM pointer
+/// @param context The Android application context (jobject cast to uintptr_t)
+/// @return true if initialization was successful, false otherwise
+bool init_android_context(JavaVM* jvm, uintptr_t context);
 
 std::unique_ptr<webrtc::VideoEncoderFactory> CreateAndroidVideoEncoderFactory();
 std::unique_ptr<webrtc::VideoDecoderFactory> CreateAndroidVideoDecoderFactory();

--- a/webrtc-sys/include/livekit/android.h
+++ b/webrtc-sys/include/livekit/android.h
@@ -30,14 +30,24 @@ typedef JavaVM JavaVM;
 #include "webrtc-sys/src/android.rs.h"
 
 namespace livekit_ffi {
+
+/// Initialize Android WebRTC with the JVM.
+/// This is called automatically by init_android_context(), so you only need to
+/// call this directly in JNI_OnLoad or if you don't have an Android Context.
+/// This function is idempotent - safe to call multiple times.
+///
+/// @param jvm The JavaVM pointer
 void init_android(JavaVM* jvm);
 
-/// Initialize the Android application context for WebRTC audio.
-/// This must be called before using PlatformAudio on Android.
+/// Initialize Android WebRTC with the application context.
+/// This is the main initialization function - it calls init_android() internally
+/// and then initializes ContextUtils for PlatformAudio support.
+/// This function is idempotent - safe to call multiple times.
 ///
 /// @param jvm The JavaVM pointer
 /// @param context The Android application context (jobject cast to uintptr_t)
-/// @return true if initialization was successful, false otherwise
+/// @return true if context initialization was successful, false otherwise.
+///         Note: JVM init (init_android) always happens regardless of return value.
 bool init_android_context(JavaVM* jvm, uintptr_t context);
 
 std::unique_ptr<webrtc::VideoEncoderFactory> CreateAndroidVideoEncoderFactory();

--- a/webrtc-sys/src/adm_proxy.cpp
+++ b/webrtc-sys/src/adm_proxy.cpp
@@ -22,42 +22,106 @@
 #include "rtc_base/logging.h"
 #include "rtc_base/thread.h"
 
+#if defined(__ANDROID__)
+#include <android/log.h>
+#include <jni.h>
+#include "sdk/android/native_api/audio_device_module/audio_device_android.h"
+#include "sdk/android/native_api/base/init.h"
+#define LOGCAT_TAG "LIVEKIT_ADM"
+#define LOGCAT_INFO(...) __android_log_print(ANDROID_LOG_INFO, LOGCAT_TAG, __VA_ARGS__)
+#define LOGCAT_ERROR(...) __android_log_print(ANDROID_LOG_ERROR, LOGCAT_TAG, __VA_ARGS__)
+#else
+#define LOGCAT_INFO(...) do {} while(0)
+#define LOGCAT_ERROR(...) do {} while(0)
+#endif
+
 namespace livekit_ffi {
 
 AdmProxy::AdmProxy(const webrtc::Environment& env, webrtc::Thread* worker_thread)
     : env_(env),
       worker_thread_(worker_thread) {
-  RTC_LOG(LS_INFO) << "AdmProxy::AdmProxy() - Initializing";
+  LOGCAT_INFO("AdmProxy::AdmProxy() - Initializing on thread: %s",
+              worker_thread ? "provided" : "null");
+  RTC_LOG(LS_INFO) << "AdmProxy::AdmProxy() - Initializing on thread: "
+                   << (worker_thread ? "provided" : "null");
 
   // Create the synthetic ADM for synthetic mode. SyntheticAudioDevice pumps
   // the WebRTC audio pipeline without platform audio, allowing FFI callbacks
   // to receive decoded remote audio.
+  LOGCAT_INFO("AdmProxy: Creating synthetic ADM...");
+  RTC_LOG(LS_INFO) << "AdmProxy: Creating synthetic ADM...";
   synthetic_adm_ = webrtc::make_ref_counted<SyntheticAudioDevice>(env_);
   if (synthetic_adm_->Init() != 0) {
+    LOGCAT_ERROR("AdmProxy: Failed to initialize synthetic ADM");
     RTC_LOG(LS_ERROR) << "AdmProxy: Failed to initialize synthetic ADM";
   } else {
-    RTC_LOG(LS_INFO) << "AdmProxy: Synthetic ADM initialized";
+    LOGCAT_INFO("AdmProxy: Synthetic ADM initialized successfully");
+    RTC_LOG(LS_INFO) << "AdmProxy: Synthetic ADM initialized successfully";
   }
 
   // Create the Platform ADM for real audio I/O.
   // This is created immediately (not lazily) for iOS compatibility.
   // iOS audio session requires early setup to avoid KVO race conditions.
+  // On Android, we defer Platform ADM creation to AcquirePlatformAdm().
+  // This is because:
+  // 1. CreateAudioDeviceModule requires JNI to be fully initialized
+  // 2. The JNI initialization (via JNI_OnLoad or manual init) may not have
+  //    completed by the time the AdmProxy constructor runs
+  // 3. Deferring creation ensures JNI is ready when we actually need the ADM
+#if defined(__ANDROID__)
+  LOGCAT_INFO("AdmProxy: Deferring Platform ADM creation until first acquire (Android)");
+  RTC_LOG(LS_INFO) << "AdmProxy: Deferring Platform ADM creation until first acquire (Android)";
+  // platform_adm_ stays nullptr, will be created in EnsurePlatformAdmCreated()
+#else
+  LOGCAT_INFO("AdmProxy: Creating Platform ADM with kPlatformDefaultAudio...");
+  RTC_LOG(LS_INFO) << "AdmProxy: Creating Platform ADM with kPlatformDefaultAudio...";
   platform_adm_ = webrtc::CreateAudioDeviceModule(
       env_, webrtc::AudioDeviceModule::kPlatformDefaultAudio);
 
   if (!platform_adm_) {
-    RTC_LOG(LS_ERROR) << "AdmProxy: Failed to create Platform ADM";
+    LOGCAT_ERROR("AdmProxy: CreateAudioDeviceModule returned nullptr!");
+    RTC_LOG(LS_ERROR) << "AdmProxy: CreateAudioDeviceModule returned nullptr! "
+                      << "This usually means: (1) No audio devices available, "
+                      << "(2) Audio permissions not granted, or "
+                      << "(3) JNI/Android audio subsystem not initialized properly.";
   } else {
+    LOGCAT_INFO("AdmProxy: Platform ADM created, calling Init()...");
+    RTC_LOG(LS_INFO) << "AdmProxy: Platform ADM created, calling Init()...";
     int32_t init_result = platform_adm_->Init();
     if (init_result != 0) {
-      RTC_LOG(LS_ERROR) << "AdmProxy: Failed to initialize Platform ADM, error=" << init_result;
+      LOGCAT_ERROR("AdmProxy: Platform ADM Init() failed with error=%d", init_result);
+      RTC_LOG(LS_ERROR) << "AdmProxy: Platform ADM Init() failed with error=" << init_result
+                        << ". Common causes: (1) RECORD_AUDIO permission denied, "
+                        << "(2) Audio focus conflict, (3) Hardware audio initialization failed.";
       platform_adm_ = nullptr;
     } else {
-      RTC_LOG(LS_INFO) << "AdmProxy: Platform ADM initialized, "
-                       << platform_adm_->RecordingDevices() << " recording devices, "
-                       << platform_adm_->PlayoutDevices() << " playout devices";
+      LOGCAT_INFO("AdmProxy: Platform ADM initialized successfully!");
+      RTC_LOG(LS_INFO) << "AdmProxy: Platform ADM initialized successfully!";
+      int16_t rec_devices = platform_adm_->RecordingDevices();
+      int16_t play_devices = platform_adm_->PlayoutDevices();
+      LOGCAT_INFO("AdmProxy: Found %d recording devices, %d playout devices",
+                  rec_devices, play_devices);
+      RTC_LOG(LS_INFO) << "AdmProxy: Found " << rec_devices << " recording devices, "
+                       << play_devices << " playout devices";
+
+      // Log device names for debugging
+      char name[webrtc::kAdmMaxDeviceNameSize] = {0};
+      char guid[webrtc::kAdmMaxGuidSize] = {0};
+      for (int i = 0; i < rec_devices; i++) {
+        if (platform_adm_->RecordingDeviceName(i, name, guid) == 0) {
+          LOGCAT_INFO("AdmProxy: Recording device [%d]: %s", i, name);
+          RTC_LOG(LS_INFO) << "AdmProxy: Recording device [" << i << "]: " << name;
+        }
+      }
+      for (int i = 0; i < play_devices; i++) {
+        if (platform_adm_->PlayoutDeviceName(i, name, guid) == 0) {
+          LOGCAT_INFO("AdmProxy: Playout device [%d]: %s", i, name);
+          RTC_LOG(LS_INFO) << "AdmProxy: Playout device [" << i << "]: " << name;
+        }
+      }
     }
   }
+#endif
 }
 
 AdmProxy::~AdmProxy() {
@@ -97,16 +161,84 @@ webrtc::AudioDeviceModule* AdmProxy::recording_adm() const {
 // Platform ADM Lifecycle Management
 // =============================================================================
 
-bool AdmProxy::AcquirePlatformAdm() {
-  webrtc::MutexLock lock(&mutex_);
+#if defined(__ANDROID__)
+// Lazily creates the Platform ADM on Android. Must be called with mutex held.
+// Returns true if ADM is available (either already existed or successfully created).
+bool AdmProxy::EnsurePlatformAdmCreated() {
+  if (platform_adm_) {
+    return true;  // Already created
+  }
+
+  LOGCAT_INFO("AdmProxy: Lazily creating Platform ADM (Android)...");
+  RTC_LOG(LS_INFO) << "AdmProxy: Lazily creating Platform ADM (Android)...";
+
+  // Use CreateAndroidAudioDeviceModule which properly uses GetAppContext()
+  // to get the application context set via ContextUtils.initialize().
+  // This is the correct way to create an ADM on Android.
+  //
+  // The function automatically selects the best audio layer based on device capabilities:
+  // - AAudio (Android 8.1+) for low latency
+  // - OpenSL ES for devices that support it
+  // - Java audio for fallback
+  LOGCAT_INFO("AdmProxy: Calling CreateAndroidAudioDeviceModule with kPlatformDefaultAudio...");
+  platform_adm_ = webrtc::CreateAndroidAudioDeviceModule(
+      env_, webrtc::AudioDeviceModule::kPlatformDefaultAudio);
 
   if (!platform_adm_) {
-    RTC_LOG(LS_ERROR) << "AdmProxy::AcquirePlatformAdm() - Platform ADM not available";
+    LOGCAT_ERROR("AdmProxy: CreateAndroidAudioDeviceModule failed! "
+                 "Possible causes: (1) ContextUtils.initialize() not called, "
+                 "(2) JNI not initialized, (3) No audio devices available.");
+    RTC_LOG(LS_ERROR) << "AdmProxy: CreateAndroidAudioDeviceModule returned nullptr";
     return false;
   }
 
+  LOGCAT_INFO("AdmProxy: Platform ADM created, calling Init()...");
+  RTC_LOG(LS_INFO) << "AdmProxy: Platform ADM created, calling Init()...";
+
+  int32_t init_result = platform_adm_->Init();
+  if (init_result != 0) {
+    LOGCAT_ERROR("AdmProxy: Platform ADM Init() failed with error=%d", init_result);
+    RTC_LOG(LS_ERROR) << "AdmProxy: Platform ADM Init() failed with error=" << init_result;
+    platform_adm_ = nullptr;
+    return false;
+  }
+
+  LOGCAT_INFO("AdmProxy: Platform ADM initialized successfully!");
+  RTC_LOG(LS_INFO) << "AdmProxy: Platform ADM initialized successfully!";
+
+  int16_t rec_devices = platform_adm_->RecordingDevices();
+  int16_t play_devices = platform_adm_->PlayoutDevices();
+  LOGCAT_INFO("AdmProxy: Found %d recording devices, %d playout devices",
+              rec_devices, play_devices);
+  RTC_LOG(LS_INFO) << "AdmProxy: Found " << rec_devices << " recording devices, "
+                   << play_devices << " playout devices";
+
+  return true;
+}
+#endif
+
+bool AdmProxy::AcquirePlatformAdm() {
+  webrtc::MutexLock lock(&mutex_);
+
+#if defined(__ANDROID__)
+  // On Android, lazily create the Platform ADM on first acquire.
+  // This ensures JNI is fully initialized before we try to create the ADM.
+  if (!EnsurePlatformAdmCreated()) {
+    LOGCAT_ERROR("AdmProxy::AcquirePlatformAdm() - Failed to create Platform ADM");
+    RTC_LOG(LS_ERROR) << "AdmProxy::AcquirePlatformAdm() - Failed to create Platform ADM";
+    return false;
+  }
+#else
+  if (!platform_adm_) {
+    LOGCAT_ERROR("AdmProxy::AcquirePlatformAdm() - Platform ADM not available (nullptr)");
+    RTC_LOG(LS_ERROR) << "AdmProxy::AcquirePlatformAdm() - Platform ADM not available";
+    return false;
+  }
+#endif
+
   int old_ref_count = platform_adm_ref_count_;
   platform_adm_ref_count_++;
+  LOGCAT_INFO("AdmProxy::AcquirePlatformAdm() ref_count=%d", platform_adm_ref_count_);
   RTC_LOG(LS_INFO) << "AdmProxy::AcquirePlatformAdm() ref_count=" << platform_adm_ref_count_;
 
   // If this is the first acquisition and playout/recording is enabled,

--- a/webrtc-sys/src/adm_proxy.cpp
+++ b/webrtc-sys/src/adm_proxy.cpp
@@ -23,16 +23,9 @@
 #include "rtc_base/thread.h"
 
 #if defined(__ANDROID__)
-#include <android/log.h>
 #include <jni.h>
 #include "sdk/android/native_api/audio_device_module/audio_device_android.h"
 #include "sdk/android/native_api/base/init.h"
-#define LOGCAT_TAG "LIVEKIT_ADM"
-#define LOGCAT_INFO(...) __android_log_print(ANDROID_LOG_INFO, LOGCAT_TAG, __VA_ARGS__)
-#define LOGCAT_ERROR(...) __android_log_print(ANDROID_LOG_ERROR, LOGCAT_TAG, __VA_ARGS__)
-#else
-#define LOGCAT_INFO(...) do {} while(0)
-#define LOGCAT_ERROR(...) do {} while(0)
 #endif
 
 namespace livekit_ffi {
@@ -40,23 +33,12 @@ namespace livekit_ffi {
 AdmProxy::AdmProxy(const webrtc::Environment& env, webrtc::Thread* worker_thread)
     : env_(env),
       worker_thread_(worker_thread) {
-  LOGCAT_INFO("AdmProxy::AdmProxy() - Initializing on thread: %s",
-              worker_thread ? "provided" : "null");
-  RTC_LOG(LS_INFO) << "AdmProxy::AdmProxy() - Initializing on thread: "
-                   << (worker_thread ? "provided" : "null");
-
   // Create the synthetic ADM for synthetic mode. SyntheticAudioDevice pumps
   // the WebRTC audio pipeline without platform audio, allowing FFI callbacks
   // to receive decoded remote audio.
-  LOGCAT_INFO("AdmProxy: Creating synthetic ADM...");
-  RTC_LOG(LS_INFO) << "AdmProxy: Creating synthetic ADM...";
   synthetic_adm_ = webrtc::make_ref_counted<SyntheticAudioDevice>(env_);
   if (synthetic_adm_->Init() != 0) {
-    LOGCAT_ERROR("AdmProxy: Failed to initialize synthetic ADM");
     RTC_LOG(LS_ERROR) << "AdmProxy: Failed to initialize synthetic ADM";
-  } else {
-    LOGCAT_INFO("AdmProxy: Synthetic ADM initialized successfully");
-    RTC_LOG(LS_INFO) << "AdmProxy: Synthetic ADM initialized successfully";
   }
 
   // Create the Platform ADM for real audio I/O.
@@ -69,56 +51,18 @@ AdmProxy::AdmProxy(const webrtc::Environment& env, webrtc::Thread* worker_thread
   //    completed by the time the AdmProxy constructor runs
   // 3. Deferring creation ensures JNI is ready when we actually need the ADM
 #if defined(__ANDROID__)
-  LOGCAT_INFO("AdmProxy: Deferring Platform ADM creation until first acquire (Android)");
-  RTC_LOG(LS_INFO) << "AdmProxy: Deferring Platform ADM creation until first acquire (Android)";
   // platform_adm_ stays nullptr, will be created in EnsurePlatformAdmCreated()
 #else
-  LOGCAT_INFO("AdmProxy: Creating Platform ADM with kPlatformDefaultAudio...");
-  RTC_LOG(LS_INFO) << "AdmProxy: Creating Platform ADM with kPlatformDefaultAudio...";
   platform_adm_ = webrtc::CreateAudioDeviceModule(
       env_, webrtc::AudioDeviceModule::kPlatformDefaultAudio);
 
   if (!platform_adm_) {
-    LOGCAT_ERROR("AdmProxy: CreateAudioDeviceModule returned nullptr!");
-    RTC_LOG(LS_ERROR) << "AdmProxy: CreateAudioDeviceModule returned nullptr! "
-                      << "This usually means: (1) No audio devices available, "
-                      << "(2) Audio permissions not granted, or "
-                      << "(3) JNI/Android audio subsystem not initialized properly.";
+    RTC_LOG(LS_ERROR) << "AdmProxy: CreateAudioDeviceModule returned nullptr";
   } else {
-    LOGCAT_INFO("AdmProxy: Platform ADM created, calling Init()...");
-    RTC_LOG(LS_INFO) << "AdmProxy: Platform ADM created, calling Init()...";
     int32_t init_result = platform_adm_->Init();
     if (init_result != 0) {
-      LOGCAT_ERROR("AdmProxy: Platform ADM Init() failed with error=%d", init_result);
-      RTC_LOG(LS_ERROR) << "AdmProxy: Platform ADM Init() failed with error=" << init_result
-                        << ". Common causes: (1) RECORD_AUDIO permission denied, "
-                        << "(2) Audio focus conflict, (3) Hardware audio initialization failed.";
+      RTC_LOG(LS_ERROR) << "AdmProxy: Platform ADM Init() failed with error=" << init_result;
       platform_adm_ = nullptr;
-    } else {
-      LOGCAT_INFO("AdmProxy: Platform ADM initialized successfully!");
-      RTC_LOG(LS_INFO) << "AdmProxy: Platform ADM initialized successfully!";
-      int16_t rec_devices = platform_adm_->RecordingDevices();
-      int16_t play_devices = platform_adm_->PlayoutDevices();
-      LOGCAT_INFO("AdmProxy: Found %d recording devices, %d playout devices",
-                  rec_devices, play_devices);
-      RTC_LOG(LS_INFO) << "AdmProxy: Found " << rec_devices << " recording devices, "
-                       << play_devices << " playout devices";
-
-      // Log device names for debugging
-      char name[webrtc::kAdmMaxDeviceNameSize] = {0};
-      char guid[webrtc::kAdmMaxGuidSize] = {0};
-      for (int i = 0; i < rec_devices; i++) {
-        if (platform_adm_->RecordingDeviceName(i, name, guid) == 0) {
-          LOGCAT_INFO("AdmProxy: Recording device [%d]: %s", i, name);
-          RTC_LOG(LS_INFO) << "AdmProxy: Recording device [" << i << "]: " << name;
-        }
-      }
-      for (int i = 0; i < play_devices; i++) {
-        if (platform_adm_->PlayoutDeviceName(i, name, guid) == 0) {
-          LOGCAT_INFO("AdmProxy: Playout device [%d]: %s", i, name);
-          RTC_LOG(LS_INFO) << "AdmProxy: Playout device [" << i << "]: " << name;
-        }
-      }
     }
   }
 #endif
@@ -169,49 +113,23 @@ bool AdmProxy::EnsurePlatformAdmCreated() {
     return true;  // Already created
   }
 
-  LOGCAT_INFO("AdmProxy: Lazily creating Platform ADM (Android)...");
-  RTC_LOG(LS_INFO) << "AdmProxy: Lazily creating Platform ADM (Android)...";
-
   // Use CreateAndroidAudioDeviceModule which properly uses GetAppContext()
   // to get the application context set via ContextUtils.initialize().
-  // This is the correct way to create an ADM on Android.
-  //
-  // The function automatically selects the best audio layer based on device capabilities:
-  // - AAudio (Android 8.1+) for low latency
-  // - OpenSL ES for devices that support it
-  // - Java audio for fallback
-  LOGCAT_INFO("AdmProxy: Calling CreateAndroidAudioDeviceModule with kPlatformDefaultAudio...");
   platform_adm_ = webrtc::CreateAndroidAudioDeviceModule(
       env_, webrtc::AudioDeviceModule::kPlatformDefaultAudio);
 
   if (!platform_adm_) {
-    LOGCAT_ERROR("AdmProxy: CreateAndroidAudioDeviceModule failed! "
-                 "Possible causes: (1) ContextUtils.initialize() not called, "
-                 "(2) JNI not initialized, (3) No audio devices available.");
-    RTC_LOG(LS_ERROR) << "AdmProxy: CreateAndroidAudioDeviceModule returned nullptr";
+    RTC_LOG(LS_ERROR) << "AdmProxy: CreateAndroidAudioDeviceModule returned nullptr. "
+                      << "Ensure ContextUtils.initialize() was called.";
     return false;
   }
 
-  LOGCAT_INFO("AdmProxy: Platform ADM created, calling Init()...");
-  RTC_LOG(LS_INFO) << "AdmProxy: Platform ADM created, calling Init()...";
-
   int32_t init_result = platform_adm_->Init();
   if (init_result != 0) {
-    LOGCAT_ERROR("AdmProxy: Platform ADM Init() failed with error=%d", init_result);
     RTC_LOG(LS_ERROR) << "AdmProxy: Platform ADM Init() failed with error=" << init_result;
     platform_adm_ = nullptr;
     return false;
   }
-
-  LOGCAT_INFO("AdmProxy: Platform ADM initialized successfully!");
-  RTC_LOG(LS_INFO) << "AdmProxy: Platform ADM initialized successfully!";
-
-  int16_t rec_devices = platform_adm_->RecordingDevices();
-  int16_t play_devices = platform_adm_->PlayoutDevices();
-  LOGCAT_INFO("AdmProxy: Found %d recording devices, %d playout devices",
-              rec_devices, play_devices);
-  RTC_LOG(LS_INFO) << "AdmProxy: Found " << rec_devices << " recording devices, "
-                   << play_devices << " playout devices";
 
   return true;
 }
@@ -224,13 +142,11 @@ bool AdmProxy::AcquirePlatformAdm() {
   // On Android, lazily create the Platform ADM on first acquire.
   // This ensures JNI is fully initialized before we try to create the ADM.
   if (!EnsurePlatformAdmCreated()) {
-    LOGCAT_ERROR("AdmProxy::AcquirePlatformAdm() - Failed to create Platform ADM");
     RTC_LOG(LS_ERROR) << "AdmProxy::AcquirePlatformAdm() - Failed to create Platform ADM";
     return false;
   }
 #else
   if (!platform_adm_) {
-    LOGCAT_ERROR("AdmProxy::AcquirePlatformAdm() - Platform ADM not available (nullptr)");
     RTC_LOG(LS_ERROR) << "AdmProxy::AcquirePlatformAdm() - Platform ADM not available";
     return false;
   }
@@ -238,8 +154,6 @@ bool AdmProxy::AcquirePlatformAdm() {
 
   int old_ref_count = platform_adm_ref_count_;
   platform_adm_ref_count_++;
-  LOGCAT_INFO("AdmProxy::AcquirePlatformAdm() ref_count=%d", platform_adm_ref_count_);
-  RTC_LOG(LS_INFO) << "AdmProxy::AcquirePlatformAdm() ref_count=" << platform_adm_ref_count_;
 
   // If this is the first acquisition and playout/recording is enabled,
   // we may need to switch from synthetic mode to platform ADM
@@ -261,7 +175,6 @@ void AdmProxy::ReleasePlatformAdm() {
   }
 
   platform_adm_ref_count_--;
-  RTC_LOG(LS_INFO) << "AdmProxy::ReleasePlatformAdm() ref_count=" << platform_adm_ref_count_;
 
   // If ref_count reaches 0, switch back from platform ADM to synthetic mode
   // Note: We do NOT terminate the Platform ADM - it stays alive until destructor.
@@ -289,12 +202,9 @@ bool AdmProxy::is_platform_adm_active() const {
 
 void AdmProxy::set_recording_enabled(bool enabled) {
   webrtc::MutexLock lock(&mutex_);
-  RTC_LOG(LS_INFO) << "AdmProxy::set_recording_enabled(" << enabled << ")";
-
   if (recording_enabled_ == enabled) {
     return;
   }
-
   recording_enabled_ = enabled;
   SwitchRecordingAdmIfNeeded();
 }
@@ -306,12 +216,9 @@ bool AdmProxy::recording_enabled() const {
 
 void AdmProxy::set_playout_enabled(bool enabled) {
   webrtc::MutexLock lock(&mutex_);
-  RTC_LOG(LS_INFO) << "AdmProxy::set_playout_enabled(" << enabled << ")";
-
   if (playout_enabled_ == enabled) {
     return;
   }
-
   playout_enabled_ = enabled;
   SwitchPlayoutModeIfNeeded();
 }
@@ -332,8 +239,6 @@ void AdmProxy::SwitchPlayoutModeIfNeeded() {
 
   if (use_platform) {
     // Switch to platform mode - stop synthetic, start platform ADM
-    RTC_LOG(LS_INFO) << "AdmProxy: Switching playout to platform mode";
-
     if (synthetic_adm_) {
       synthetic_adm_->StopPlayout();
     }
@@ -342,9 +247,7 @@ void AdmProxy::SwitchPlayoutModeIfNeeded() {
       platform_adm_->StartPlayout();
     }
   } else {
-    // Switch to synthetic mode: stop platform ADM, start synthetic ADM.
-    RTC_LOG(LS_INFO) << "AdmProxy: Switching playout to synthetic mode";
-
+    // Switch to synthetic mode - stop platform ADM, start synthetic ADM
     if (platform_adm_) {
       platform_adm_->StopPlayout();
     }
@@ -363,11 +266,9 @@ void AdmProxy::SwitchRecordingAdmIfNeeded() {
   // Start if new ADM supports recording
   auto* adm = recording_adm();
   if (adm) {
-    RTC_LOG(LS_INFO) << "AdmProxy: Switching recording to platform ADM";
     adm->InitRecording();
     adm->StartRecording();
   } else {
-    RTC_LOG(LS_INFO) << "AdmProxy: Recording stopped (no ADM available)";
     recording_ = false;
   }
 }
@@ -601,7 +502,6 @@ int32_t AdmProxy::StartPlayout() {
   playing_ = true;
 
   if (is_platform_playout_active()) {
-    RTC_LOG(LS_INFO) << "AdmProxy::StartPlayout() using platform ADM";
     if (platform_adm_) {
       return platform_adm_->StartPlayout();
     }
@@ -609,7 +509,6 @@ int32_t AdmProxy::StartPlayout() {
   }
 
   // Synthetic mode
-  RTC_LOG(LS_INFO) << "AdmProxy::StartPlayout() using synthetic ADM";
   if (synthetic_adm_) {
     return synthetic_adm_->StartPlayout();
   }
@@ -644,14 +543,11 @@ int32_t AdmProxy::StartRecording() {
   auto* adm = recording_adm();
   if (!adm) {
     // Recording not available - return success to avoid breaking WebRTC
-    RTC_LOG(LS_INFO) << "AdmProxy::StartRecording() - recording not enabled, skipping";
     return 0;
   }
 
   recording_ = true;
-  int32_t result = adm->StartRecording();
-  RTC_LOG(LS_INFO) << "AdmProxy::StartRecording() result=" << result;
-  return result;
+  return adm->StartRecording();
 }
 
 int32_t AdmProxy::StopRecording() {

--- a/webrtc-sys/src/android.cpp
+++ b/webrtc-sys/src/android.cpp
@@ -16,6 +16,7 @@
 
 #include "livekit/android.h"
 
+#include <atomic>
 #include <jni.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -42,10 +43,20 @@ FILE *stderr = fdopen(STDERR_FILENO, "w");
 
 namespace livekit_ffi {
 
+// Track whether Android WebRTC has been initialized to prevent crashes on double-init.
+static std::atomic<bool> g_android_initialized{false};
+
 void init_android(JavaVM* jvm) {
+  // Idempotent - safe to call multiple times
+  if (g_android_initialized.exchange(true)) {
+    RTC_LOG(LS_INFO) << "livekit_ffi::init_android() - already initialized, skipping";
+    return;
+  }
+
   RTC_LOG(LS_INFO) << "livekit_ffi::init_android() called with jvm=" << (jvm ? "valid" : "null");
   if (!jvm) {
     RTC_LOG(LS_ERROR) << "livekit_ffi::init_android() - JavaVM is null! Cannot initialize Android WebRTC.";
+    g_android_initialized.store(false);
     return;
   }
   webrtc::InitAndroid(jvm);
@@ -59,6 +70,9 @@ bool init_android_context(JavaVM* jvm, uintptr_t context_ptr) {
     RTC_LOG(LS_ERROR) << "livekit_ffi::init_android_context() - jvm or context is null";
     return false;
   }
+
+  // Initialize JVM first (idempotent - WebRTC handles double-init internally)
+  init_android(jvm);
 
   // Cast uintptr_t back to jobject
   jobject context = reinterpret_cast<jobject>(context_ptr);

--- a/webrtc-sys/src/android.cpp
+++ b/webrtc-sys/src/android.cpp
@@ -22,6 +22,7 @@
 #include <memory>
 
 #include "api/video_codecs/video_decoder_factory.h"
+#include "rtc_base/logging.h"
 #include "sdk/android/native_api/base/init.h"
 #include "sdk/android/native_api/codecs/wrapper.h"
 #include "sdk/android/native_api/jni/class_loader.h"
@@ -42,7 +43,65 @@ FILE *stderr = fdopen(STDERR_FILENO, "w");
 namespace livekit_ffi {
 
 void init_android(JavaVM* jvm) {
+  RTC_LOG(LS_INFO) << "livekit_ffi::init_android() called with jvm=" << (jvm ? "valid" : "null");
+  if (!jvm) {
+    RTC_LOG(LS_ERROR) << "livekit_ffi::init_android() - JavaVM is null! Cannot initialize Android WebRTC.";
+    return;
+  }
   webrtc::InitAndroid(jvm);
+  RTC_LOG(LS_INFO) << "livekit_ffi::init_android() - webrtc::InitAndroid() completed";
+}
+
+bool init_android_context(JavaVM* jvm, uintptr_t context_ptr) {
+  RTC_LOG(LS_INFO) << "livekit_ffi::init_android_context() called";
+
+  if (!jvm || !context_ptr) {
+    RTC_LOG(LS_ERROR) << "livekit_ffi::init_android_context() - jvm or context is null";
+    return false;
+  }
+
+  // Cast uintptr_t back to jobject
+  jobject context = reinterpret_cast<jobject>(context_ptr);
+
+  JNIEnv* env = webrtc::AttachCurrentThreadIfNeeded();
+  if (!env) {
+    RTC_LOG(LS_ERROR) << "livekit_ffi::init_android_context() - Failed to attach to JNI";
+    return false;
+  }
+
+  // Find livekit.org.webrtc.ContextUtils class
+  jclass context_utils_class = env->FindClass("livekit/org/webrtc/ContextUtils");
+  if (!context_utils_class) {
+    RTC_LOG(LS_ERROR) << "livekit_ffi::init_android_context() - Failed to find ContextUtils class";
+    env->ExceptionClear();
+    return false;
+  }
+
+  // Get the initialize method
+  jmethodID initialize_method = env->GetStaticMethodID(
+      context_utils_class, "initialize", "(Landroid/content/Context;)V");
+  if (!initialize_method) {
+    RTC_LOG(LS_ERROR) << "livekit_ffi::init_android_context() - Failed to find initialize method";
+    env->ExceptionClear();
+    env->DeleteLocalRef(context_utils_class);
+    return false;
+  }
+
+  // Call ContextUtils.initialize(context)
+  env->CallStaticVoidMethod(context_utils_class, initialize_method, context);
+
+  // Check for exceptions
+  if (env->ExceptionCheck()) {
+    RTC_LOG(LS_ERROR) << "livekit_ffi::init_android_context() - Exception during initialize";
+    env->ExceptionDescribe();
+    env->ExceptionClear();
+    env->DeleteLocalRef(context_utils_class);
+    return false;
+  }
+
+  env->DeleteLocalRef(context_utils_class);
+  RTC_LOG(LS_INFO) << "livekit_ffi::init_android_context() - ContextUtils initialized successfully";
+  return true;
 }
 
 std::unique_ptr<webrtc::VideoEncoderFactory>

--- a/webrtc-sys/src/android.rs
+++ b/webrtc-sys/src/android.rs
@@ -21,18 +21,23 @@ pub mod ffi {
         type JavaVM;
 
         /// Initialize Android WebRTC with the JVM.
-        /// This must be called before any WebRTC operations on Android.
+        /// Called automatically by init_android_context(), so only call directly
+        /// in JNI_OnLoad or when you don't have an Android Context.
+        /// Idempotent - safe to call multiple times.
         unsafe fn init_android(vm: *mut JavaVM);
 
-        /// Initialize the Android application context for WebRTC audio.
-        /// This must be called before using PlatformAudio on Android.
+        /// Initialize Android WebRTC with the application context.
+        /// This is the main init function - calls init_android() internally,
+        /// then initializes ContextUtils for PlatformAudio.
+        /// Idempotent - safe to call multiple times.
         ///
         /// # Arguments
         /// * `jvm` - The JavaVM pointer
         /// * `context` - The Android application context (jobject as usize)
         ///
         /// # Returns
-        /// true if initialization was successful, false otherwise
+        /// true if context init succeeded, false otherwise.
+        /// Note: JVM init always happens regardless of return value.
         unsafe fn init_android_context(jvm: *mut JavaVM, context: usize) -> bool;
     }
 }

--- a/webrtc-sys/src/android.rs
+++ b/webrtc-sys/src/android.rs
@@ -19,6 +19,20 @@ pub mod ffi {
         include!("livekit/android.h");
 
         type JavaVM;
+
+        /// Initialize Android WebRTC with the JVM.
+        /// This must be called before any WebRTC operations on Android.
         unsafe fn init_android(vm: *mut JavaVM);
+
+        /// Initialize the Android application context for WebRTC audio.
+        /// This must be called before using PlatformAudio on Android.
+        ///
+        /// # Arguments
+        /// * `jvm` - The JavaVM pointer
+        /// * `context` - The Android application context (jobject as usize)
+        ///
+        /// # Returns
+        /// true if initialization was successful, false otherwise
+        unsafe fn init_android_context(jvm: *mut JavaVM, context: usize) -> bool;
     }
 }

--- a/webrtc-sys/src/audio_device_controller.cpp
+++ b/webrtc-sys/src/audio_device_controller.cpp
@@ -71,6 +71,16 @@ bool AudioDeviceController::set_recording_device(uint16_t index) const {
 
 bool AudioDeviceController::set_playout_device_by_guid(rust::String guid) const {
   int16_t count = adm_proxy_->PlayoutDevices();
+
+  // On Android, devices don't have GUIDs - they're identified by index only.
+  // Android also only reports a single "default" device because audio routing
+  // (speaker vs earpiece vs Bluetooth) is handled by the system via AudioManager,
+  // not through WebRTC device selection.
+  // If an empty GUID is passed and we have at least one device, use index 0.
+  if (guid.empty() && count > 0) {
+    return adm_proxy_->SetPlayoutDevice(0) == 0;
+  }
+
   for (int16_t i = 0; i < count; i++) {
     char name[webrtc::kAdmMaxDeviceNameSize] = {0};
     char device_guid[webrtc::kAdmMaxGuidSize] = {0};
@@ -85,6 +95,15 @@ bool AudioDeviceController::set_playout_device_by_guid(rust::String guid) const 
 
 bool AudioDeviceController::set_recording_device_by_guid(rust::String guid) const {
   int16_t count = adm_proxy_->RecordingDevices();
+
+  // On Android, devices don't have GUIDs - they're identified by index only.
+  // Android also only reports a single "default" microphone because the system
+  // automatically selects the best input source based on the audio mode.
+  // If an empty GUID is passed and we have at least one device, use index 0.
+  if (guid.empty() && count > 0) {
+    return adm_proxy_->SetRecordingDevice(0) == 0;
+  }
+
   for (int16_t i = 0; i < count; i++) {
     char name[webrtc::kAdmMaxDeviceNameSize] = {0};
     char device_guid[webrtc::kAdmMaxGuidSize] = {0};

--- a/webrtc-sys/src/audio_device_controller.cpp
+++ b/webrtc-sys/src/audio_device_controller.cpp
@@ -72,15 +72,7 @@ bool AudioDeviceController::set_recording_device(uint16_t index) const {
 bool AudioDeviceController::set_playout_device_by_guid(rust::String guid) const {
   int16_t count = adm_proxy_->PlayoutDevices();
 
-  // On Android, devices don't have GUIDs - they're identified by index only.
-  // Android also only reports a single "default" device because audio routing
-  // (speaker vs earpiece vs Bluetooth) is handled by the system via AudioManager,
-  // not through WebRTC device selection.
-  // If an empty GUID is passed and we have at least one device, use index 0.
-  if (guid.empty() && count > 0) {
-    return adm_proxy_->SetPlayoutDevice(0) == 0;
-  }
-
+  // Try to find a device matching the GUID
   for (int16_t i = 0; i < count; i++) {
     char name[webrtc::kAdmMaxDeviceNameSize] = {0};
     char device_guid[webrtc::kAdmMaxGuidSize] = {0};
@@ -90,20 +82,21 @@ bool AudioDeviceController::set_playout_device_by_guid(rust::String guid) const 
       }
     }
   }
+
+  // No match found - fall back to default device (index 0).
+  // This handles mobile platforms (iOS/Android) where:
+  // - GUIDs may be empty or not meaningful
+  // - Device selection is a no-op (system handles routing)
+  if (count > 0) {
+    return adm_proxy_->SetPlayoutDevice(0) == 0;
+  }
   return false;
 }
 
 bool AudioDeviceController::set_recording_device_by_guid(rust::String guid) const {
   int16_t count = adm_proxy_->RecordingDevices();
 
-  // On Android, devices don't have GUIDs - they're identified by index only.
-  // Android also only reports a single "default" microphone because the system
-  // automatically selects the best input source based on the audio mode.
-  // If an empty GUID is passed and we have at least one device, use index 0.
-  if (guid.empty() && count > 0) {
-    return adm_proxy_->SetRecordingDevice(0) == 0;
-  }
-
+  // Try to find a device matching the GUID
   for (int16_t i = 0; i < count; i++) {
     char name[webrtc::kAdmMaxDeviceNameSize] = {0};
     char device_guid[webrtc::kAdmMaxGuidSize] = {0};
@@ -112,6 +105,14 @@ bool AudioDeviceController::set_recording_device_by_guid(rust::String guid) cons
         return adm_proxy_->SetRecordingDevice(i) == 0;
       }
     }
+  }
+
+  // No match found - fall back to default device (index 0).
+  // This handles mobile platforms (iOS/Android) where:
+  // - GUIDs may be empty or not meaningful
+  // - Device selection is a no-op (system handles routing)
+  if (count > 0) {
+    return adm_proxy_->SetRecordingDevice(0) == 0;
   }
   return false;
 }


### PR DESCRIPTION
### Before you submit your PR

Make sure the following is true before submitting your PR:

- [x] I have read the [contributing guidelines](https://github.com/livekit/rust-sdks/blob/main/CONTRIBUTING.md) and validated that this PR will be accepted.
- [x] I have read and followed the principles regarding breaking changes, testing, and code quality.

### PR description

⏺ Android PlatformAudio: Problems & Solutions

  Problem 1: ADM Creation Failed

  Symptom:
  CreateAudioDeviceModule returned nullptr
  Failed to initialize PlatformAudio

  Root Cause:
  WebRTC's CreateAndroidAudioDeviceModule internally calls GetAppContext() to get the Android application context. But GetAppContext() returns null unless ContextUtils.initialize(context) was called first.

  CreateAndroidAudioDeviceModule()
      └── GetAppContext()
              └── Returns null ❌ (ContextUtils not initialized)

  Solution:
  Pass the Android Context from Unity to Rust, then call ContextUtils.initialize(context) before any WebRTC audio initialization.

  Unity                          Rust/C++
  ─────                          ────────
  GetApplicationContext() ──────► livekit_ffi_initialize_android_context()
                                      │
                                      ├── do_android_init(vm)      // JVM init
                                      └── ContextUtils.initialize(context)  // Now GetAppContext() works!

  Files changed:
  - livekit-ffi/src/cabi.rs - Added livekit_ffi_initialize_android_context()
  - webrtc-sys/src/android.cpp - Added init_android_context()
  - client-sdk-unity/.../FFIClient.cs - Calls the init with context
  - client-sdk-unity/.../NativeMethods.cs - P/Invoke declaration

  ---
  Problem 2: Wrong ADM Factory Function

  Symptom:
  AdmProxy: All Android audio layers failed!

  Root Cause:
  The code was using the generic CreateAudioDeviceModule() which doesn't work properly on Android. Android requires CreateAndroidAudioDeviceModule() from the Android-specific header.

  Solution:
  Changed adm_proxy.cpp to use the correct function:

  // Before (wrong):
  #include "modules/audio_device/include/audio_device.h"
  platform_adm_ = webrtc::AudioDeviceModule::Create(...);

  // After (correct):
  #include "sdk/android/native_api/audio_device_module/audio_device_android.h"
  platform_adm_ = webrtc::CreateAndroidAudioDeviceModule(...);

  File changed:
  - webrtc-sys/src/adm_proxy.cpp

  ---
  Problem 3: Empty GUID Validation Failed

  Symptom:
  Recording device at index 0 has no GUID

  Root Cause:
  Unity SDK threw an exception when device GUID was empty. But on Android, devices don't have GUIDs - WebRTC returns empty strings.

  Solution:
  Allow empty GUIDs and pass them to native code, which falls back to index 0:

  // Before:
  if (string.IsNullOrEmpty(deviceId))
      throw new InvalidOperationException("has no GUID");

  // After:
  SetRecordingDevice(deviceId ?? "");  // Empty string triggers fallback

  File changed:
  - client-sdk-unity/.../PlatformAudio.cs

  ---
  Problem 4: Device Not Found with Empty GUID

  Symptom:
  Failed to set recording device: Device not found

  Root Cause:
  Native code searched for a device matching the empty GUID string, found nothing.

  Solution:
  Added fallback in C++ - if GUID is empty and devices exist, use index 0:

  bool AudioDeviceController::set_recording_device_by_guid(rust::String guid) const {
      int16_t count = adm_proxy_->RecordingDevices();

      // Android fallback: empty GUID → use index 0
      if (guid.empty() && count > 0) {
          return adm_proxy_->SetRecordingDevice(0) == 0;
      }
      // ... normal GUID lookup for desktop
  }

  File changed:
  - webrtc-sys/src/audio_device_controller.cpp

### Breaking changes

N/A
### MSRV

N/A
### Testing

Tested with Unity

### Async

N/A


