### PR TITLE
Add readme to livekit-ffi-node-bindings

### DIFF
--- a/livekit-ffi-node-bindings/README.md
+++ b/livekit-ffi-node-bindings/README.md
@@ -1,0 +1,3 @@
+# `@livekit/rtc-ffi-bindings`
+
+This is an internal package used by the LiveKit Node SDK to invoke the Rust `livekit-ffi` bindings.


### PR DESCRIPTION
Right now, the `@livekit/rtc-ffi-bindings` package does not have a `README.md`, so it looks like this on npm:

<img width="862" height="415" alt="Screenshot 2026-05-20 at 3 14 18 PM" src="https://github.com/user-attachments/assets/f82cb42b-6058-440d-ba82-d2d0cd6756ed" />

So, add something simple so it looks a little nicer.