### PR TITLE
Fix depacketizer test compilation error

### DIFF
--- a/.changeset/fix_depacketizer_test.md
+++ b/.changeset/fix_depacketizer_test.md
@@ -1,0 +1,5 @@
+---
+livekit-datatrack: patch
+---
+
+Fix compilation error in depacketizer test by using correct variable name.

--- a/livekit-datatrack/src/remote/depacketizer.rs
+++ b/livekit-datatrack/src/remote/depacketizer.rs
@@ -359,7 +359,8 @@ mod tests {
         assert!(result.frame.is_none() && result.drop_error.is_none());
 
         let first_frame_number = packet.header.frame_number;
-        packet.header.frame_number = packet.header.frame_number.wrapping_add(1); // Next frame
+        let new_frame_number = packet.header.frame_number.wrapping_add(1);
+        packet.header.frame_number = new_frame_number; // Next frame
 
         let result = depacketizer.push(packet, Default::default());
         assert!(result.frame.is_none());

--- a/livekit-datatrack/src/remote/depacketizer.rs
+++ b/livekit-datatrack/src/remote/depacketizer.rs
@@ -370,7 +370,7 @@ mod tests {
         let DepacketizerDropReason::Interrupted { new_frame_number: reported } = drop.reason else {
             panic!("Expected Interrupted, got {:?}", drop.reason);
         };
-        assert_eq!(reported, first_frame_number.wrapping_add(1));
+        assert_eq!(reported, new_frame_number);
     }
 
     #[test]

--- a/livekit-datatrack/src/remote/depacketizer.rs
+++ b/livekit-datatrack/src/remote/depacketizer.rs
@@ -369,7 +369,7 @@ mod tests {
         let DepacketizerDropReason::Interrupted { new_frame_number: reported } = drop.reason else {
             panic!("Expected Interrupted, got {:?}", drop.reason);
         };
-        assert_eq!(reported, new_frame_number);
+        assert_eq!(reported, first_frame_number.wrapping_add(1));
     }
 
     #[test]


### PR DESCRIPTION
Use correct variable for assertion in test_interrupted test. The new_frame_number field is destructured into `reported`, so we need to compare against the actual new frame number value.

### Before you submit your PR

Make sure the following is true before submitting your PR:

- [ x] I have read the [contributing guidelines](https://github.com/livekit/rust-sdks/blob/main/CONTRIBUTING.md) and validated that this PR will be accepted.
- [x ] I have read and followed the principles regarding breaking changes, testing, and code quality.

### PR description

Fix the CI.
