### PR TITLE
Use workspace toolchain across CI workflows

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -111,9 +111,12 @@ jobs:
         run: |
           sudo apt install -y libva-dev libdrm-dev libnvidia-compute-570 libnvidia-decode-570 nvidia-cuda-dev -y
 
-      - name: Install Rust toolchain.
-        run: |
-          rustup target add ${{ matrix.target }}
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          target: ${{ matrix.target }}
+          cache: false
+          rustflags: ""
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10

--- a/.github/workflows/ffi-builds.yml
+++ b/.github/workflows/ffi-builds.yml
@@ -149,9 +149,12 @@ jobs:
         with:
           submodules: true
 
-      - name: Install Rust toolchain.
-        run: |
-          rustup target add ${{ matrix.target }}
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          target: ${{ matrix.target }}
+          cache: false
+          rustflags: ""
 
       - name: Cache cargo registry
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -25,11 +25,11 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          toolchain: nightly-2023-12-30
-          components: rustfmt
+          cache: false
+          rustflags: ""
 
       - name: Cargo fmt
         run: |

--- a/.github/workflows/gen-protocol.yaml
+++ b/.github/workflows/gen-protocol.yaml
@@ -39,9 +39,11 @@ jobs:
           submodules: true
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          toolchain: stable
+          cache: false
+          rustflags: ""
 
       - name: Install Protoc
         uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2.1.0

--- a/.github/workflows/node-builds.yml
+++ b/.github/workflows/node-builds.yml
@@ -73,10 +73,12 @@ jobs:
       - run: pnpm install
         working-directory: livekit-ffi-node-bindings
 
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          toolchain: stable
-          targets: ${{ matrix.target }}
+          target: ${{ matrix.target }}
+          cache: false
+          rustflags: ""
 
       - name: Cache cargo registry
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,11 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          toolchain: stable
+          cache: false
+          rustflags: ""
 
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@aaa84a43aec4955a42c5ffc65d258961e39f276e # v1.19.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -210,4 +210,4 @@ jobs:
         if: ${{ matrix.e2e-testing }}
         env:
           RUST_LOG: info
-        run: cargo test --release --verbose --target ${{ matrix.target }} --features __lk-e2e-test -- --nocapture --test-threads=1
+        run: cargo test --verbose --target ${{ matrix.target }} --features __lk-e2e-test -- --nocapture --test-threads=1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
           submodules: true
 
       - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           target: ${{ matrix.target }}
           cache: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,10 +64,12 @@ jobs:
         with:
           submodules: true
 
-      - name: Install Rust toolchain
-        run: |
-          rustup update --no-self-update nightly
-          rustup target add ${{ matrix.target }} --toolchain nightly
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: ${{ matrix.target }}
+          cache: false
+          rustflags: ""
 
       - name: Install Protoc
         uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -204,10 +204,10 @@ jobs:
         if: ${{ !matrix.e2e-testing }}
         env:
           RUST_LOG: info
-        run: cargo +nightly test --verbose --target ${{ matrix.target }} -- --nocapture
+        run: cargo test --verbose --target ${{ matrix.target }} -- --nocapture
 
       - name: Test (with E2E)
         if: ${{ matrix.e2e-testing }}
         env:
           RUST_LOG: info
-        run: cargo +nightly test --release --verbose --target ${{ matrix.target }} --features __lk-e2e-test -- --nocapture --test-threads=1
+        run: cargo test --release --verbose --target ${{ matrix.target }} --features __lk-e2e-test -- --nocapture --test-threads=1

--- a/.github/workflows/uniffi-android.yml
+++ b/.github/workflows/uniffi-android.yml
@@ -35,7 +35,12 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          cache: false
+          rustflags: ""
+
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/.github/workflows/uniffi-swift.yml
+++ b/.github/workflows/uniffi-swift.yml
@@ -44,11 +44,16 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          cache: false
+          rustflags: ""
+
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install Apple Rust targets (tier 1/2)


### PR DESCRIPTION
Summary of changes:
- Use workspace toolchain version across all CI workflows (see #1122)
- Do not use nightly toolchain for formatting or tests (reverts #495)
- Switch to [_actions-rust-lang/setup-rust-toolchain_](https://github.com/actions-rust-lang/setup-rust-toolchain) to setup Rust toolchain across all workflows
  - Respects workspace toolchain version by default
  
