### PR TITLE
adding support to setting preferred encoder on video track publication

### DIFF
--- a/.changeset/video-encoder-backend-list.md
+++ b/.changeset/video-encoder-backend-list.md
@@ -1,0 +1,7 @@
+---
+webrtc-sys: patch
+libwebrtc: patch
+livekit: patch
+---
+
+Add a video encoder backend availability query.

--- a/.changeset/video-encoder-backend-list.md
+++ b/.changeset/video-encoder-backend-list.md
@@ -1,7 +1,0 @@
----
-webrtc-sys: patch
-libwebrtc: patch
-livekit: patch
----
-
-Add a video encoder backend availability query.

--- a/.changeset/video-encoder-backend.md
+++ b/.changeset/video-encoder-backend.md
@@ -1,0 +1,8 @@
+---
+webrtc-sys: patch
+libwebrtc: patch
+livekit: patch
+livekit-ffi: patch
+---
+
+Add per-publication video encoder backend selection.

--- a/.changeset/video-encoder-backend.md
+++ b/.changeset/video-encoder-backend.md
@@ -5,4 +5,4 @@ livekit: patch
 livekit-ffi: patch
 ---
 
-Add per-publication video encoder backend selection. Add a video encoder backend availability query.
+Add per-publication video encoder backend selection. Add a video encoder backend availability query. Remove `LIVEKIT_PREFERRED_HW_ENCODER` in favor of per-publication backend selection.

--- a/.changeset/video-encoder-backend.md
+++ b/.changeset/video-encoder-backend.md
@@ -5,4 +5,4 @@ livekit: patch
 livekit-ffi: patch
 ---
 
-Add per-publication video encoder backend selection.
+Add per-publication video encoder backend selection. Add a video encoder backend availability query.

--- a/README.md
+++ b/README.md
@@ -180,17 +180,6 @@ When building on MacOS, `-ObjC` linker flag is needed. LiveKit's WebRTC implemen
 *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[RTCVideoCodecInfo nativeSdpVideoFormat]: unrecognized selector sent to instance 0x600003bc6660'
 ```
 
-## Environment variables
-
-### `LIVEKIT_PREFERRED_HW_ENCODER`
-
-On Linux builds that include support for multiple hardware video encoders (NVENC and VAAPI), this variable selects which one is preferred when both are available at runtime. Accepted values:
-
-- `nvenc` — prefer the NVIDIA NVENC encoder.
-- `vaapi` — prefer the VAAPI encoder.
-
-If unset (the default), NVENC is preferred. If the requested encoder is not supported or not compiled in, the SDK logs a warning and falls back to the other available hardware encoder (or software encoders). Any other value is ignored with a warning.
-
 ## Motivation and Design Goals
 
 LiveKit aims to provide an open source, end-to-end WebRTC stack that works everywhere. We have two goals in mind with this SDK:

--- a/examples/local_video/src/publisher.rs
+++ b/examples/local_video/src/publisher.rs
@@ -67,7 +67,7 @@ enum PublisherEncoder {
     Hardware,
     Nvenc,
     Vaapi,
-    #[value(alias = "videotoolbox")]
+    #[value(name = "videotoolbox")]
     VideoToolbox,
 }
 
@@ -79,7 +79,7 @@ impl PublisherEncoder {
             PublisherEncoder::Hardware => "hardware",
             PublisherEncoder::Nvenc => "nvenc",
             PublisherEncoder::Vaapi => "vaapi",
-            PublisherEncoder::VideoToolbox => "video-toolbox",
+            PublisherEncoder::VideoToolbox => "videotoolbox",
         }
     }
 }
@@ -104,7 +104,7 @@ fn video_encoder_backend_name(backend: VideoEncoderBackend) -> &'static str {
         VideoEncoderBackend::Hardware => "hardware",
         VideoEncoderBackend::Nvenc => "nvenc",
         VideoEncoderBackend::Vaapi => "vaapi",
-        VideoEncoderBackend::VideoToolbox => "video-toolbox",
+        VideoEncoderBackend::VideoToolbox => "videotoolbox",
         _ => "unknown",
     }
 }

--- a/examples/local_video/src/publisher.rs
+++ b/examples/local_video/src/publisher.rs
@@ -3,7 +3,7 @@ use clap::{Parser, ValueEnum};
 use livekit::e2ee::{key_provider::*, E2eeOptions, EncryptionType};
 use livekit::options::{
     self, video as video_presets, PacketTrailerFeatures, TrackPublishOptions, VideoCodec,
-    VideoEncoding, VideoPreset,
+    VideoEncoderBackend, VideoEncoding, VideoPreset,
 };
 use livekit::prelude::*;
 use livekit::webrtc::video_frame::{FrameMetadata, I420Buffer, VideoFrame, VideoRotation};
@@ -56,6 +56,43 @@ impl From<PublisherCodec> for VideoCodec {
             PublisherCodec::VP8 => VideoCodec::VP8,
             PublisherCodec::VP9 => VideoCodec::VP9,
             PublisherCodec::AV1 => VideoCodec::AV1,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+enum PublisherEncoder {
+    Auto,
+    Software,
+    Hardware,
+    Nvenc,
+    Vaapi,
+    #[value(alias = "videotoolbox")]
+    VideoToolbox,
+}
+
+impl PublisherEncoder {
+    fn as_str(&self) -> &'static str {
+        match self {
+            PublisherEncoder::Auto => "auto",
+            PublisherEncoder::Software => "software",
+            PublisherEncoder::Hardware => "hardware",
+            PublisherEncoder::Nvenc => "nvenc",
+            PublisherEncoder::Vaapi => "vaapi",
+            PublisherEncoder::VideoToolbox => "video-toolbox",
+        }
+    }
+}
+
+impl From<PublisherEncoder> for VideoEncoderBackend {
+    fn from(encoder: PublisherEncoder) -> Self {
+        match encoder {
+            PublisherEncoder::Auto => VideoEncoderBackend::Auto,
+            PublisherEncoder::Software => VideoEncoderBackend::Software,
+            PublisherEncoder::Hardware => VideoEncoderBackend::Hardware,
+            PublisherEncoder::Nvenc => VideoEncoderBackend::Nvenc,
+            PublisherEncoder::Vaapi => VideoEncoderBackend::Vaapi,
+            PublisherEncoder::VideoToolbox => VideoEncoderBackend::VideoToolbox,
         }
     }
 }
@@ -126,6 +163,10 @@ struct Args {
     /// Video codec to use for publishing
     #[arg(long, value_enum, default_value_t = PublisherCodec::H264)]
     codec: PublisherCodec,
+
+    /// Preferred video encoder backend to use for publishing
+    #[arg(long, value_enum, default_value_t = PublisherEncoder::Auto)]
+    encoder: PublisherEncoder,
 
     /// Attach the current system time (microseconds since UNIX epoch) as the user timestamp on each frame
     #[arg(long, default_value_t = false)]
@@ -703,7 +744,12 @@ async fn run(args: Args, ctrl_c_received: Arc<AtomicBool>) -> Result<()> {
 
     // Choose requested codec and attempt to publish; if H.265 fails, retry with H.264
     let requested_codec = VideoCodec::from(args.codec);
-    info!("Attempting publish with codec: {}", requested_codec.as_str());
+    let requested_encoder = VideoEncoderBackend::from(args.encoder);
+    info!(
+        "Attempting publish with codec: {}, encoder: {}",
+        requested_codec.as_str(),
+        args.encoder.as_str()
+    );
 
     // Compute an explicit video encoding so all simulcast layers use 30 fps.
     // The SDK defaults reduce lower layers to 15/20 fps; we override that here.
@@ -740,6 +786,7 @@ async fn run(args: Args, ctrl_c_received: Arc<AtomicBool>) -> Result<()> {
         source: TrackSource::Camera,
         simulcast: args.simulcast,
         video_codec: codec,
+        video_encoder: requested_encoder,
         packet_trailer_features,
         video_encoding: Some(main_encoding.clone()),
         simulcast_layers: Some(simulcast_presets.clone()),

--- a/examples/local_video/src/publisher.rs
+++ b/examples/local_video/src/publisher.rs
@@ -2,8 +2,8 @@ use anyhow::Result;
 use clap::{Parser, ValueEnum};
 use livekit::e2ee::{key_provider::*, E2eeOptions, EncryptionType};
 use livekit::options::{
-    self, video as video_presets, video_encoder_backend_list, PacketTrailerFeatures,
-    TrackPublishOptions, VideoCodec, VideoEncoderBackend, VideoEncoding, VideoPreset,
+    self, video as video_presets, PacketTrailerFeatures, TrackPublishOptions, VideoCodec,
+    VideoEncoderBackend, VideoEncoding, VideoPreset,
 };
 use livekit::prelude::*;
 use livekit::webrtc::video_frame::{FrameMetadata, I420Buffer, VideoFrame, VideoRotation};
@@ -551,7 +551,7 @@ fn list_cameras() -> Result<()> {
 
 fn list_encoders() {
     println!("Available video encoder backends:");
-    for backend in video_encoder_backend_list() {
+    for backend in VideoEncoderBackend::list_available() {
         println!("- {}", video_encoder_backend_name(backend));
     }
 }
@@ -772,7 +772,7 @@ async fn run(args: Args, ctrl_c_received: Arc<AtomicBool>) -> Result<()> {
     // Choose requested codec and attempt to publish; if H.265 fails, retry with H.264
     let requested_codec = VideoCodec::from(args.codec);
     let requested_encoder = VideoEncoderBackend::from(args.encoder);
-    let available_encoders = video_encoder_backend_list();
+    let available_encoders: Vec<_> = VideoEncoderBackend::list_available().into_iter().collect();
     info!(
         "Available video encoder backends: {}",
         available_encoders

--- a/examples/local_video/src/publisher.rs
+++ b/examples/local_video/src/publisher.rs
@@ -2,8 +2,8 @@ use anyhow::Result;
 use clap::{Parser, ValueEnum};
 use livekit::e2ee::{key_provider::*, E2eeOptions, EncryptionType};
 use livekit::options::{
-    self, video as video_presets, PacketTrailerFeatures, TrackPublishOptions, VideoCodec,
-    VideoEncoderBackend, VideoEncoding, VideoPreset,
+    self, video as video_presets, video_encoder_backend_list, PacketTrailerFeatures,
+    TrackPublishOptions, VideoCodec, VideoEncoderBackend, VideoEncoding, VideoPreset,
 };
 use livekit::prelude::*;
 use livekit::webrtc::video_frame::{FrameMetadata, I420Buffer, VideoFrame, VideoRotation};
@@ -97,6 +97,18 @@ impl From<PublisherEncoder> for VideoEncoderBackend {
     }
 }
 
+fn video_encoder_backend_name(backend: VideoEncoderBackend) -> &'static str {
+    match backend {
+        VideoEncoderBackend::Auto => "auto",
+        VideoEncoderBackend::Software => "software",
+        VideoEncoderBackend::Hardware => "hardware",
+        VideoEncoderBackend::Nvenc => "nvenc",
+        VideoEncoderBackend::Vaapi => "vaapi",
+        VideoEncoderBackend::VideoToolbox => "video-toolbox",
+        _ => "unknown",
+    }
+}
+
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
@@ -104,12 +116,16 @@ struct Args {
     #[arg(long)]
     list_cameras: bool,
 
+    /// List available video encoder backends and exit
+    #[arg(long)]
+    list_encoders: bool,
+
     /// Camera index to use (numeric)
     #[arg(long, default_value_t = 0)]
     camera_index: usize,
 
     /// Generate a standard SMPTE color-bar test pattern instead of using a camera
-    #[arg(long, default_value_t = false, conflicts_with = "list_cameras")]
+    #[arg(long, default_value_t = false, conflicts_with_all = ["list_cameras", "list_encoders"])]
     test_pattern: bool,
 
     /// Desired width
@@ -533,6 +549,13 @@ fn list_cameras() -> Result<()> {
     Ok(())
 }
 
+fn list_encoders() {
+    println!("Available video encoder backends:");
+    for backend in video_encoder_backend_list() {
+        println!("- {}", video_encoder_backend_name(backend));
+    }
+}
+
 enum VideoInput {
     TestPattern(TestPattern),
     Camera { camera: Camera, is_yuyv: bool },
@@ -583,6 +606,10 @@ async fn main() -> Result<()> {
 async fn run(args: Args, ctrl_c_received: Arc<AtomicBool>) -> Result<()> {
     if args.list_cameras {
         return list_cameras();
+    }
+    if args.list_encoders {
+        list_encoders();
+        return Ok(());
     }
 
     // LiveKit connection details
@@ -745,6 +772,21 @@ async fn run(args: Args, ctrl_c_received: Arc<AtomicBool>) -> Result<()> {
     // Choose requested codec and attempt to publish; if H.265 fails, retry with H.264
     let requested_codec = VideoCodec::from(args.codec);
     let requested_encoder = VideoEncoderBackend::from(args.encoder);
+    let available_encoders = video_encoder_backend_list();
+    info!(
+        "Available video encoder backends: {}",
+        available_encoders
+            .iter()
+            .map(|backend| video_encoder_backend_name(*backend))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    if !available_encoders.contains(&requested_encoder) {
+        log::warn!(
+            "Requested video encoder backend '{}' is not reported as available; libwebrtc may fall back to another compatible encoder",
+            args.encoder.as_str()
+        );
+    }
     info!(
         "Attempting publish with codec: {}, encoder: {}",
         requested_codec.as_str(),

--- a/libwebrtc/src/native/rtp_sender.rs
+++ b/libwebrtc/src/native/rtp_sender.rs
@@ -99,6 +99,24 @@ impl From<VideoEncoderBackend> for sys_webrtc::ffi::VideoEncoderBackend {
     }
 }
 
+impl From<sys_webrtc::ffi::VideoEncoderBackend> for VideoEncoderBackend {
+    fn from(value: sys_webrtc::ffi::VideoEncoderBackend) -> Self {
+        match value {
+            sys_webrtc::ffi::VideoEncoderBackend::Auto => Self::Auto,
+            sys_webrtc::ffi::VideoEncoderBackend::Software => Self::Software,
+            sys_webrtc::ffi::VideoEncoderBackend::Hardware => Self::Hardware,
+            sys_webrtc::ffi::VideoEncoderBackend::Nvenc => Self::Nvenc,
+            sys_webrtc::ffi::VideoEncoderBackend::Vaapi => Self::Vaapi,
+            sys_webrtc::ffi::VideoEncoderBackend::VideoToolbox => Self::VideoToolbox,
+            _ => panic!("unknown VideoEncoderBackend"),
+        }
+    }
+}
+
+pub fn video_encoder_backend_list() -> Vec<VideoEncoderBackend> {
+    sys_webrtc::ffi::video_encoder_backend_list().into_iter().map(Into::into).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::{sys_webrtc, VideoEncoderBackend};
@@ -116,6 +134,7 @@ mod tests {
 
         for (backend, expected) in cases {
             assert_eq!(sys_webrtc::ffi::VideoEncoderBackend::from(backend), expected);
+            assert_eq!(VideoEncoderBackend::from(expected), backend);
         }
     }
 }

--- a/libwebrtc/src/native/rtp_sender.rs
+++ b/libwebrtc/src/native/rtp_sender.rs
@@ -14,12 +14,12 @@
 
 use cxx::SharedPtr;
 use tokio::sync::oneshot;
-use webrtc_sys::{rtc_error as sys_err, rtp_sender as sys_rs};
+use webrtc_sys::{rtc_error as sys_err, rtp_sender as sys_rs, webrtc as sys_webrtc};
 
 use super::media_stream_track::new_media_stream_track;
 use crate::{
-    media_stream_track::MediaStreamTrack, rtp_parameters::RtpParameters, stats::RtcStats, RtcError,
-    RtcErrorType,
+    media_stream_track::MediaStreamTrack, rtp_parameters::RtpParameters,
+    rtp_sender::VideoEncoderBackend, stats::RtcStats, RtcError, RtcErrorType,
 };
 
 #[derive(Clone)]
@@ -79,5 +79,43 @@ impl RtpSender {
         self.sys_handle
             .set_parameters(parameters.into())
             .map_err(|e| unsafe { sys_err::ffi::RtcError::from(e.what()).into() })
+    }
+
+    pub fn set_video_encoder_backend(&self, backend: VideoEncoderBackend) {
+        self.sys_handle.set_video_encoder_backend(backend.into());
+    }
+}
+
+impl From<VideoEncoderBackend> for sys_webrtc::ffi::VideoEncoderBackend {
+    fn from(value: VideoEncoderBackend) -> Self {
+        match value {
+            VideoEncoderBackend::Auto => Self::Auto,
+            VideoEncoderBackend::Software => Self::Software,
+            VideoEncoderBackend::Hardware => Self::Hardware,
+            VideoEncoderBackend::Nvenc => Self::Nvenc,
+            VideoEncoderBackend::Vaapi => Self::Vaapi,
+            VideoEncoderBackend::VideoToolbox => Self::VideoToolbox,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{sys_webrtc, VideoEncoderBackend};
+
+    #[test]
+    fn video_encoder_backend_maps_to_native_enum() {
+        let cases = [
+            (VideoEncoderBackend::Auto, sys_webrtc::ffi::VideoEncoderBackend::Auto),
+            (VideoEncoderBackend::Software, sys_webrtc::ffi::VideoEncoderBackend::Software),
+            (VideoEncoderBackend::Hardware, sys_webrtc::ffi::VideoEncoderBackend::Hardware),
+            (VideoEncoderBackend::Nvenc, sys_webrtc::ffi::VideoEncoderBackend::Nvenc),
+            (VideoEncoderBackend::Vaapi, sys_webrtc::ffi::VideoEncoderBackend::Vaapi),
+            (VideoEncoderBackend::VideoToolbox, sys_webrtc::ffi::VideoEncoderBackend::VideoToolbox),
+        ];
+
+        for (backend, expected) in cases {
+            assert_eq!(sys_webrtc::ffi::VideoEncoderBackend::from(backend), expected);
+        }
     }
 }

--- a/libwebrtc/src/prelude.rs
+++ b/libwebrtc/src/prelude.rs
@@ -30,7 +30,7 @@ pub use crate::{
     },
     rtp_parameters::*,
     rtp_receiver::RtpReceiver,
-    rtp_sender::RtpSender,
+    rtp_sender::{RtpSender, VideoEncoderBackend},
     rtp_transceiver::{RtpTransceiver, RtpTransceiverDirection, RtpTransceiverInit},
     session_description::{SdpType, SessionDescription},
     video_frame::{

--- a/libwebrtc/src/rtp_sender.rs
+++ b/libwebrtc/src/rtp_sender.rs
@@ -19,6 +19,25 @@ use crate::{
     stats::RtcStats, RtcError,
 };
 
+/// Preferred backend for video encoding on an [`RtpSender`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum VideoEncoderBackend {
+    /// Use the SDK's default encoder selection.
+    #[default]
+    Auto,
+    /// Prefer a software encoder.
+    Software,
+    /// Prefer any available hardware encoder.
+    Hardware,
+    /// Prefer NVIDIA NVENC when available.
+    Nvenc,
+    /// Prefer VAAPI when available.
+    Vaapi,
+    /// Prefer VideoToolbox on Apple platforms when available.
+    VideoToolbox,
+}
+
 #[derive(Clone)]
 pub struct RtpSender {
     pub(crate) handle: imp_rs::RtpSender,
@@ -43,6 +62,14 @@ impl RtpSender {
 
     pub fn set_parameters(&self, parameters: RtpParameters) -> Result<(), RtcError> {
         self.handle.set_parameters(parameters)
+    }
+
+    /// Sets the preferred video encoder backend for this sender.
+    ///
+    /// If the requested backend is unavailable, libwebrtc falls back to another
+    /// compatible encoder.
+    pub fn set_video_encoder_backend(&self, backend: VideoEncoderBackend) {
+        self.handle.set_video_encoder_backend(backend)
     }
 }
 

--- a/libwebrtc/src/rtp_sender.rs
+++ b/libwebrtc/src/rtp_sender.rs
@@ -38,20 +38,22 @@ pub enum VideoEncoderBackend {
     VideoToolbox,
 }
 
-/// Returns video encoder backends available in this process.
-///
-/// The list reflects the current platform, build flags, and runtime hardware
-/// capability checks.
-///
-/// ```
-/// use libwebrtc::rtp_sender::{video_encoder_backend_list, VideoEncoderBackend};
-///
-/// let backends = video_encoder_backend_list();
-/// assert!(backends.contains(&VideoEncoderBackend::Auto));
-/// assert!(backends.contains(&VideoEncoderBackend::Software));
-/// ```
-pub fn video_encoder_backend_list() -> Vec<VideoEncoderBackend> {
-    imp_rs::video_encoder_backend_list()
+impl VideoEncoderBackend {
+    /// Returns the video encoder backends available in this process.
+    ///
+    /// The result reflects the current platform, build flags, and runtime
+    /// hardware capability checks.
+    ///
+    /// ```
+    /// use libwebrtc::rtp_sender::VideoEncoderBackend;
+    ///
+    /// let backends: Vec<_> = VideoEncoderBackend::list_available().into_iter().collect();
+    /// assert!(backends.contains(&VideoEncoderBackend::Auto));
+    /// assert!(backends.contains(&VideoEncoderBackend::Software));
+    /// ```
+    pub fn list_available() -> impl IntoIterator<Item = VideoEncoderBackend> {
+        imp_rs::video_encoder_backend_list()
+    }
 }
 
 #[derive(Clone)]

--- a/libwebrtc/src/rtp_sender.rs
+++ b/libwebrtc/src/rtp_sender.rs
@@ -38,6 +38,22 @@ pub enum VideoEncoderBackend {
     VideoToolbox,
 }
 
+/// Returns video encoder backends available in this process.
+///
+/// The list reflects the current platform, build flags, and runtime hardware
+/// capability checks.
+///
+/// ```
+/// use libwebrtc::rtp_sender::{video_encoder_backend_list, VideoEncoderBackend};
+///
+/// let backends = video_encoder_backend_list();
+/// assert!(backends.contains(&VideoEncoderBackend::Auto));
+/// assert!(backends.contains(&VideoEncoderBackend::Software));
+/// ```
+pub fn video_encoder_backend_list() -> Vec<VideoEncoderBackend> {
+    imp_rs::video_encoder_backend_list()
+}
+
 #[derive(Clone)]
 pub struct RtpSender {
     pub(crate) handle: imp_rs::RtpSender,

--- a/livekit-ffi-node-bindings/proto/room_pb.d.ts
+++ b/livekit-ffi-node-bindings/proto/room_pb.d.ts
@@ -84,6 +84,41 @@ export declare enum SimulateScenarioKind {
 }
 
 /**
+ * @generated from enum livekit.proto.VideoEncoderBackend
+ */
+export declare enum VideoEncoderBackend {
+  /**
+   * @generated from enum value: ENCODER_BACKEND_AUTO = 0;
+   */
+  ENCODER_BACKEND_AUTO = 0,
+
+  /**
+   * @generated from enum value: ENCODER_BACKEND_SOFTWARE = 1;
+   */
+  ENCODER_BACKEND_SOFTWARE = 1,
+
+  /**
+   * @generated from enum value: ENCODER_BACKEND_HARDWARE = 2;
+   */
+  ENCODER_BACKEND_HARDWARE = 2,
+
+  /**
+   * @generated from enum value: ENCODER_BACKEND_NVENC = 3;
+   */
+  ENCODER_BACKEND_NVENC = 3,
+
+  /**
+   * @generated from enum value: ENCODER_BACKEND_VAAPI = 4;
+   */
+  ENCODER_BACKEND_VAAPI = 4,
+
+  /**
+   * @generated from enum value: ENCODER_BACKEND_VIDEOTOOLBOX = 5;
+   */
+  ENCODER_BACKEND_VIDEOTOOLBOX = 5,
+}
+
+/**
  * @generated from enum livekit.proto.IceTransportType
  */
 export declare enum IceTransportType {
@@ -176,41 +211,6 @@ export declare enum DataPacketKind {
    * @generated from enum value: KIND_RELIABLE = 1;
    */
   KIND_RELIABLE = 1,
-}
-
-/**
- * @generated from enum livekit.proto.VideoEncoderBackend
- */
-export declare enum VideoEncoderBackend {
-  /**
-   * @generated from enum value: ENCODER_BACKEND_AUTO = 0;
-   */
-  ENCODER_BACKEND_AUTO = 0,
-
-  /**
-   * @generated from enum value: ENCODER_BACKEND_SOFTWARE = 1;
-   */
-  ENCODER_BACKEND_SOFTWARE = 1,
-
-  /**
-   * @generated from enum value: ENCODER_BACKEND_HARDWARE = 2;
-   */
-  ENCODER_BACKEND_HARDWARE = 2,
-
-  /**
-   * @generated from enum value: ENCODER_BACKEND_NVENC = 3;
-   */
-  ENCODER_BACKEND_NVENC = 3,
-
-  /**
-   * @generated from enum value: ENCODER_BACKEND_VAAPI = 4;
-   */
-  ENCODER_BACKEND_VAAPI = 4,
-
-  /**
-   * @generated from enum value: ENCODER_BACKEND_VIDEOTOOLBOX = 5;
-   */
-  ENCODER_BACKEND_VIDEOTOOLBOX = 5,
 }
 
 /**

--- a/livekit-ffi-node-bindings/proto/room_pb.d.ts
+++ b/livekit-ffi-node-bindings/proto/room_pb.d.ts
@@ -179,6 +179,41 @@ export declare enum DataPacketKind {
 }
 
 /**
+ * @generated from enum livekit.proto.VideoEncoderBackend
+ */
+export declare enum VideoEncoderBackend {
+  /**
+   * @generated from enum value: ENCODER_BACKEND_AUTO = 0;
+   */
+  ENCODER_BACKEND_AUTO = 0,
+
+  /**
+   * @generated from enum value: ENCODER_BACKEND_SOFTWARE = 1;
+   */
+  ENCODER_BACKEND_SOFTWARE = 1,
+
+  /**
+   * @generated from enum value: ENCODER_BACKEND_HARDWARE = 2;
+   */
+  ENCODER_BACKEND_HARDWARE = 2,
+
+  /**
+   * @generated from enum value: ENCODER_BACKEND_NVENC = 3;
+   */
+  ENCODER_BACKEND_NVENC = 3,
+
+  /**
+   * @generated from enum value: ENCODER_BACKEND_VAAPI = 4;
+   */
+  ENCODER_BACKEND_VAAPI = 4,
+
+  /**
+   * @generated from enum value: ENCODER_BACKEND_VIDEOTOOLBOX = 5;
+   */
+  ENCODER_BACKEND_VIDEOTOOLBOX = 5,
+}
+
+/**
  * Connect to a new LiveKit room
  *
  * @generated from message livekit.proto.ConnectRequest
@@ -1821,6 +1856,13 @@ export declare class TrackPublishOptions extends Message<TrackPublishOptions> {
    * @generated from field: optional string scalability_mode = 11;
    */
   scalabilityMode?: string;
+
+  /**
+   * Preferred encoder backend to use when publishing a video track.
+   *
+   * @generated from field: optional livekit.proto.VideoEncoderBackend video_encoder = 12;
+   */
+  videoEncoder?: VideoEncoderBackend;
 
   constructor(data?: PartialMessage<TrackPublishOptions>);
 

--- a/livekit-ffi-node-bindings/proto/room_pb.js
+++ b/livekit-ffi-node-bindings/proto/room_pb.js
@@ -112,6 +112,21 @@ const DataPacketKind = /*@__PURE__*/ proto2.makeEnum(
 );
 
 /**
+ * @generated from enum livekit.proto.VideoEncoderBackend
+ */
+const VideoEncoderBackend = /*@__PURE__*/ proto2.makeEnum(
+  "livekit.proto.VideoEncoderBackend",
+  [
+    {no: 0, name: "ENCODER_BACKEND_AUTO"},
+    {no: 1, name: "ENCODER_BACKEND_SOFTWARE"},
+    {no: 2, name: "ENCODER_BACKEND_HARDWARE"},
+    {no: 3, name: "ENCODER_BACKEND_NVENC"},
+    {no: 4, name: "ENCODER_BACKEND_VAAPI"},
+    {no: 5, name: "ENCODER_BACKEND_VIDEOTOOLBOX"},
+  ],
+);
+
+/**
  * Connect to a new LiveKit room
  *
  * @generated from message livekit.proto.ConnectRequest
@@ -716,6 +731,7 @@ const TrackPublishOptions = /*@__PURE__*/ proto2.makeMessageType(
     { no: 9, name: "preconnect_buffer", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
     { no: 10, name: "packet_trailer_features", kind: "enum", T: proto2.getEnumType(PacketTrailerFeature), repeated: true },
     { no: 11, name: "scalability_mode", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+    { no: 12, name: "video_encoder", kind: "enum", T: proto2.getEnumType(VideoEncoderBackend), opt: true },
   ],
 );
 
@@ -1622,6 +1638,7 @@ exports.ContinualGatheringPolicy = ContinualGatheringPolicy;
 exports.ConnectionQuality = ConnectionQuality;
 exports.ConnectionState = ConnectionState;
 exports.DataPacketKind = DataPacketKind;
+exports.VideoEncoderBackend = VideoEncoderBackend;
 exports.ConnectRequest = ConnectRequest;
 exports.ConnectResponse = ConnectResponse;
 exports.ConnectCallback = ConnectCallback;

--- a/livekit-ffi-node-bindings/proto/room_pb.js
+++ b/livekit-ffi-node-bindings/proto/room_pb.js
@@ -53,6 +53,21 @@ const SimulateScenarioKind = /*@__PURE__*/ proto2.makeEnum(
 );
 
 /**
+ * @generated from enum livekit.proto.VideoEncoderBackend
+ */
+const VideoEncoderBackend = /*@__PURE__*/ proto2.makeEnum(
+  "livekit.proto.VideoEncoderBackend",
+  [
+    {no: 0, name: "ENCODER_BACKEND_AUTO"},
+    {no: 1, name: "ENCODER_BACKEND_SOFTWARE"},
+    {no: 2, name: "ENCODER_BACKEND_HARDWARE"},
+    {no: 3, name: "ENCODER_BACKEND_NVENC"},
+    {no: 4, name: "ENCODER_BACKEND_VAAPI"},
+    {no: 5, name: "ENCODER_BACKEND_VIDEOTOOLBOX"},
+  ],
+);
+
+/**
  * @generated from enum livekit.proto.IceTransportType
  */
 const IceTransportType = /*@__PURE__*/ proto2.makeEnum(
@@ -108,21 +123,6 @@ const DataPacketKind = /*@__PURE__*/ proto2.makeEnum(
   [
     {no: 0, name: "KIND_LOSSY"},
     {no: 1, name: "KIND_RELIABLE"},
-  ],
-);
-
-/**
- * @generated from enum livekit.proto.VideoEncoderBackend
- */
-const VideoEncoderBackend = /*@__PURE__*/ proto2.makeEnum(
-  "livekit.proto.VideoEncoderBackend",
-  [
-    {no: 0, name: "ENCODER_BACKEND_AUTO"},
-    {no: 1, name: "ENCODER_BACKEND_SOFTWARE"},
-    {no: 2, name: "ENCODER_BACKEND_HARDWARE"},
-    {no: 3, name: "ENCODER_BACKEND_NVENC"},
-    {no: 4, name: "ENCODER_BACKEND_VAAPI"},
-    {no: 5, name: "ENCODER_BACKEND_VIDEOTOOLBOX"},
   ],
 );
 
@@ -1633,12 +1633,12 @@ const DataTrackUnpublished = /*@__PURE__*/ proto2.makeMessageType(
 
 
 exports.SimulateScenarioKind = SimulateScenarioKind;
+exports.VideoEncoderBackend = VideoEncoderBackend;
 exports.IceTransportType = IceTransportType;
 exports.ContinualGatheringPolicy = ContinualGatheringPolicy;
 exports.ConnectionQuality = ConnectionQuality;
 exports.ConnectionState = ConnectionState;
 exports.DataPacketKind = DataPacketKind;
-exports.VideoEncoderBackend = VideoEncoderBackend;
 exports.ConnectRequest = ConnectRequest;
 exports.ConnectResponse = ConnectResponse;
 exports.ConnectCallback = ConnectCallback;

--- a/livekit-ffi/protocol/room.proto
+++ b/livekit-ffi/protocol/room.proto
@@ -317,6 +317,17 @@ message TrackPublishOptions {
   // encoding is produced with this mode, enabling true SVC for codecs
   // that support it (VP9, AV1). Has no effect for VP8/H264.
   optional string scalability_mode = 11;
+  // Preferred encoder backend to use when publishing a video track.
+  optional VideoEncoderBackend video_encoder = 12;
+}
+
+enum VideoEncoderBackend {
+  ENCODER_BACKEND_AUTO = 0;
+  ENCODER_BACKEND_SOFTWARE = 1;
+  ENCODER_BACKEND_HARDWARE = 2;
+  ENCODER_BACKEND_NVENC = 3;
+  ENCODER_BACKEND_VAAPI = 4;
+  ENCODER_BACKEND_VIDEOTOOLBOX = 5;
 }
 
 enum IceTransportType {

--- a/livekit-ffi/src/conversion/room.rs
+++ b/livekit-ffi/src/conversion/room.rs
@@ -18,7 +18,10 @@ use livekit::{
         key_provider::{KeyProvider, KeyProviderOptions},
         E2eeOptions, EncryptionType,
     },
-    options::{AudioEncoding, PacketTrailerFeatures, TrackPublishOptions, VideoEncoding},
+    options::{
+        AudioEncoding, PacketTrailerFeatures, TrackPublishOptions, VideoEncoderBackend,
+        VideoEncoding,
+    },
     prelude::*,
     webrtc::{
         native::frame_cryptor::{EncryptionState, KeyDerivationAlgorithm},
@@ -45,6 +48,19 @@ fn packet_trailer_features_from_proto(features: Vec<i32>) -> PacketTrailerFeatur
     }
 
     packet_trailer_features
+}
+
+fn video_encoder_from_proto(backend: Option<i32>) -> Option<VideoEncoderBackend> {
+    match backend.and_then(|value| proto::VideoEncoderBackend::try_from(value).ok())? {
+        proto::VideoEncoderBackend::EncoderBackendAuto => Some(VideoEncoderBackend::Auto),
+        proto::VideoEncoderBackend::EncoderBackendSoftware => Some(VideoEncoderBackend::Software),
+        proto::VideoEncoderBackend::EncoderBackendHardware => Some(VideoEncoderBackend::Hardware),
+        proto::VideoEncoderBackend::EncoderBackendNvenc => Some(VideoEncoderBackend::Nvenc),
+        proto::VideoEncoderBackend::EncoderBackendVaapi => Some(VideoEncoderBackend::Vaapi),
+        proto::VideoEncoderBackend::EncoderBackendVideotoolbox => {
+            Some(VideoEncoderBackend::VideoToolbox)
+        }
+    }
 }
 
 impl From<EncryptionState> for proto::EncryptionState {
@@ -316,6 +332,8 @@ impl From<proto::TrackPublishOptions> for TrackPublishOptions {
             packet_trailer_features: packet_trailer_features_from_proto(
                 opts.packet_trailer_features,
             ),
+            video_encoder: video_encoder_from_proto(opts.video_encoder)
+                .unwrap_or(default_publish_options.video_encoder),
             scalability_mode: opts.scalability_mode,
         }
     }
@@ -335,7 +353,9 @@ impl From<proto::AudioEncoding> for AudioEncoding {
 
 #[cfg(test)]
 mod tests {
-    use super::packet_trailer_features_from_proto;
+    use livekit::options::{TrackPublishOptions, VideoEncoderBackend};
+
+    use super::{packet_trailer_features_from_proto, video_encoder_from_proto};
     use crate::proto;
 
     #[test]
@@ -355,6 +375,32 @@ mod tests {
 
         assert!(features.user_timestamp);
         assert!(features.frame_id);
+    }
+
+    #[test]
+    fn video_encoder_defaults_to_auto() {
+        let options = TrackPublishOptions::from(proto::TrackPublishOptions::default());
+
+        assert_eq!(options.video_encoder, VideoEncoderBackend::Auto);
+    }
+
+    #[test]
+    fn video_encoder_maps_known_values() {
+        let cases = [
+            (proto::VideoEncoderBackend::EncoderBackendAuto, VideoEncoderBackend::Auto),
+            (proto::VideoEncoderBackend::EncoderBackendSoftware, VideoEncoderBackend::Software),
+            (proto::VideoEncoderBackend::EncoderBackendHardware, VideoEncoderBackend::Hardware),
+            (proto::VideoEncoderBackend::EncoderBackendNvenc, VideoEncoderBackend::Nvenc),
+            (proto::VideoEncoderBackend::EncoderBackendVaapi, VideoEncoderBackend::Vaapi),
+            (
+                proto::VideoEncoderBackend::EncoderBackendVideotoolbox,
+                VideoEncoderBackend::VideoToolbox,
+            ),
+        ];
+
+        for (proto_backend, expected) in cases {
+            assert_eq!(video_encoder_from_proto(Some(proto_backend as i32)), Some(expected));
+        }
     }
 }
 

--- a/livekit/src/room/options.rs
+++ b/livekit/src/room/options.rs
@@ -17,6 +17,9 @@ use livekit_protocol as proto;
 
 use crate::prelude::*;
 
+/// Preferred backend for video encoding when publishing a video track.
+pub use libwebrtc::rtp_sender::VideoEncoderBackend;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum VideoCodec {
     VP8,
@@ -119,6 +122,11 @@ pub struct TrackPublishOptions {
     pub stream: String,
     pub preconnect_buffer: bool,
     pub packet_trailer_features: PacketTrailerFeatures,
+    /// Preferred encoder backend for video tracks published with these options.
+    ///
+    /// If the requested backend is unavailable, the SDK logs a warning and
+    /// falls back to another compatible encoder.
+    pub video_encoder: VideoEncoderBackend,
     /// RTP scalability mode (e.g. "L3T3_KEY"). When set, a single RTP
     /// encoding is produced and that mode is forwarded to libwebrtc to
     /// enable true SVC for VP9/AV1. Has no effect for VP8/H264.
@@ -139,6 +147,7 @@ impl Default for TrackPublishOptions {
             stream: "".to_string(),
             preconnect_buffer: false,
             packet_trailer_features: PacketTrailerFeatures::default(),
+            video_encoder: VideoEncoderBackend::Auto,
             scalability_mode: None,
         }
     }
@@ -406,6 +415,16 @@ pub fn video_layers_from_encodings(
 }
 
 const VIDEO_RIDS: &[char] = &['q', 'h', 'f'];
+
+#[cfg(test)]
+mod tests {
+    use super::{TrackPublishOptions, VideoEncoderBackend};
+
+    #[test]
+    fn track_publish_options_default_encoder_is_auto() {
+        assert_eq!(TrackPublishOptions::default().video_encoder, VideoEncoderBackend::Auto);
+    }
+}
 
 pub mod audio {
     use super::AudioPreset;

--- a/livekit/src/room/options.rs
+++ b/livekit/src/room/options.rs
@@ -17,6 +17,7 @@ use livekit_protocol as proto;
 
 use crate::prelude::*;
 
+pub use libwebrtc::rtp_sender::video_encoder_backend_list;
 /// Preferred backend for video encoding when publishing a video track.
 pub use libwebrtc::rtp_sender::VideoEncoderBackend;
 

--- a/livekit/src/room/options.rs
+++ b/livekit/src/room/options.rs
@@ -17,7 +17,6 @@ use livekit_protocol as proto;
 
 use crate::prelude::*;
 
-pub use libwebrtc::rtp_sender::video_encoder_backend_list;
 /// Preferred backend for video encoding when publishing a video track.
 pub use libwebrtc::rtp_sender::VideoEncoderBackend;
 
@@ -497,7 +496,6 @@ pub mod screenshare {
         )
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/livekit/src/room/options.rs
+++ b/livekit/src/room/options.rs
@@ -417,16 +417,6 @@ pub fn video_layers_from_encodings(
 
 const VIDEO_RIDS: &[char] = &['q', 'h', 'f'];
 
-#[cfg(test)]
-mod tests {
-    use super::{TrackPublishOptions, VideoEncoderBackend};
-
-    #[test]
-    fn track_publish_options_default_encoder_is_auto() {
-        assert_eq!(TrackPublishOptions::default().video_encoder, VideoEncoderBackend::Auto);
-    }
-}
-
 pub mod audio {
     use super::AudioPreset;
 
@@ -505,5 +495,16 @@ pub mod screenshare {
             ),
             FPS,
         )
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::{TrackPublishOptions, VideoEncoderBackend};
+
+    #[test]
+    fn track_publish_options_default_encoder_is_auto() {
+        assert_eq!(TrackPublishOptions::default().video_encoder, VideoEncoderBackend::Auto);
     }
 }

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -1623,6 +1623,8 @@ impl SessionInner {
             self.publisher_pc.peer_connection().add_transceiver(track.rtc_track(), init)?;
 
         if track.kind() == TrackKind::Video {
+            transceiver.sender().set_video_encoder_backend(options.video_encoder);
+
             let capabilities = LkRuntime::instance().pc_factory().get_rtp_sender_capabilities(
                 match track.kind() {
                     TrackKind::Video => MediaType::Video,

--- a/webrtc-sys/include/livekit/rtp_sender.h
+++ b/webrtc-sys/include/livekit/rtp_sender.h
@@ -65,6 +65,8 @@ class RtpSender {
 
   void set_parameters(RtpParameters params) const;
 
+  void set_video_encoder_backend(VideoEncoderBackend backend) const;
+
   webrtc::scoped_refptr<webrtc::RtpSenderInterface> rtc_sender() const {
     return sender_;
   }

--- a/webrtc-sys/include/livekit/video_encoder_factory.h
+++ b/webrtc-sys/include/livekit/video_encoder_factory.h
@@ -16,16 +16,30 @@
 
 #pragma once
 
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
 #include "api/video_codecs/video_encoder.h"
 #include "api/video_codecs/video_encoder_factory.h"
 
 namespace livekit_ffi {
+enum class VideoEncoderBackend : std::int32_t;
+
+struct VideoEncoderBackendFactory {
+  VideoEncoderBackend backend;
+  std::unique_ptr<webrtc::VideoEncoderFactory> factory;
+};
+
 class VideoEncoderFactory : public webrtc::VideoEncoderFactory {
   class InternalFactory : public webrtc::VideoEncoderFactory {
    public:
     InternalFactory();
 
     std::vector<webrtc::SdpVideoFormat> GetSupportedFormats() const override;
+
+    std::vector<webrtc::SdpVideoFormat> GetImplementations() const override;
 
     CodecSupport QueryCodecSupport(
         const webrtc::SdpVideoFormat& format,
@@ -35,13 +49,15 @@ class VideoEncoderFactory : public webrtc::VideoEncoderFactory {
         const webrtc::Environment& env, const webrtc::SdpVideoFormat& format) override;
 
    private:
-    std::vector<std::unique_ptr<webrtc::VideoEncoderFactory>> factories_;
+    std::vector<VideoEncoderBackendFactory> factories_;
   };
 
  public:
   VideoEncoderFactory();
 
   std::vector<webrtc::SdpVideoFormat> GetSupportedFormats() const override;
+
+  std::vector<webrtc::SdpVideoFormat> GetImplementations() const override;
 
   CodecSupport QueryCodecSupport(
       const webrtc::SdpVideoFormat& format,

--- a/webrtc-sys/include/livekit/webrtc.h
+++ b/webrtc-sys/include/livekit/webrtc.h
@@ -115,4 +115,6 @@ std::unique_ptr<LogSink> new_log_sink(
 
 rust::String create_random_uuid();
 
+rust::Vec<VideoEncoderBackend> video_encoder_backend_list();
+
 }  // namespace livekit_ffi

--- a/webrtc-sys/src/rtp_sender.cpp
+++ b/webrtc-sys/src/rtp_sender.cpp
@@ -17,11 +17,113 @@
 #include "livekit/rtp_sender.h"
 #include "livekit/jsep.h"
 
+#include <memory>
+#include <optional>
+
+#include "api/video_codecs/sdp_video_format.h"
+#include "api/video_codecs/video_encoder_factory.h"
 #include "rust/cxx.h"
+#include "rtc_base/logging.h"
 #include "webrtc-sys/src/rtp_sender.rs.h"
 
 namespace livekit_ffi {
 
+namespace {
+
+constexpr char kBackendParameter[] = "x-livekit-video-encoder-backend";
+
+const char* BackendName(VideoEncoderBackend backend) {
+  switch (backend) {
+    case VideoEncoderBackend::Auto:
+      return "auto";
+    case VideoEncoderBackend::Software:
+      return "software";
+    case VideoEncoderBackend::Hardware:
+      return "hardware";
+    case VideoEncoderBackend::Nvenc:
+      return "nvenc";
+    case VideoEncoderBackend::Vaapi:
+      return "vaapi";
+    case VideoEncoderBackend::VideoToolbox:
+      return "videotoolbox";
+  }
+}
+
+std::optional<VideoEncoderBackend> BackendFromFormat(
+    const webrtc::SdpVideoFormat& format) {
+  auto it = format.parameters.find(kBackendParameter);
+  if (it == format.parameters.end()) {
+    return std::nullopt;
+  }
+
+  if (it->second == BackendName(VideoEncoderBackend::Software)) {
+    return VideoEncoderBackend::Software;
+  }
+  if (it->second == BackendName(VideoEncoderBackend::Hardware)) {
+    return VideoEncoderBackend::Hardware;
+  }
+  if (it->second == BackendName(VideoEncoderBackend::Nvenc)) {
+    return VideoEncoderBackend::Nvenc;
+  }
+  if (it->second == BackendName(VideoEncoderBackend::Vaapi)) {
+    return VideoEncoderBackend::Vaapi;
+  }
+  if (it->second == BackendName(VideoEncoderBackend::VideoToolbox)) {
+    return VideoEncoderBackend::VideoToolbox;
+  }
+
+  return std::nullopt;
+}
+
+webrtc::SdpVideoFormat WithBackend(
+    const webrtc::SdpVideoFormat& format,
+    VideoEncoderBackend backend) {
+  webrtc::SdpVideoFormat tagged = format;
+  tagged.parameters[kBackendParameter] = BackendName(backend);
+  return tagged;
+}
+
+class FixedVideoEncoderSelector final
+    : public webrtc::VideoEncoderFactory::EncoderSelectorInterface {
+ public:
+  explicit FixedVideoEncoderSelector(VideoEncoderBackend backend)
+      : backend_(backend) {}
+
+  void OnCurrentEncoder(const webrtc::SdpVideoFormat& format) override {
+    current_encoder_ = format;
+    requested_ = BackendFromFormat(format) == backend_;
+  }
+
+  std::optional<webrtc::SdpVideoFormat> OnAvailableBitrate(
+      const webrtc::DataRate& /* rate */) override {
+    return SelectEncoder();
+  }
+
+  std::optional<webrtc::SdpVideoFormat> OnResolutionChange(
+      const webrtc::RenderResolution& /* resolution */) override {
+    return SelectEncoder();
+  }
+
+  std::optional<webrtc::SdpVideoFormat> OnEncoderBroken() override {
+    return std::nullopt;
+  }
+
+ private:
+  std::optional<webrtc::SdpVideoFormat> SelectEncoder() {
+    if (requested_ || !current_encoder_) {
+      return std::nullopt;
+    }
+
+    requested_ = true;
+    return WithBackend(*current_encoder_, backend_);
+  }
+
+  VideoEncoderBackend backend_;
+  bool requested_ = false;
+  std::optional<webrtc::SdpVideoFormat> current_encoder_;
+};
+
+}  // namespace
 
 
 RtpSender::RtpSender(
@@ -88,6 +190,23 @@ void RtpSender::set_parameters(RtpParameters params) const {
   auto error = sender_->SetParameters(to_native_rtp_parameters(params));
   if (!error.ok())
     throw std::runtime_error(serialize_error(to_error(error)));
+}
+
+void RtpSender::set_video_encoder_backend(VideoEncoderBackend backend) const {
+  if (sender_->media_type() != webrtc::MediaType::VIDEO) {
+    RTC_LOG(LS_WARNING)
+        << "Ignoring video encoder backend preference on non-video sender.";
+    return;
+  }
+
+  if (backend == VideoEncoderBackend::Auto) {
+    sender_->SetEncoderSelector(
+        std::unique_ptr<webrtc::VideoEncoderFactory::EncoderSelectorInterface>());
+    return;
+  }
+
+  sender_->SetEncoderSelector(
+      std::make_unique<FixedVideoEncoderSelector>(backend));
 }
 
 }  // namespace livekit_ffi

--- a/webrtc-sys/src/rtp_sender.rs
+++ b/webrtc-sys/src/rtp_sender.rs
@@ -18,13 +18,13 @@ use crate::impl_thread_safety;
 
 #[cxx::bridge(namespace = "livekit_ffi")]
 pub mod ffi {
-
     extern "C++" {
         include!("livekit/webrtc.h");
         include!("livekit/rtp_parameters.h");
         include!("livekit/media_stream.h");
 
         type MediaType = crate::webrtc::ffi::MediaType;
+        type VideoEncoderBackend = crate::webrtc::ffi::VideoEncoderBackend;
         type RtpEncodingParameters = crate::rtp_parameters::ffi::RtpEncodingParameters;
         type RtpParameters = crate::rtp_parameters::ffi::RtpParameters;
         type MediaStreamTrack = crate::media_stream::ffi::MediaStreamTrack;
@@ -50,6 +50,7 @@ pub mod ffi {
         fn init_send_encodings(self: &RtpSender) -> Vec<RtpEncodingParameters>;
         fn get_parameters(self: &RtpSender) -> RtpParameters;
         fn set_parameters(self: &RtpSender, parameters: RtpParameters) -> Result<()>;
+        fn set_video_encoder_backend(self: &RtpSender, backend: VideoEncoderBackend);
 
         fn _shared_rtp_sender() -> SharedPtr<RtpSender>;
     }

--- a/webrtc-sys/src/video_encoder_factory.cpp
+++ b/webrtc-sys/src/video_encoder_factory.cpp
@@ -17,7 +17,9 @@
 #include "livekit/video_encoder_factory.h"
 
 #include <cstdlib>
+#include <optional>
 #include <string_view>
+#include <utility>
 
 #include "api/environment/environment_factory.h"
 #include "api/video_codecs/sdp_video_format.h"
@@ -50,9 +52,19 @@
 
 namespace livekit_ffi {
 
+enum class VideoEncoderBackend : std::int32_t {
+  Auto,
+  Software,
+  Hardware,
+  Nvenc,
+  Vaapi,
+  VideoToolbox,
+};
+
 namespace {
 
 constexpr char kPreferredHwEncoderEnv[] = "LIVEKIT_PREFERRED_HW_ENCODER";
+constexpr char kBackendParameter[] = "x-livekit-video-encoder-backend";
 
 enum class PreferredHwEncoder {
   kNvenc,
@@ -63,6 +75,84 @@ struct PreferredHwEncoderConfig {
   PreferredHwEncoder encoder = PreferredHwEncoder::kNvenc;
   bool explicitly_set = false;
 };
+
+const char* BackendName(VideoEncoderBackend backend) {
+  switch (backend) {
+    case VideoEncoderBackend::Auto:
+      return "auto";
+    case VideoEncoderBackend::Software:
+      return "software";
+    case VideoEncoderBackend::Hardware:
+      return "hardware";
+    case VideoEncoderBackend::Nvenc:
+      return "nvenc";
+    case VideoEncoderBackend::Vaapi:
+      return "vaapi";
+    case VideoEncoderBackend::VideoToolbox:
+      return "videotoolbox";
+  }
+}
+
+std::optional<VideoEncoderBackend> BackendFromFormat(
+    const webrtc::SdpVideoFormat& format) {
+  auto it = format.parameters.find(kBackendParameter);
+  if (it == format.parameters.end()) {
+    return std::nullopt;
+  }
+
+  if (it->second == BackendName(VideoEncoderBackend::Software)) {
+    return VideoEncoderBackend::Software;
+  }
+  if (it->second == BackendName(VideoEncoderBackend::Hardware)) {
+    return VideoEncoderBackend::Hardware;
+  }
+  if (it->second == BackendName(VideoEncoderBackend::Nvenc)) {
+    return VideoEncoderBackend::Nvenc;
+  }
+  if (it->second == BackendName(VideoEncoderBackend::Vaapi)) {
+    return VideoEncoderBackend::Vaapi;
+  }
+  if (it->second == BackendName(VideoEncoderBackend::VideoToolbox)) {
+    return VideoEncoderBackend::VideoToolbox;
+  }
+
+  return std::nullopt;
+}
+
+webrtc::SdpVideoFormat StripBackendParameter(
+    const webrtc::SdpVideoFormat& format) {
+  webrtc::SdpVideoFormat stripped = format;
+  stripped.parameters.erase(kBackendParameter);
+  return stripped;
+}
+
+webrtc::SdpVideoFormat WithBackend(
+    const webrtc::SdpVideoFormat& format,
+    VideoEncoderBackend backend) {
+  webrtc::SdpVideoFormat tagged = format;
+  tagged.parameters[kBackendParameter] = BackendName(backend);
+  return tagged;
+}
+
+bool IsSpecificHardwareBackend(VideoEncoderBackend backend) {
+  return backend == VideoEncoderBackend::Nvenc ||
+         backend == VideoEncoderBackend::Vaapi ||
+         backend == VideoEncoderBackend::VideoToolbox;
+}
+
+bool BackendMatches(VideoEncoderBackend requested, VideoEncoderBackend actual) {
+  return requested == actual ||
+         (requested == VideoEncoderBackend::Hardware &&
+          actual != VideoEncoderBackend::Software &&
+          actual != VideoEncoderBackend::Auto);
+}
+
+void AddBackendFactory(
+    std::vector<VideoEncoderBackendFactory>& factories,
+    VideoEncoderBackend backend,
+    std::unique_ptr<webrtc::VideoEncoderFactory> factory) {
+  factories.push_back(VideoEncoderBackendFactory{backend, std::move(factory)});
+}
 
 PreferredHwEncoderConfig GetPreferredHwEncoderConfig() {
   const char* preferred_encoder = std::getenv(kPreferredHwEncoderEnv);
@@ -85,11 +175,14 @@ PreferredHwEncoderConfig GetPreferredHwEncoderConfig() {
 }
 
 void AddNvencFactory(
-    std::vector<std::unique_ptr<webrtc::VideoEncoderFactory>>& factories,
+    std::vector<VideoEncoderBackendFactory>& factories,
     bool preferred) {
 #if defined(USE_NVIDIA_VIDEO_CODEC)
   if (webrtc::NvidiaVideoEncoderFactory::IsSupported()) {
-    factories.push_back(std::make_unique<webrtc::NvidiaVideoEncoderFactory>());
+    AddBackendFactory(
+        factories,
+        VideoEncoderBackend::Nvenc,
+        std::make_unique<webrtc::NvidiaVideoEncoderFactory>());
     return;
   }
 
@@ -108,11 +201,14 @@ void AddNvencFactory(
 }
 
 void AddVaapiFactory(
-    std::vector<std::unique_ptr<webrtc::VideoEncoderFactory>>& factories,
+    std::vector<VideoEncoderBackendFactory>& factories,
     bool preferred) {
 #if defined(USE_VAAPI_VIDEO_CODEC)
   if (webrtc::VAAPIVideoEncoderFactory::IsSupported()) {
-    factories.push_back(std::make_unique<webrtc::VAAPIVideoEncoderFactory>());
+    AddBackendFactory(
+        factories,
+        VideoEncoderBackend::Vaapi,
+        std::make_unique<webrtc::VAAPIVideoEncoderFactory>());
     return;
   }
 
@@ -144,11 +240,17 @@ using Factory = webrtc::VideoEncoderFactoryTemplate<
 
 VideoEncoderFactory::InternalFactory::InternalFactory() {
 #ifdef __APPLE__
-  factories_.push_back(livekit_ffi::CreateObjCVideoEncoderFactory());
+  AddBackendFactory(
+      factories_,
+      VideoEncoderBackend::VideoToolbox,
+      livekit_ffi::CreateObjCVideoEncoderFactory());
 #endif
 
 #ifdef WEBRTC_ANDROID
-  factories_.push_back(CreateAndroidVideoEncoderFactory());
+  AddBackendFactory(
+      factories_,
+      VideoEncoderBackend::Hardware,
+      CreateAndroidVideoEncoderFactory());
 #endif
 
   const PreferredHwEncoderConfig preferred_hw_encoder =
@@ -166,11 +268,30 @@ std::vector<webrtc::SdpVideoFormat>
 VideoEncoderFactory::InternalFactory::GetSupportedFormats() const {
   std::vector<webrtc::SdpVideoFormat> formats = Factory().GetSupportedFormats();
 
-  for (const auto& factory : factories_) {
-    auto supported_formats = factory->GetSupportedFormats();
+  for (const auto& backend_factory : factories_) {
+    auto supported_formats = backend_factory.factory->GetSupportedFormats();
     formats.insert(formats.end(), supported_formats.begin(),
                    supported_formats.end());
   }
+  return formats;
+}
+
+std::vector<webrtc::SdpVideoFormat>
+VideoEncoderFactory::InternalFactory::GetImplementations() const {
+  std::vector<webrtc::SdpVideoFormat> formats;
+  for (const auto& backend_factory : factories_) {
+    for (const auto& format : backend_factory.factory->GetImplementations()) {
+      formats.push_back(WithBackend(format, backend_factory.backend));
+      if (IsSpecificHardwareBackend(backend_factory.backend)) {
+        formats.push_back(WithBackend(format, VideoEncoderBackend::Hardware));
+      }
+    }
+  }
+
+  for (const auto& format : Factory().GetImplementations()) {
+    formats.push_back(WithBackend(format, VideoEncoderBackend::Software));
+  }
+
   return formats;
 }
 
@@ -178,32 +299,129 @@ VideoEncoderFactory::CodecSupport
 VideoEncoderFactory::InternalFactory::QueryCodecSupport(
     const webrtc::SdpVideoFormat& format,
     std::optional<std::string> scalability_mode) const {
+  auto requested_backend = BackendFromFormat(format);
+  auto stripped_format = StripBackendParameter(format);
+  if (requested_backend == VideoEncoderBackend::Software) {
+    auto original_format =
+        webrtc::FuzzyMatchSdpVideoFormat(Factory().GetSupportedFormats(),
+                                         stripped_format);
+    auto support =
+        original_format
+            ? Factory().QueryCodecSupport(*original_format, scalability_mode)
+            : webrtc::VideoEncoderFactory::CodecSupport{.is_supported = false};
+    if (support.is_supported) {
+      return support;
+    }
+  } else if (requested_backend &&
+             *requested_backend != VideoEncoderBackend::Software &&
+             *requested_backend != VideoEncoderBackend::Auto) {
+    for (const auto& backend_factory : factories_) {
+      if (!BackendMatches(*requested_backend, backend_factory.backend)) {
+        continue;
+      }
+
+      for (const auto& supported_format :
+           backend_factory.factory->GetSupportedFormats()) {
+        if (stripped_format.IsSameCodec(supported_format)) {
+          return webrtc::VideoEncoderFactory::CodecSupport{
+              .is_supported = true,
+              .is_power_efficient = true,
+          };
+        }
+      }
+    }
+  }
+
   auto original_format =
-      webrtc::FuzzyMatchSdpVideoFormat(Factory().GetSupportedFormats(), format);
-  return original_format
-             ? Factory().QueryCodecSupport(*original_format, scalability_mode)
-             : webrtc::VideoEncoderFactory::CodecSupport{.is_supported = false};
+      webrtc::FuzzyMatchSdpVideoFormat(Factory().GetSupportedFormats(),
+                                       stripped_format);
+  auto support =
+      original_format
+          ? Factory().QueryCodecSupport(*original_format, scalability_mode)
+          : webrtc::VideoEncoderFactory::CodecSupport{.is_supported = false};
+  if (support.is_supported) {
+    return support;
+  }
+
+  for (const auto& backend_factory : factories_) {
+    for (const auto& supported_format :
+         backend_factory.factory->GetSupportedFormats()) {
+      if (stripped_format.IsSameCodec(supported_format)) {
+        return webrtc::VideoEncoderFactory::CodecSupport{
+            .is_supported = true,
+            .is_power_efficient = true,
+        };
+      }
+    }
+  }
+
+  return support;
 }
 
 std::unique_ptr<webrtc::VideoEncoder>
 VideoEncoderFactory::InternalFactory::Create(
     const webrtc::Environment& env,
     const webrtc::SdpVideoFormat& format) {
-  for (const auto& factory : factories_) {
-    for (const auto& supported_format : factory->GetSupportedFormats()) {
-      if (supported_format.IsSameCodec(format))
-        return factory->Create(env, format);
+  auto requested_backend = BackendFromFormat(format);
+  auto stripped_format = StripBackendParameter(format);
+  bool requested_backend_unavailable = false;
+
+  if (requested_backend == VideoEncoderBackend::Software) {
+    auto original_format =
+        webrtc::FuzzyMatchSdpVideoFormat(Factory().GetSupportedFormats(),
+                                         stripped_format);
+    if (original_format) {
+      auto encoder = Factory().Create(env, *original_format);
+      if (encoder) {
+        return encoder;
+      }
+    }
+    requested_backend_unavailable = true;
+  } else if (requested_backend &&
+             *requested_backend != VideoEncoderBackend::Auto) {
+    for (const auto& backend_factory : factories_) {
+      if (!BackendMatches(*requested_backend, backend_factory.backend)) {
+        continue;
+      }
+
+      for (const auto& supported_format :
+           backend_factory.factory->GetSupportedFormats()) {
+        if (supported_format.IsSameCodec(stripped_format)) {
+          auto encoder = backend_factory.factory->Create(env, stripped_format);
+          if (encoder) {
+            return encoder;
+          }
+        }
+      }
+    }
+
+    requested_backend_unavailable = true;
+  }
+
+  if (requested_backend_unavailable) {
+    RTC_LOG(LS_WARNING) << "Requested video encoder backend "
+                        << BackendName(*requested_backend)
+                        << " is unavailable for " << stripped_format.name
+                        << "; falling back to another compatible encoder.";
+  }
+
+  for (const auto& backend_factory : factories_) {
+    for (const auto& supported_format :
+         backend_factory.factory->GetSupportedFormats()) {
+      if (supported_format.IsSameCodec(stripped_format))
+        return backend_factory.factory->Create(env, stripped_format);
     }
   }
 
   auto original_format =
-      webrtc::FuzzyMatchSdpVideoFormat(Factory().GetSupportedFormats(), format);
+      webrtc::FuzzyMatchSdpVideoFormat(Factory().GetSupportedFormats(),
+                                       stripped_format);
 
   if (original_format) {
     return Factory().Create(env, *original_format);
   }
 
-  RTC_LOG(LS_ERROR) << "No VideoEncoder found for " << format.name;
+  RTC_LOG(LS_ERROR) << "No VideoEncoder found for " << stripped_format.name;
   return nullptr;
 }
 
@@ -214,6 +432,11 @@ VideoEncoderFactory::VideoEncoderFactory() {
 std::vector<webrtc::SdpVideoFormat> VideoEncoderFactory::GetSupportedFormats()
     const {
   return internal_factory_->GetSupportedFormats();
+}
+
+std::vector<webrtc::SdpVideoFormat> VideoEncoderFactory::GetImplementations()
+    const {
+  return internal_factory_->GetImplementations();
 }
 
 VideoEncoderFactory::CodecSupport VideoEncoderFactory::QueryCodecSupport(

--- a/webrtc-sys/src/video_encoder_factory.cpp
+++ b/webrtc-sys/src/video_encoder_factory.cpp
@@ -26,9 +26,11 @@
 #include "api/video_codecs/video_encoder.h"
 #include "api/video_codecs/video_encoder_factory_template.h"
 #include "livekit/objc_video_factory.h"
+#include "livekit/webrtc.h"
 #include "media/base/media_constants.h"
 #include "media/engine/simulcast_encoder_adapter.h"
 #include "rtc_base/logging.h"
+#include "rust/cxx.h"
 #if defined(RTC_USE_LIBAOM_AV1_ENCODER)
 #include "api/video_codecs/video_encoder_factory_template_libaom_av1_adapter.h"
 #endif
@@ -51,15 +53,6 @@
 #endif
 
 namespace livekit_ffi {
-
-enum class VideoEncoderBackend : std::int32_t {
-  Auto,
-  Software,
-  Hardware,
-  Nvenc,
-  Vaapi,
-  VideoToolbox,
-};
 
 namespace {
 
@@ -237,6 +230,46 @@ using Factory = webrtc::VideoEncoderFactoryTemplate<
     webrtc::LibaomAv1EncoderTemplateAdapter,
 #endif
     webrtc::LibvpxVp9EncoderTemplateAdapter>;
+
+rust::Vec<VideoEncoderBackend> video_encoder_backend_list() {
+  rust::Vec<VideoEncoderBackend> backends;
+  backends.push_back(VideoEncoderBackend::Auto);
+  backends.push_back(VideoEncoderBackend::Software);
+
+  bool has_hardware_backend = false;
+  bool hardware_backend_listed = false;
+
+#ifdef __APPLE__
+  backends.push_back(VideoEncoderBackend::VideoToolbox);
+  has_hardware_backend = true;
+#endif
+
+#ifdef WEBRTC_ANDROID
+  backends.push_back(VideoEncoderBackend::Hardware);
+  has_hardware_backend = true;
+  hardware_backend_listed = true;
+#endif
+
+#if defined(USE_NVIDIA_VIDEO_CODEC)
+  if (webrtc::NvidiaVideoEncoderFactory::IsSupported()) {
+    backends.push_back(VideoEncoderBackend::Nvenc);
+    has_hardware_backend = true;
+  }
+#endif
+
+#if defined(USE_VAAPI_VIDEO_CODEC)
+  if (webrtc::VAAPIVideoEncoderFactory::IsSupported()) {
+    backends.push_back(VideoEncoderBackend::Vaapi);
+    has_hardware_backend = true;
+  }
+#endif
+
+  if (has_hardware_backend && !hardware_backend_listed) {
+    backends.push_back(VideoEncoderBackend::Hardware);
+  }
+
+  return backends;
+}
 
 VideoEncoderFactory::InternalFactory::InternalFactory() {
 #ifdef __APPLE__

--- a/webrtc-sys/src/video_encoder_factory.cpp
+++ b/webrtc-sys/src/video_encoder_factory.cpp
@@ -16,9 +16,7 @@
 
 #include "livekit/video_encoder_factory.h"
 
-#include <cstdlib>
 #include <optional>
-#include <string_view>
 #include <utility>
 
 #include "api/environment/environment_factory.h"
@@ -56,18 +54,7 @@ namespace livekit_ffi {
 
 namespace {
 
-constexpr char kPreferredHwEncoderEnv[] = "LIVEKIT_PREFERRED_HW_ENCODER";
 constexpr char kBackendParameter[] = "x-livekit-video-encoder-backend";
-
-enum class PreferredHwEncoder {
-  kNvenc,
-  kVaapi,
-};
-
-struct PreferredHwEncoderConfig {
-  PreferredHwEncoder encoder = PreferredHwEncoder::kNvenc;
-  bool explicitly_set = false;
-};
 
 const char* BackendName(VideoEncoderBackend backend) {
   switch (backend) {
@@ -147,29 +134,8 @@ void AddBackendFactory(
   factories.push_back(VideoEncoderBackendFactory{backend, std::move(factory)});
 }
 
-PreferredHwEncoderConfig GetPreferredHwEncoderConfig() {
-  const char* preferred_encoder = std::getenv(kPreferredHwEncoderEnv);
-  if (!preferred_encoder) {
-    return {};
-  }
-
-  std::string_view preferred_encoder_view(preferred_encoder);
-  if (preferred_encoder_view == "nvenc") {
-    return {PreferredHwEncoder::kNvenc, true};
-  }
-  if (preferred_encoder_view == "vaapi") {
-    return {PreferredHwEncoder::kVaapi, true};
-  }
-
-  RTC_LOG(LS_WARNING) << "Ignoring invalid LIVEKIT_PREFERRED_HW_ENCODER=\""
-                      << preferred_encoder
-                      << "\"; expected \"nvenc\" or \"vaapi\".";
-  return {};
-}
-
 void AddNvencFactory(
-    std::vector<VideoEncoderBackendFactory>& factories,
-    bool preferred) {
+    std::vector<VideoEncoderBackendFactory>& factories) {
 #if defined(USE_NVIDIA_VIDEO_CODEC)
   if (webrtc::NvidiaVideoEncoderFactory::IsSupported()) {
     AddBackendFactory(
@@ -178,24 +144,13 @@ void AddNvencFactory(
         std::make_unique<webrtc::NvidiaVideoEncoderFactory>());
     return;
   }
-
-  if (preferred) {
-    RTC_LOG(LS_WARNING)
-        << "LIVEKIT_PREFERRED_HW_ENCODER=nvenc requested, but NVENC "
-           "is unavailable; falling back to other encoders.";
-  }
 #else
-  if (preferred) {
-    RTC_LOG(LS_WARNING)
-        << "LIVEKIT_PREFERRED_HW_ENCODER=nvenc requested, but NVENC support "
-           "is not compiled in; falling back to other encoders.";
-  }
+  (void)factories;
 #endif
 }
 
 void AddVaapiFactory(
-    std::vector<VideoEncoderBackendFactory>& factories,
-    bool preferred) {
+    std::vector<VideoEncoderBackendFactory>& factories) {
 #if defined(USE_VAAPI_VIDEO_CODEC)
   if (webrtc::VAAPIVideoEncoderFactory::IsSupported()) {
     AddBackendFactory(
@@ -204,18 +159,8 @@ void AddVaapiFactory(
         std::make_unique<webrtc::VAAPIVideoEncoderFactory>());
     return;
   }
-
-  if (preferred) {
-    RTC_LOG(LS_WARNING)
-        << "LIVEKIT_PREFERRED_HW_ENCODER=vaapi requested, but VAAPI "
-           "is unavailable; falling back to other encoders.";
-  }
 #else
-  if (preferred) {
-    RTC_LOG(LS_WARNING)
-        << "LIVEKIT_PREFERRED_HW_ENCODER=vaapi requested, but VAAPI support "
-           "is not compiled in; falling back to other encoders.";
-  }
+  (void)factories;
 #endif
 }
 
@@ -286,15 +231,8 @@ VideoEncoderFactory::InternalFactory::InternalFactory() {
       CreateAndroidVideoEncoderFactory());
 #endif
 
-  const PreferredHwEncoderConfig preferred_hw_encoder =
-      GetPreferredHwEncoderConfig();
-  if (preferred_hw_encoder.encoder == PreferredHwEncoder::kVaapi) {
-    AddVaapiFactory(factories_, preferred_hw_encoder.explicitly_set);
-    AddNvencFactory(factories_, false);
-  } else {
-    AddNvencFactory(factories_, preferred_hw_encoder.explicitly_set);
-    AddVaapiFactory(factories_, false);
-  }
+  AddNvencFactory(factories_);
+  AddVaapiFactory(factories_);
 }
 
 std::vector<webrtc::SdpVideoFormat>

--- a/webrtc-sys/src/webrtc.rs
+++ b/webrtc-sys/src/webrtc.rs
@@ -54,6 +54,17 @@ pub mod ffi {
         None,
     }
 
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[repr(i32)]
+    pub enum VideoEncoderBackend {
+        Auto,
+        Software,
+        Hardware,
+        Nvenc,
+        Vaapi,
+        VideoToolbox,
+    }
+
     unsafe extern "C++" {
         include!("livekit/webrtc.h");
 

--- a/webrtc-sys/src/webrtc.rs
+++ b/webrtc-sys/src/webrtc.rs
@@ -71,6 +71,7 @@ pub mod ffi {
         type LogSink;
 
         fn create_random_uuid() -> String;
+        fn video_encoder_backend_list() -> Vec<VideoEncoderBackend>;
         fn new_log_sink(fnc: fn(String, LoggingSeverity)) -> UniquePtr<LogSink>;
     }
 }


### PR DESCRIPTION
- Add field to `TrackPublishOptions` that allows the user to set a preferred video encoder when there are multiple options.
- Options can be `auto`, `software`, `hardware`, `nvenc`, `vaapi`, `videotoolbox`.  