### PR TITLE
UniFFI Android release followups

### DIFF
--- a/.github/workflows/uniffi-android.yml
+++ b/.github/workflows/uniffi-android.yml
@@ -61,6 +61,7 @@ jobs:
           ORG_GRADLE_PROJECT_STAGING_PROFILE_ID: ${{ secrets.UNIFFI_MAVEN_STAGING_PROFILE_ID }}
           UNIFFI_MAVEN_SIGNING_KEY_ID: ${{ secrets.UNIFFI_MAVEN_SIGNING_KEY_ID }}
           UNIFFI_MAVEN_SIGNING_PASSWORD: ${{ secrets.UNIFFI_MAVEN_SIGNING_PASSWORD }}
+          # UNIFFI_MAVEN_SIGNING_KEY is base64 armored GPG export
           UNIFFI_MAVEN_SIGNING_KEY: ${{ secrets.UNIFFI_MAVEN_SIGNING_KEY }}
         run: |
           group="$(grep '^GROUP=' gradle.properties | cut -d= -f2)"
@@ -68,8 +69,12 @@ jobs:
           echo "Publishing ${group}:${artifact}:${{ inputs.version }}"
           echo "Source tag: ${{ inputs.tag_name }}"
 
+          signing_key_armored="${RUNNER_TEMP}/signing-key.asc"
           signing_key_file="${RUNNER_TEMP}/signing-key.gpg"
-          printf '%s' "${UNIFFI_MAVEN_SIGNING_KEY}" > "${signing_key_file}"
+          trap 'rm -f "${signing_key_armored}" "${signing_key_file}"' EXIT
+          printf '%s' "${UNIFFI_MAVEN_SIGNING_KEY}" | base64 --decode > "${signing_key_armored}"
+          gpg --batch --yes --dearmor --output "${signing_key_file}" "${signing_key_armored}"
+          rm -f "${signing_key_armored}"
           chmod 600 "${signing_key_file}"
 
           ./gradlew publishToNexus closeAndReleaseNexusStagingRepository \

--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -454,7 +454,49 @@ run_task = "swift-package-flow"
 # Local dev: cargo make android-package-local
 #            → additionally publishes the package to local maven for local use
 
+# Enforce a size budget on the arm64-v8a native library an Android user actually
+# downloads. arm64-v8a is the primary shipping arch, so it's the most meaningful 
+# proxy for "how much does this dep cost an end user".
+# Measured on the stripped .so inside the release AAR (AGP strips debug symbols
+# during assemble; the raw target/ artifact is larger and not what ships).
+# Override the limit per release with ANDROID_SIZE_LIMIT_BYTES.
+[tasks.android-check-size.env]
+ANDROID_SIZE_LIMIT_BYTES = { value = "1572864", condition = { env_not_set = ["ANDROID_SIZE_LIMIT_BYTES"] } }
+
+[tasks.android-check-size]
+private = true
+condition = { profiles = ["release"] }
+script_runner = "@shell"
+script = """
+aar="${SUPPORT_DIR}/android/build/outputs/aar/livekit-uniffi-android-release.aar"
+
+if [ ! -f "${aar}" ]; then
+  echo "android-check-size: release AAR not found at ${aar}" >&2
+  exit 1
+fi
+
+bytes=$(unzip -l "${aar}" | awk '$4 ~ /jni\\/arm64-v8a\\/.*\\.so$/ { print $1; exit }')
+if [ -z "${bytes}" ]; then
+  echo "android-check-size: arm64-v8a .so not found in ${aar}" >&2
+  exit 1
+fi
+
+limit=${ANDROID_SIZE_LIMIT_BYTES}
+
+kib=$((bytes / 1024))
+limit_kib=$((limit / 1024))
+
+if [ "${bytes}" -gt "${limit}" ]; then
+  echo "android-check-size: ${LIB_NAME} (arm64-v8a) is ${kib} KiB (${bytes} bytes), exceeds limit ${limit_kib} KiB (${limit} bytes)." >&2
+  echo "  Either land the size regression intentionally and bump ANDROID_SIZE_LIMIT_BYTES, or investigate (cargo bloat, panic = abort, opt-level)." >&2
+  exit 1
+fi
+
+echo "${LIB_NAME} (arm64-v8a) ${kib} KiB / ${limit_kib} KiB budget"
+"""
+
 [tasks.android-copy-jniLibs]
+private = true
 description = "Copy release Android .so files into support/android jniLibs"
 script_runner = "@shell"
 script = """
@@ -465,6 +507,7 @@ cp "${TARGET_DIR}/x86_64-linux-android/release/${LIB_NAME}.so" "${JNI_LIBS}/x86_
 """
 
 [tasks.android-assemble]
+private = true
 description = "Build the release AAR from support/android"
 script_runner = "@shell"
 script = """
@@ -474,6 +517,7 @@ echo "AAR: ${SUPPORT_DIR}/android/build/outputs/aar/livekit-uniffi-android-relea
 """
 
 [tasks.android-copy-to-packages]
+private = true
 description = "Copy the release AAR into packages/android"
 script_runner = "@shell"
 script = """
@@ -491,6 +535,7 @@ dependencies = [
     "bindgen-kotlin",
     "android-copy-jniLibs",
     "android-assemble",
+    "android-check-size",
     "android-copy-to-packages",
 ]
 
@@ -499,6 +544,7 @@ description = "Build Android AAR with native libs and Kotlin bindings"
 run_task = "android-package-flow"
 
 [tasks.android-publish-maven-local]
+private = true
 description = "Publish the release AAR to the local Maven repository (~/.m2/repository)"
 script_runner = "@shell"
 script = """

--- a/livekit-uniffi/support/android/README.md
+++ b/livekit-uniffi/support/android/README.md
@@ -55,8 +55,35 @@ build/outputs/aar/livekit-uniffi-android-release.aar
 
 ```kotlin
 dependencies {
-    implementation(project(":livekit-uniffi")) // or published Maven coordinate
+    implementation("io.livekit:livekit-uniffi-android:x.y.z")
 }
 ```
 
 The AAR bundles `jniLibs` and compiled Kotlin. UniFFI also requires **JNA** and **kotlinx-coroutines**; this module declares them as `implementation` dependencies so they are pulled in transitively when consuming through Maven.
+
+### Local app development
+
+Add `mavenLocal()` to your app's repository list (before `mavenCentral()` so that the local artifact wins):
+
+```kotlin
+// settings.gradle.kts
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        google()
+        mavenCentral()
+    }
+}
+```
+
+If your project uses per-module `repositories` in `build.gradle.kts` instead, add `mavenLocal()` there in the same order.
+
+Depend on the artifact as above, using the `VERSION_NAME` in this module's `gradle.properties`:
+
+```kotlin
+dependencies {
+    implementation("io.livekit:livekit-uniffi-android:0.0.1")
+}
+```
+
+Re-run `cargo make android-package-local` to rebuild and publish any changes.


### PR DESCRIPTION
Fixes up signing and adds some more docs for local dev.

Also added check-size to match swift. Tried adding bloaty and cargo-bloat to analyze the internal size contributors, but they didn't work properly for ndk builds.