### PR TITLE
Filter internal data streams out of livekit-ffi interface

### DIFF
--- a/.changeset/filter_internal_data_streams_out_of_livekit_ffi_interface.md
+++ b/.changeset/filter_internal_data_streams_out_of_livekit_ffi_interface.md
@@ -1,0 +1,6 @@
+---
+livekit: patch
+livekit-ffi: patch
+---
+
+Filter internal data streams out of livekit-ffi interface - #1112 (@1egoman)

--- a/.changeset/fix_depacketizer_test.md
+++ b/.changeset/fix_depacketizer_test.md
@@ -1,0 +1,5 @@
+---
+livekit-datatrack: patch
+---
+
+Fix compilation error in depacketizer test by using correct variable name.

--- a/livekit-datatrack/src/remote/depacketizer.rs
+++ b/livekit-datatrack/src/remote/depacketizer.rs
@@ -359,7 +359,8 @@ mod tests {
         assert!(result.frame.is_none() && result.drop_error.is_none());
 
         let first_frame_number = packet.header.frame_number;
-        packet.header.frame_number = packet.header.frame_number.wrapping_add(1); // Next frame
+        let new_frame_number = packet.header.frame_number.wrapping_add(1);
+        packet.header.frame_number = new_frame_number; // Next frame
 
         let result = depacketizer.push(packet, Default::default());
         assert!(result.frame.is_none());

--- a/livekit/src/room/data_stream/incoming.rs
+++ b/livekit/src/room/data_stream/incoming.rs
@@ -298,7 +298,7 @@ impl IncomingStreamManager {
     /// (e.g. `lk.rpc_request`). Used to suppress `RoomEvent::Stream*Received`
     /// dispatches for traffic the SDK handles itself.
     pub fn is_internal(&self, stream_id: &str) -> bool {
-        self.inner.lock().open_streams.get(stream_id).map(|d| d.is_internal).unwrap_or(false)
+        self.inner.lock().open_streams.get(stream_id).is_some_and(|d| d.is_internal)
     }
 
     /// Handles an incoming chunk packet.

--- a/livekit/src/room/data_stream/incoming.rs
+++ b/livekit/src/room/data_stream/incoming.rs
@@ -237,6 +237,7 @@ struct Descriptor {
     progress: StreamProgress,
     chunk_tx: UnboundedSender<StreamResult<Bytes>>,
     encryption_type: EncryptionType,
+    is_internal: bool,
     // TODO(ladvoc): keep track of open time.
 }
 
@@ -264,6 +265,7 @@ impl IncomingStreamManager {
         identity: String,
         encryption_type: livekit_protocol::encryption::Type,
     ) {
+        let is_internal = super::is_internal_topic(&header.topic);
         let Ok(info) = AnyStreamInfo::try_from_with_encryption(header, encryption_type.into())
             .inspect_err(|e| log::error!("Invalid header: {}", e))
         else {
@@ -287,8 +289,16 @@ impl IncomingStreamManager {
             progress: StreamProgress { bytes_total, ..Default::default() },
             chunk_tx,
             encryption_type: stream_encryption_type,
+            is_internal,
         };
         inner.open_streams.insert(id, descriptor);
+    }
+
+    /// Returns whether the given open stream belongs to an internal topic
+    /// (e.g. `lk.rpc_request`). Used to suppress `RoomEvent::Stream*Received`
+    /// dispatches for traffic the SDK handles itself.
+    pub fn is_internal(&self, stream_id: &str) -> bool {
+        self.inner.lock().open_streams.get(stream_id).map(|d| d.is_internal).unwrap_or(false)
     }
 
     /// Handles an incoming chunk packet.

--- a/livekit/src/room/data_stream/mod.rs
+++ b/livekit/src/room/data_stream/mod.rs
@@ -25,6 +25,16 @@ pub use incoming::*;
 pub use outgoing::*;
 
 use crate::e2ee::EncryptionType;
+use crate::room::rpc::{RPC_REQUEST_TOPIC, RPC_RESPONSE_TOPIC};
+
+/// Data stream topics reserved for internal SDK use. Events for these
+/// topics are handled within the `livekit` crate and never surfaced
+/// through `RoomEvent`.
+pub(crate) const INTERNAL_TOPICS: &[&str] = &[RPC_REQUEST_TOPIC, RPC_RESPONSE_TOPIC];
+
+pub(crate) fn is_internal_topic(topic: &str) -> bool {
+    INTERNAL_TOPICS.contains(&topic)
+}
 
 /// Result type for data stream operations.
 pub type StreamResult<T> = Result<T, StreamError>;

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -2164,15 +2164,14 @@ async fn incoming_data_stream_task(
                                     session.rpc_client.handle_v2_response_stream(reader).await;
                                 });
                             }
-                            other if data_stream::is_internal_topic(other) => {
-                                // Future internal topic without a dedicated routing branch.
-                            }
                             _ => {
-                                dispatcher.dispatch(&RoomEvent::TextStreamOpened {
-                                    topic,
-                                    reader: TakeCell::new(reader),
-                                    participant_identity: ParticipantIdentity(identity)
-                                });
+                                if !data_stream::is_internal_topic(other) {
+                                    dispatcher.dispatch(&RoomEvent::TextStreamOpened {
+                                        topic,
+                                        reader: TakeCell::new(reader),
+                                        participant_identity: ParticipantIdentity(identity)
+                                    });
+                                }
                             }
                         }
                     }

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -2165,7 +2165,7 @@ async fn incoming_data_stream_task(
                                 });
                             }
                             _ => {
-                                if !data_stream::is_internal_topic(other) {
+                                if !data_stream::is_internal_topic(&topic) {
                                     dispatcher.dispatch(&RoomEvent::TextStreamOpened {
                                         topic,
                                         reader: TakeCell::new(reader),

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -1775,6 +1775,7 @@ impl RoomSession {
         participant_identity: String,
         encryption_type: proto::encryption::Type,
     ) {
+        let is_internal = data_stream::is_internal_topic(&header.topic);
         self.incoming_stream_manager.handle_header(
             header.clone(),
             participant_identity.clone(),
@@ -1790,9 +1791,11 @@ impl RoomSession {
             participant.update_data_encryption_status(is_encrypted);
         }
 
-        // For backwards compatibly
-        let event = RoomEvent::StreamHeaderReceived { header, participant_identity };
-        self.dispatcher.dispatch(&event);
+        if !is_internal {
+            // For backwards compatibly
+            let event = RoomEvent::StreamHeaderReceived { header, participant_identity };
+            self.dispatcher.dispatch(&event);
+        }
     }
 
     fn handle_data_stream_chunk(
@@ -1801,11 +1804,14 @@ impl RoomSession {
         participant_identity: String,
         encryption_type: proto::encryption::Type,
     ) {
+        let is_internal = self.incoming_stream_manager.is_internal(&chunk.stream_id);
         self.incoming_stream_manager.handle_chunk(chunk.clone(), encryption_type);
 
-        // For backwards compatibly
-        let event = RoomEvent::StreamChunkReceived { chunk, participant_identity };
-        self.dispatcher.dispatch(&event);
+        if !is_internal {
+            // For backwards compatibly
+            let event = RoomEvent::StreamChunkReceived { chunk, participant_identity };
+            self.dispatcher.dispatch(&event);
+        }
     }
 
     fn handle_data_stream_trailer(
@@ -1813,11 +1819,16 @@ impl RoomSession {
         trailer: proto::data_stream::Trailer,
         participant_identity: String,
     ) {
+        // Check is_internal *before* handle_trailer, which removes the
+        // descriptor from the open-streams map.
+        let is_internal = self.incoming_stream_manager.is_internal(&trailer.stream_id);
         self.incoming_stream_manager.handle_trailer(trailer.clone());
 
-        // For backwards compatibly
-        let event = RoomEvent::StreamTrailerReceived { trailer, participant_identity };
-        self.dispatcher.dispatch(&event);
+        if !is_internal {
+            // For backwards compatibly
+            let event = RoomEvent::StreamTrailerReceived { trailer, participant_identity };
+            self.dispatcher.dispatch(&event);
+        }
     }
 
     fn handle_data_channel_buffered_low_threshold_change(
@@ -2122,11 +2133,16 @@ async fn incoming_data_stream_task(
         tokio::select! {
             Some((reader, identity)) = open_rx.recv() => {
                 match reader {
-                    AnyStreamReader::Byte(reader) => dispatcher.dispatch(&RoomEvent::ByteStreamOpened {
-                        topic: reader.info().topic.clone(),
-                        reader: TakeCell::new(reader),
-                        participant_identity: ParticipantIdentity(identity)
-                    }),
+                    AnyStreamReader::Byte(reader) => {
+                        let topic = reader.info().topic.clone();
+                        if !data_stream::is_internal_topic(&topic) {
+                            dispatcher.dispatch(&RoomEvent::ByteStreamOpened {
+                                topic,
+                                reader: TakeCell::new(reader),
+                                participant_identity: ParticipantIdentity(identity)
+                            });
+                        }
+                    }
                     AnyStreamReader::Text(reader) => {
                         let topic = reader.info().topic.clone();
                         match topic.as_str() {
@@ -2147,6 +2163,9 @@ async fn incoming_data_stream_task(
                                 livekit_runtime::spawn(async move {
                                     session.rpc_client.handle_v2_response_stream(reader).await;
                                 });
+                            }
+                            other if data_stream::is_internal_topic(other) => {
+                                // Future internal topic without a dedicated routing branch.
                             }
                             _ => {
                                 dispatcher.dispatch(&RoomEvent::TextStreamOpened {

--- a/livekit/tests/rpc_test.rs
+++ b/livekit/tests/rpc_test.rs
@@ -169,15 +169,13 @@ pub async fn test_rpc_v2_does_not_emit_data_stream_events() -> Result<()> {
     let (callee_room, callee_events) = rooms.pop().unwrap();
     let callee_identity = callee_room.local_participant().identity();
 
-    callee_room.local_participant().register_rpc_method("echo".to_string(), |data| {
-        Box::pin(async move { Ok(data.payload) })
-    });
+    callee_room
+        .local_participant()
+        .register_rpc_method("echo".to_string(), |data| Box::pin(async move { Ok(data.payload) }));
 
     async fn collect(mut rx: UnboundedReceiver<RoomEvent>) -> Vec<RoomEvent> {
         let mut events = Vec::new();
-        while let Ok(Some(ev)) =
-            tokio::time::timeout(Duration::from_millis(250), rx.recv()).await
-        {
+        while let Ok(Some(ev)) = tokio::time::timeout(Duration::from_millis(250), rx.recv()).await {
             events.push(ev);
         }
         events

--- a/livekit/tests/rpc_test.rs
+++ b/livekit/tests/rpc_test.rs
@@ -16,8 +16,9 @@
 use {
     anyhow::{Context, Result},
     common::test_rooms,
-    livekit::prelude::PerformRpcData,
+    livekit::{prelude::PerformRpcData, RoomEvent},
     std::time::Duration,
+    tokio::sync::mpsc::UnboundedReceiver,
 };
 
 mod common;
@@ -157,5 +158,62 @@ pub async fn test_rpc_unknown_destination() -> Result<()> {
     };
     let result = caller_room.local_participant().perform_rpc(perform_data).await;
     assert!(result.is_err(), "Expected error");
+    Ok(())
+}
+
+#[cfg(feature = "__lk-e2e-test")]
+#[test_log::test(tokio::test)]
+pub async fn test_rpc_v2_does_not_emit_data_stream_events() -> Result<()> {
+    let mut rooms = test_rooms(2).await?;
+    let (caller_room, caller_events) = rooms.pop().unwrap();
+    let (callee_room, callee_events) = rooms.pop().unwrap();
+    let callee_identity = callee_room.local_participant().identity();
+
+    callee_room.local_participant().register_rpc_method("echo".to_string(), |data| {
+        Box::pin(async move { Ok(data.payload) })
+    });
+
+    async fn collect(mut rx: UnboundedReceiver<RoomEvent>) -> Vec<RoomEvent> {
+        let mut events = Vec::new();
+        while let Ok(Some(ev)) =
+            tokio::time::timeout(Duration::from_millis(250), rx.recv()).await
+        {
+            events.push(ev);
+        }
+        events
+    }
+    let caller_handle = tokio::spawn(collect(caller_events));
+    let callee_handle = tokio::spawn(collect(callee_events));
+
+    let perform_data = PerformRpcData {
+        method: "echo".to_string(),
+        destination_identity: callee_identity.to_string(),
+        payload: "hi".to_string(),
+        response_timeout: Duration::from_millis(500),
+        ..Default::default()
+    };
+    let resp = caller_room
+        .local_participant()
+        .perform_rpc(perform_data)
+        .await
+        .context("Invocation failed")?;
+    assert_eq!(resp, "hi");
+
+    let caller = caller_handle.await?;
+    let callee = callee_handle.await?;
+    for ev in caller.iter().chain(callee.iter()) {
+        assert!(
+            !matches!(
+                ev,
+                RoomEvent::TextStreamOpened { .. }
+                    | RoomEvent::ByteStreamOpened { .. }
+                    | RoomEvent::StreamHeaderReceived { .. }
+                    | RoomEvent::StreamChunkReceived { .. }
+                    | RoomEvent::StreamTrailerReceived { .. }
+            ),
+            "unexpected data-stream event leaked from internal RPC traffic: {:?}",
+            ev,
+        );
+    }
     Ok(())
 }


### PR DESCRIPTION
Without this, logs like the below would show up in the node sdk while rpc requests are occurring with rpc v2 capable participants:

> ignoring incoming text stream due to no handler for topic: lk.rpc_request

So, adds a new mechanism to specify "internal topics" which should not be exposed into the room's public api interface. Also adds a new e2e test to exercise this case and ensure that these events aren't inadvertently exposed (which if they aren't exposed in `livekit`, they won't be exposed in `livekit-ffi`, which means they won't be exposed in end sdks).

