### PR TITLE
Add max round trip latency

### DIFF
--- a/.changeset/add_max_round_trip_latency.md
+++ b/.changeset/add_max_round_trip_latency.md
@@ -1,0 +1,6 @@
+---
+livekit: patch
+livekit-ffi: patch
+---
+
+Add rpc max_round_trip_latency and move to builder pattern - #1127 (@1egoman)

--- a/.changeset/add_max_round_trip_latency.md
+++ b/.changeset/add_max_round_trip_latency.md
@@ -1,5 +1,5 @@
 ---
-livekit: patch
+livekit: minor
 livekit-ffi: patch
 ---
 

--- a/examples/rpc/src/main.rs
+++ b/examples/rpc/src/main.rs
@@ -153,11 +153,10 @@ async fn register_receiver_methods(greeters_room: Arc<Room>, math_genius_room: A
 
                 match math_genius_room
                     .local_participant()
-                    .perform_rpc(PerformRpcData::new(
-                        data.caller_identity.clone(),
-                        "provide-intermediate",
-                        json!({"original": number}).to_string(),
-                    ))
+                    .perform_rpc(
+                        PerformRpcData::new(data.caller_identity.clone(), "provide-intermediate")
+                            .with_payload(json!({"original": number}).to_string()),
+                    )
                     .await
                 {
                     Ok(intermediate_response) => {
@@ -188,7 +187,7 @@ async fn perform_greeting(room: &Arc<Room>) -> Result<(), Box<dyn std::error::Er
     println!("[{}] Letting the greeter know that I've arrived", elapsed_time());
     match room
         .local_participant()
-        .perform_rpc(PerformRpcData::new("greeter", "arrival", "Hello"))
+        .perform_rpc(PerformRpcData::new("greeter", "arrival").with_payload("Hello"))
         .await
     {
         Ok(response) => {
@@ -203,11 +202,10 @@ async fn perform_square_root(room: &Arc<Room>) -> Result<(), Box<dyn std::error:
     println!("[{}] What's the square root of 16?", elapsed_time());
     match room
         .local_participant()
-        .perform_rpc(PerformRpcData::new(
-            "math-genius",
-            "square-root",
-            json!({"number": 16}).to_string(),
-        ))
+        .perform_rpc(
+            PerformRpcData::new("math-genius", "square-root")
+                .with_payload(json!({"number": 16}).to_string()),
+        )
         .await
     {
         Ok(response) => {
@@ -225,11 +223,10 @@ async fn perform_quantum_hypergeometric_series(
     println!("[{}] What's the quantum hypergeometric series of 42?", elapsed_time());
     match room
         .local_participant()
-        .perform_rpc(PerformRpcData::new(
-            "math-genius",
-            "quantum-hypergeometric-series",
-            json!({"number": 42}).to_string(),
-        ))
+        .perform_rpc(
+            PerformRpcData::new("math-genius", "quantum-hypergeometric-series")
+                .with_payload(json!({"number": 42}).to_string()),
+        )
         .await
     {
         Ok(response) => {
@@ -251,11 +248,10 @@ async fn perform_division(room: &Arc<Room>) -> Result<(), Box<dyn std::error::Er
     println!("[{}] Let's try dividing 5 by 0", elapsed_time());
     match room
         .local_participant()
-        .perform_rpc(PerformRpcData::new(
-            "math-genius",
-            "divide",
-            json!({"dividend": 5, "divisor": 0}).to_string(),
-        ))
+        .perform_rpc(
+            PerformRpcData::new("math-genius", "divide")
+                .with_payload(json!({"dividend": 5, "divisor": 0}).to_string()),
+        )
         .await
     {
         Ok(response) => {
@@ -290,11 +286,10 @@ async fn perform_nested_calculation(room: &Arc<Room>) -> Result<(), Box<dyn std:
     println!("[{}] Starting nested calculation with value 5", elapsed_time());
     match room
         .local_participant()
-        .perform_rpc(PerformRpcData::new(
-            "math-genius",
-            "nested-calculation",
-            json!({"number": 5.0}).to_string(),
-        ))
+        .perform_rpc(
+            PerformRpcData::new("math-genius", "nested-calculation")
+                .with_payload(json!({"number": 5.0}).to_string()),
+        )
         .await
     {
         Ok(response) => {

--- a/examples/rpc/src/main.rs
+++ b/examples/rpc/src/main.rs
@@ -154,9 +154,9 @@ async fn register_receiver_methods(greeters_room: Arc<Room>, math_genius_room: A
                 match math_genius_room
                     .local_participant()
                     .perform_rpc(PerformRpcData::new(
-                        &data.caller_identity.to_string(),
+                        data.caller_identity.clone(),
                         "provide-intermediate",
-                        &json!({"original": number}).to_string(),
+                        json!({"original": number}).to_string(),
                     ))
                     .await
                 {
@@ -206,7 +206,7 @@ async fn perform_square_root(room: &Arc<Room>) -> Result<(), Box<dyn std::error:
         .perform_rpc(PerformRpcData::new(
             "math-genius",
             "square-root",
-            &json!({"number": 16}).to_string(),
+            json!({"number": 16}).to_string(),
         ))
         .await
     {
@@ -228,7 +228,7 @@ async fn perform_quantum_hypergeometric_series(
         .perform_rpc(PerformRpcData::new(
             "math-genius",
             "quantum-hypergeometric-series",
-            &json!({"number": 42}).to_string(),
+            json!({"number": 42}).to_string(),
         ))
         .await
     {
@@ -254,7 +254,7 @@ async fn perform_division(room: &Arc<Room>) -> Result<(), Box<dyn std::error::Er
         .perform_rpc(PerformRpcData::new(
             "math-genius",
             "divide",
-            &json!({"dividend": 5, "divisor": 0}).to_string(),
+            json!({"dividend": 5, "divisor": 0}).to_string(),
         ))
         .await
     {
@@ -293,7 +293,7 @@ async fn perform_nested_calculation(room: &Arc<Room>) -> Result<(), Box<dyn std:
         .perform_rpc(PerformRpcData::new(
             "math-genius",
             "nested-calculation",
-            &json!({"number": 5.0}).to_string(),
+            json!({"number": 5.0}).to_string(),
         ))
         .await
     {

--- a/examples/rpc/src/main.rs
+++ b/examples/rpc/src/main.rs
@@ -153,12 +153,11 @@ async fn register_receiver_methods(greeters_room: Arc<Room>, math_genius_room: A
 
                 match math_genius_room
                     .local_participant()
-                    .perform_rpc(PerformRpcData {
-                        destination_identity: data.caller_identity.to_string(),
-                        method: "provide-intermediate".to_string(),
-                        payload: json!({"original": number}).to_string(),
-                        ..Default::default()
-                    })
+                    .perform_rpc(PerformRpcData::new(
+                        &data.caller_identity.to_string(),
+                        "provide-intermediate",
+                        &json!({"original": number}).to_string(),
+                    ))
                     .await
                 {
                     Ok(intermediate_response) => {
@@ -189,12 +188,7 @@ async fn perform_greeting(room: &Arc<Room>) -> Result<(), Box<dyn std::error::Er
     println!("[{}] Letting the greeter know that I've arrived", elapsed_time());
     match room
         .local_participant()
-        .perform_rpc(PerformRpcData {
-            destination_identity: "greeter".to_string(),
-            method: "arrival".to_string(),
-            payload: "Hello".to_string(),
-            ..Default::default()
-        })
+        .perform_rpc(PerformRpcData::new("greeter", "arrival", "Hello"))
         .await
     {
         Ok(response) => {
@@ -209,12 +203,11 @@ async fn perform_square_root(room: &Arc<Room>) -> Result<(), Box<dyn std::error:
     println!("[{}] What's the square root of 16?", elapsed_time());
     match room
         .local_participant()
-        .perform_rpc(PerformRpcData {
-            destination_identity: "math-genius".to_string(),
-            method: "square-root".to_string(),
-            payload: json!({"number": 16}).to_string(),
-            ..Default::default()
-        })
+        .perform_rpc(PerformRpcData::new(
+            "math-genius",
+            "square-root",
+            &json!({"number": 16}).to_string(),
+        ))
         .await
     {
         Ok(response) => {
@@ -232,12 +225,11 @@ async fn perform_quantum_hypergeometric_series(
     println!("[{}] What's the quantum hypergeometric series of 42?", elapsed_time());
     match room
         .local_participant()
-        .perform_rpc(PerformRpcData {
-            destination_identity: "math-genius".to_string(),
-            method: "quantum-hypergeometric-series".to_string(),
-            payload: json!({"number": 42}).to_string(),
-            ..Default::default()
-        })
+        .perform_rpc(PerformRpcData::new(
+            "math-genius",
+            "quantum-hypergeometric-series",
+            &json!({"number": 42}).to_string(),
+        ))
         .await
     {
         Ok(response) => {
@@ -259,12 +251,11 @@ async fn perform_division(room: &Arc<Room>) -> Result<(), Box<dyn std::error::Er
     println!("[{}] Let's try dividing 5 by 0", elapsed_time());
     match room
         .local_participant()
-        .perform_rpc(PerformRpcData {
-            destination_identity: "math-genius".to_string(),
-            method: "divide".to_string(),
-            payload: json!({"dividend": 5, "divisor": 0}).to_string(),
-            ..Default::default()
-        })
+        .perform_rpc(PerformRpcData::new(
+            "math-genius",
+            "divide",
+            &json!({"dividend": 5, "divisor": 0}).to_string(),
+        ))
         .await
     {
         Ok(response) => {
@@ -299,12 +290,11 @@ async fn perform_nested_calculation(room: &Arc<Room>) -> Result<(), Box<dyn std:
     println!("[{}] Starting nested calculation with value 5", elapsed_time());
     match room
         .local_participant()
-        .perform_rpc(PerformRpcData {
-            destination_identity: "math-genius".to_string(),
-            method: "nested-calculation".to_string(),
-            payload: json!({"number": 5.0}).to_string(),
-            ..Default::default()
-        })
+        .perform_rpc(PerformRpcData::new(
+            "math-genius",
+            "nested-calculation",
+            &json!({"number": 5.0}).to_string(),
+        ))
         .await
     {
         Ok(response) => {

--- a/examples/wgpu_room/src/service.rs
+++ b/examples/wgpu_room/src/service.rs
@@ -208,12 +208,7 @@ async fn service_task(inner: Arc<ServiceInner>, mut cmd_rx: mpsc::UnboundedRecei
                     let ui_tx = inner.ui_tx.clone();
                     tokio::spawn(async move {
                         let result = local
-                            .perform_rpc(PerformRpcData {
-                                destination_identity: destination,
-                                method,
-                                payload,
-                                ..Default::default()
-                            })
+                            .perform_rpc(PerformRpcData::new(&destination, &method, &payload))
                             .await;
                         let _ = ui_tx.send(UiCmd::RpcSendResult { request_id, result });
                     });

--- a/examples/wgpu_room/src/service.rs
+++ b/examples/wgpu_room/src/service.rs
@@ -208,7 +208,7 @@ async fn service_task(inner: Arc<ServiceInner>, mut cmd_rx: mpsc::UnboundedRecei
                     let ui_tx = inner.ui_tx.clone();
                     tokio::spawn(async move {
                         let result = local
-                            .perform_rpc(PerformRpcData::new(&destination, &method, &payload))
+                            .perform_rpc(PerformRpcData::new(destination, method, payload))
                             .await;
                         let _ = ui_tx.send(UiCmd::RpcSendResult { request_id, result });
                     });

--- a/examples/wgpu_room/src/service.rs
+++ b/examples/wgpu_room/src/service.rs
@@ -208,7 +208,9 @@ async fn service_task(inner: Arc<ServiceInner>, mut cmd_rx: mpsc::UnboundedRecei
                     let ui_tx = inner.ui_tx.clone();
                     tokio::spawn(async move {
                         let result = local
-                            .perform_rpc(PerformRpcData::new(destination, method, payload))
+                            .perform_rpc(
+                                PerformRpcData::new(destination, method).with_payload(payload),
+                            )
                             .await;
                         let _ = ui_tx.send(UiCmd::RpcSendResult { request_id, result });
                     });

--- a/livekit-ffi-node-bindings/proto/rpc_pb.d.ts
+++ b/livekit-ffi-node-bindings/proto/rpc_pb.d.ts
@@ -90,6 +90,11 @@ export declare class PerformRpcRequest extends Message<PerformRpcRequest> {
    */
   requestAsyncId?: bigint;
 
+  /**
+   * @generated from field: optional uint32 max_round_trip_latency_ms = 7;
+   */
+  maxRoundTripLatencyMs?: number;
+
   constructor(data?: PartialMessage<PerformRpcRequest>);
 
   static readonly runtime: typeof proto2;

--- a/livekit-ffi-node-bindings/proto/rpc_pb.js
+++ b/livekit-ffi-node-bindings/proto/rpc_pb.js
@@ -48,6 +48,7 @@ const PerformRpcRequest = /*@__PURE__*/ proto2.makeMessageType(
     { no: 4, name: "payload", kind: "scalar", T: 9 /* ScalarType.STRING */, req: true },
     { no: 5, name: "response_timeout_ms", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
     { no: 6, name: "request_async_id", kind: "scalar", T: 4 /* ScalarType.UINT64 */, opt: true },
+    { no: 7, name: "max_round_trip_latency_ms", kind: "scalar", T: 13 /* ScalarType.UINT32 */, opt: true },
   ],
 );
 

--- a/livekit-ffi/protocol/rpc.proto
+++ b/livekit-ffi/protocol/rpc.proto
@@ -31,6 +31,7 @@ message PerformRpcRequest {
   required string payload = 4;
   optional uint32 response_timeout_ms = 5;
   optional uint64 request_async_id = 6;
+  optional uint32 max_round_trip_latency_ms = 7;
 }
 
 message RegisterRpcMethodRequest {

--- a/livekit-ffi/src/server/participant.rs
+++ b/livekit-ffi/src/server/participant.rs
@@ -60,7 +60,7 @@ impl FfiParticipant {
 
         let handle = server.async_runtime.spawn(async move {
             let mut data =
-                PerformRpcData::new(&request.destination_identity, &request.method, &request.payload);
+                PerformRpcData::new(request.destination_identity, request.method, request.payload);
             if let Some(ms) = request.response_timeout_ms {
                 data = data.with_response_timeout(Duration::from_millis(ms as u64));
             }

--- a/livekit-ffi/src/server/participant.rs
+++ b/livekit-ffi/src/server/participant.rs
@@ -59,8 +59,8 @@ impl FfiParticipant {
         let local = self.guard_local_participant()?;
 
         let handle = server.async_runtime.spawn(async move {
-            let mut data =
-                PerformRpcData::new(request.destination_identity, request.method, request.payload);
+            let mut data = PerformRpcData::new(request.destination_identity, request.method)
+                .with_payload(request.payload);
             if let Some(ms) = request.response_timeout_ms {
                 data = data.with_response_timeout(Duration::from_millis(ms as u64));
             }

--- a/livekit-ffi/src/server/participant.rs
+++ b/livekit-ffi/src/server/participant.rs
@@ -59,21 +59,15 @@ impl FfiParticipant {
         let local = self.guard_local_participant()?;
 
         let handle = server.async_runtime.spawn(async move {
-            let result = local
-                .perform_rpc(PerformRpcData {
-                    destination_identity: request.destination_identity.to_string(),
-                    method: request.method,
-                    payload: request.payload,
-                    response_timeout: request
-                        .response_timeout_ms
-                        .map(|ms| Duration::from_millis(ms as u64))
-                        .unwrap_or(PerformRpcData::default().response_timeout),
-                    max_round_trip_latency: request
-                        .max_round_trip_latency_ms
-                        .map(|ms| Duration::from_millis(ms as u64))
-                        .unwrap_or(PerformRpcData::default().max_round_trip_latency),
-                })
-                .await;
+            let mut data =
+                PerformRpcData::new(&request.destination_identity, &request.method, &request.payload);
+            if let Some(ms) = request.response_timeout_ms {
+                data = data.with_response_timeout(Duration::from_millis(ms as u64));
+            }
+            if let Some(ms) = request.max_round_trip_latency_ms {
+                data = data.with_max_round_trip_latency(Duration::from_millis(ms as u64));
+            }
+            let result = local.perform_rpc(data).await;
 
             let callback = proto::PerformRpcCallback {
                 async_id,

--- a/livekit-ffi/src/server/participant.rs
+++ b/livekit-ffi/src/server/participant.rs
@@ -68,6 +68,10 @@ impl FfiParticipant {
                         .response_timeout_ms
                         .map(|ms| Duration::from_millis(ms as u64))
                         .unwrap_or(PerformRpcData::default().response_timeout),
+                    max_round_trip_latency: request
+                        .max_round_trip_latency_ms
+                        .map(|ms| Duration::from_millis(ms as u64))
+                        .unwrap_or(PerformRpcData::default().max_round_trip_latency),
                 })
                 .await;
 

--- a/livekit/src/prelude.rs
+++ b/livekit/src/prelude.rs
@@ -24,6 +24,7 @@ pub use crate::{
     participant::{
         ConnectionQuality, DisconnectReason, LocalParticipant, Participant, PerformRpcData,
         RemoteParticipant, RpcError, RpcErrorCode, RpcInvocationData,
+        DEFAULT_MAX_ROUND_TRIP_LATENCY,
     },
     publication::{LocalTrackPublication, RemoteTrackPublication, TrackPublication},
     track::{

--- a/livekit/src/prelude.rs
+++ b/livekit/src/prelude.rs
@@ -24,7 +24,6 @@ pub use crate::{
     participant::{
         ConnectionQuality, DisconnectReason, LocalParticipant, Participant, PerformRpcData,
         RemoteParticipant, RpcError, RpcErrorCode, RpcInvocationData,
-        DEFAULT_MAX_ROUND_TRIP_LATENCY,
     },
     publication::{LocalTrackPublication, RemoteTrackPublication, TrackPublication},
     track::{

--- a/livekit/src/room/id.rs
+++ b/livekit/src/room/id.rs
@@ -38,6 +38,12 @@ impl From<String> for ParticipantIdentity {
     }
 }
 
+impl From<&str> for ParticipantIdentity {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
 macro_rules! impl_string_into {
     ($from:ty) => {
         impl From<$from> for String {

--- a/livekit/src/room/rpc/client.rs
+++ b/livekit/src/room/rpc/client.rs
@@ -66,7 +66,8 @@ impl RpcClientManager {
         }
 
         // Determine transport version based on remote participant's client_protocol
-        let remote_protocol = transport.remote_client_protocol(&data.destination_identity);
+        let remote_protocol = transport
+            .remote_client_protocol(&ParticipantIdentity(data.destination_identity.clone()));
         let use_v2 = remote_protocol >= CLIENT_PROTOCOL_DATA_STREAM_RPC;
 
         // Only enforce payload size limit for v1 transport

--- a/livekit/src/room/rpc/client.rs
+++ b/livekit/src/room/rpc/client.rs
@@ -54,7 +54,7 @@ impl RpcClientManager {
         data: PerformRpcData,
         transport: &(impl RpcTransport + 'static),
     ) -> Result<String, RpcError> {
-        let max_round_trip_latency = Duration::from_millis(7000);
+        let max_round_trip_latency = data.max_round_trip_latency;
         let min_effective_timeout = Duration::from_millis(1000);
 
         if let Some(version_str) = transport.server_version() {

--- a/livekit/src/room/rpc/client.rs
+++ b/livekit/src/room/rpc/client.rs
@@ -66,8 +66,7 @@ impl RpcClientManager {
         }
 
         // Determine transport version based on remote participant's client_protocol
-        let remote_protocol = transport
-            .remote_client_protocol(&ParticipantIdentity(data.destination_identity.clone()));
+        let remote_protocol = transport.remote_client_protocol(&data.destination_identity);
         let use_v2 = remote_protocol >= CLIENT_PROTOCOL_DATA_STREAM_RPC;
 
         // Only enforce payload size limit for v1 transport
@@ -95,7 +94,7 @@ impl RpcClientManager {
         let send_result = if use_v2 {
             self.send_v2_request(
                 transport,
-                &data.destination_identity,
+                data.destination_identity.as_str(),
                 &id,
                 &data.method,
                 &data.payload,
@@ -105,7 +104,7 @@ impl RpcClientManager {
         } else {
             self.send_v1_request(
                 transport,
-                &data.destination_identity,
+                data.destination_identity.as_str(),
                 &id,
                 &data.method,
                 &data.payload,

--- a/livekit/src/room/rpc/mod.rs
+++ b/livekit/src/room/rpc/mod.rs
@@ -107,7 +107,7 @@ impl RpcTransport for SessionTransport {
 /// Parameters for performing an RPC call
 #[derive(Debug, Clone)]
 pub struct PerformRpcData {
-    destination_identity: String,
+    destination_identity: ParticipantIdentity,
     method: String,
     payload: String,
     response_timeout: Duration,
@@ -115,7 +115,11 @@ pub struct PerformRpcData {
 }
 
 impl PerformRpcData {
-    pub fn new(destination_identity: &str, method: &str, payload: &str) -> Self {
+    pub fn new(
+        destination_identity: impl Into<ParticipantIdentity>,
+        method: impl Into<String>,
+        payload: impl Into<String>,
+    ) -> Self {
         let mut perform_rpc_data = Self::default();
         perform_rpc_data.destination_identity = destination_identity.into();
         perform_rpc_data.method = method.into();
@@ -123,15 +127,18 @@ impl PerformRpcData {
         perform_rpc_data
     }
 
-    pub fn with_destination_identity(mut self, destination_identity: &str) -> Self {
+    pub fn with_destination_identity(
+        mut self,
+        destination_identity: impl Into<ParticipantIdentity>,
+    ) -> Self {
         self.destination_identity = destination_identity.into();
         self
     }
-    pub fn with_method(mut self, method: &str) -> Self {
+    pub fn with_method(mut self, method: impl Into<String>) -> Self {
         self.method = method.into();
         self
     }
-    pub fn with_payload(mut self, payload: &str) -> Self {
+    pub fn with_payload(mut self, payload: impl Into<String>) -> Self {
         self.payload = payload.into();
         self
     }

--- a/livekit/src/room/rpc/mod.rs
+++ b/livekit/src/room/rpc/mod.rs
@@ -31,12 +31,6 @@ use std::{error::Error, fmt::Display, future::Future, time::Duration};
 pub(crate) const RPC_VERSION_V1: u32 = 1;
 pub(crate) const RPC_VERSION_V2: u32 = 2;
 
-/// Default maximum amount of time it should ever take for an RPC request to reach the
-/// destination and for the ACK to come back. Set to 7 seconds to account for various
-/// relay timeouts and retries in LiveKit Cloud that occur in rare cases. Most callers
-/// should not need to change this.
-pub const DEFAULT_MAX_ROUND_TRIP_LATENCY: Duration = Duration::from_secs(7);
-
 // Data stream topic constants for RPC v2
 pub(crate) const RPC_REQUEST_TOPIC: &str = "lk.rpc_request";
 pub(crate) const RPC_RESPONSE_TOPIC: &str = "lk.rpc_response";
@@ -113,16 +107,47 @@ impl RpcTransport for SessionTransport {
 /// Parameters for performing an RPC call
 #[derive(Debug, Clone)]
 pub struct PerformRpcData {
-    pub destination_identity: String,
-    pub method: String,
-    pub payload: String,
-    pub response_timeout: Duration,
+    destination_identity: String,
+    method: String,
+    payload: String,
+    response_timeout: Duration,
+    max_round_trip_latency: Duration,
+}
+
+impl PerformRpcData {
+    fn new(destination_identity: &str, method: &str, payload: &str) -> Self {
+        let mut perform_rpc_data = Self::default();
+        perform_rpc_data.destination_identity = destination_identity.into();
+        perform_rpc_data.method = method.into();
+        perform_rpc_data.payload = payload.into();
+        perform_rpc_data
+    }
+
+    fn with_destination_identity(mut self, destination_identity: &str) -> Self {
+        self.destination_identity = destination_identity.into();
+        self
+    }
+    fn with_method(mut self, method: &str) -> Self {
+        self.method = method.into();
+        self
+    }
+    fn with_payload(mut self, payload: &str) -> Self {
+        self.payload = payload.into();
+        self
+    }
+    fn with_response_timeout(mut self, response_timeout: Duration) -> Self {
+        self.response_timeout = response_timeout;
+        self
+    }
+
     /// Maximum amount of time it should ever take for an RPC request to reach the
-    /// destination and for the ACK to come back. Defaults to
-    /// [`DEFAULT_MAX_ROUND_TRIP_LATENCY`] (7 seconds). Most callers should not need
+    /// destination and for the ACK to come back. Most callers should not need
     /// to change this, but it can be increased to tolerate high-latency networks where
     /// RPC requests are backed up behind other messages on the data channel.
-    pub max_round_trip_latency: Duration,
+    fn with_max_round_trip_latency(mut self, max_round_trip_latency: Duration) -> Self {
+        self.max_round_trip_latency = max_round_trip_latency;
+        self
+    }
 }
 
 impl Default for PerformRpcData {
@@ -132,7 +157,7 @@ impl Default for PerformRpcData {
             method: Default::default(),
             payload: Default::default(),
             response_timeout: Duration::from_secs(15),
-            max_round_trip_latency: DEFAULT_MAX_ROUND_TRIP_LATENCY,
+            max_round_trip_latency: Duration::from_secs(7),
         }
     }
 }

--- a/livekit/src/room/rpc/mod.rs
+++ b/livekit/src/room/rpc/mod.rs
@@ -115,7 +115,7 @@ pub struct PerformRpcData {
 }
 
 impl PerformRpcData {
-    fn new(destination_identity: &str, method: &str, payload: &str) -> Self {
+    pub fn new(destination_identity: &str, method: &str, payload: &str) -> Self {
         let mut perform_rpc_data = Self::default();
         perform_rpc_data.destination_identity = destination_identity.into();
         perform_rpc_data.method = method.into();
@@ -123,19 +123,22 @@ impl PerformRpcData {
         perform_rpc_data
     }
 
-    fn with_destination_identity(mut self, destination_identity: &str) -> Self {
+    pub fn with_destination_identity(mut self, destination_identity: &str) -> Self {
         self.destination_identity = destination_identity.into();
         self
     }
-    fn with_method(mut self, method: &str) -> Self {
+    pub fn with_method(mut self, method: &str) -> Self {
         self.method = method.into();
         self
     }
-    fn with_payload(mut self, payload: &str) -> Self {
+    pub fn with_payload(mut self, payload: &str) -> Self {
         self.payload = payload.into();
         self
     }
-    fn with_response_timeout(mut self, response_timeout: Duration) -> Self {
+
+    /// The maximum time the caller will wait for a response after the request has been
+    /// acknowledged by the remote. Defaults to 15 seconds.
+    pub fn with_response_timeout(mut self, response_timeout: Duration) -> Self {
         self.response_timeout = response_timeout;
         self
     }
@@ -144,7 +147,8 @@ impl PerformRpcData {
     /// destination and for the ACK to come back. Most callers should not need
     /// to change this, but it can be increased to tolerate high-latency networks where
     /// RPC requests are backed up behind other messages on the data channel.
-    fn with_max_round_trip_latency(mut self, max_round_trip_latency: Duration) -> Self {
+    /// Defaults to 7 seconds.
+    pub fn with_max_round_trip_latency(mut self, max_round_trip_latency: Duration) -> Self {
         self.max_round_trip_latency = max_round_trip_latency;
         self
     }

--- a/livekit/src/room/rpc/mod.rs
+++ b/livekit/src/room/rpc/mod.rs
@@ -107,11 +107,11 @@ impl RpcTransport for SessionTransport {
 /// Parameters for performing an RPC call
 #[derive(Debug, Clone)]
 pub struct PerformRpcData {
-    destination_identity: ParticipantIdentity,
-    method: String,
-    payload: String,
-    response_timeout: Duration,
-    max_round_trip_latency: Duration,
+    pub destination_identity: String,
+    pub method: String,
+    pub payload: String,
+    pub response_timeout: Duration,
+    pub max_round_trip_latency: Duration,
 }
 
 impl PerformRpcData {

--- a/livekit/src/room/rpc/mod.rs
+++ b/livekit/src/room/rpc/mod.rs
@@ -31,6 +31,12 @@ use std::{error::Error, fmt::Display, future::Future, time::Duration};
 pub(crate) const RPC_VERSION_V1: u32 = 1;
 pub(crate) const RPC_VERSION_V2: u32 = 2;
 
+/// Default maximum amount of time it should ever take for an RPC request to reach the
+/// destination and for the ACK to come back. Set to 7 seconds to account for various
+/// relay timeouts and retries in LiveKit Cloud that occur in rare cases. Most callers
+/// should not need to change this.
+pub const DEFAULT_MAX_ROUND_TRIP_LATENCY: Duration = Duration::from_secs(7);
+
 // Data stream topic constants for RPC v2
 pub(crate) const RPC_REQUEST_TOPIC: &str = "lk.rpc_request";
 pub(crate) const RPC_RESPONSE_TOPIC: &str = "lk.rpc_response";
@@ -111,6 +117,12 @@ pub struct PerformRpcData {
     pub method: String,
     pub payload: String,
     pub response_timeout: Duration,
+    /// Maximum amount of time it should ever take for an RPC request to reach the
+    /// destination and for the ACK to come back. Defaults to
+    /// [`DEFAULT_MAX_ROUND_TRIP_LATENCY`] (7 seconds). Most callers should not need
+    /// to change this, but it can be increased to tolerate high-latency networks where
+    /// RPC requests are backed up behind other messages on the data channel.
+    pub max_round_trip_latency: Duration,
 }
 
 impl Default for PerformRpcData {
@@ -120,6 +132,7 @@ impl Default for PerformRpcData {
             method: Default::default(),
             payload: Default::default(),
             response_timeout: Duration::from_secs(15),
+            max_round_trip_latency: DEFAULT_MAX_ROUND_TRIP_LATENCY,
         }
     }
 }

--- a/livekit/src/room/rpc/mod.rs
+++ b/livekit/src/room/rpc/mod.rs
@@ -118,20 +118,16 @@ impl PerformRpcData {
     pub fn new(
         destination_identity: impl Into<ParticipantIdentity>,
         method: impl Into<String>,
-        payload: impl Into<String>,
     ) -> Self {
-        let mut perform_rpc_data = Self::default();
-        perform_rpc_data.destination_identity = destination_identity.into();
-        perform_rpc_data.method = method.into();
-        perform_rpc_data.payload = payload.into();
-        perform_rpc_data
+        Self::default().with_destination_identity(destination_identity).with_method(method)
     }
 
     pub fn with_destination_identity(
         mut self,
         destination_identity: impl Into<ParticipantIdentity>,
     ) -> Self {
-        self.destination_identity = destination_identity.into();
+        let identity: ParticipantIdentity = destination_identity.into();
+        self.destination_identity = identity.into();
         self
     }
     pub fn with_method(mut self, method: impl Into<String>) -> Self {

--- a/livekit/src/room/rpc/tests.rs
+++ b/livekit/src/room/rpc/tests.rs
@@ -277,7 +277,7 @@ async fn test_v2_v2_caller_happy_path_large_payload() {
     let handle = spawn_perform_rpc(
         client.clone(),
         transport.clone(),
-        PerformRpcData::new("dest", "big", &large_payload)
+        PerformRpcData::new("dest", "big", large_payload)
             .with_response_timeout(Duration::from_secs(5)),
     )
     .await;
@@ -532,7 +532,7 @@ async fn test_v2_v1_payload_too_large() {
     let large_payload = "x".repeat(MAX_V1_PAYLOAD_BYTES + 1);
     let result = client
         .perform_rpc(
-            PerformRpcData::new("dest", "big", &large_payload)
+            PerformRpcData::new("dest", "big", large_payload)
                 .with_response_timeout(Duration::from_secs(5)),
             &transport,
         )

--- a/livekit/src/room/rpc/tests.rs
+++ b/livekit/src/room/rpc/tests.rs
@@ -239,7 +239,9 @@ async fn test_v2_v2_caller_happy_path_short() {
     let handle = spawn_perform_rpc(
         client.clone(),
         transport.clone(),
-        PerformRpcData::new("dest", "greet", "hello").with_response_timeout(Duration::from_secs(5)),
+        PerformRpcData::new("dest", "greet")
+            .with_payload("hello")
+            .with_response_timeout(Duration::from_secs(5)),
     )
     .await;
 
@@ -276,7 +278,8 @@ async fn test_v2_v2_caller_happy_path_large_payload() {
     let handle = spawn_perform_rpc(
         client.clone(),
         transport.clone(),
-        PerformRpcData::new("dest", "big", large_payload)
+        PerformRpcData::new("dest", "big")
+            .with_payload(large_payload)
             .with_response_timeout(Duration::from_secs(5)),
     )
     .await;
@@ -380,7 +383,8 @@ async fn test_v2_v2_response_timeout() {
     // so connection timeout fires.
     let result = client
         .perform_rpc(
-            PerformRpcData::new("dest", "slow", "x")
+            PerformRpcData::new("dest", "slow")
+                .with_payload("x")
                 .with_response_timeout(Duration::from_millis(50)),
             &transport,
         )
@@ -401,7 +405,9 @@ async fn test_v2_v2_error_response() {
     let handle = spawn_perform_rpc(
         client.clone(),
         transport.clone(),
-        PerformRpcData::new("dest", "err", "x").with_response_timeout(Duration::from_secs(5)),
+        PerformRpcData::new("dest", "err")
+            .with_payload("x")
+            .with_response_timeout(Duration::from_secs(5)),
     )
     .await;
 
@@ -433,7 +439,9 @@ async fn test_v2_v2_participant_disconnection() {
     let handle = spawn_perform_rpc(
         client.clone(),
         transport.clone(),
-        PerformRpcData::new("dest", "dc", "x").with_response_timeout(Duration::from_secs(5)),
+        PerformRpcData::new("dest", "dc")
+            .with_payload("x")
+            .with_response_timeout(Duration::from_secs(5)),
     )
     .await;
 
@@ -465,7 +473,9 @@ async fn test_v2_v1_caller_request_fallback() {
     let handle = spawn_perform_rpc(
         client.clone(),
         transport.clone(),
-        PerformRpcData::new("dest", "greet", "hi").with_response_timeout(Duration::from_secs(5)),
+        PerformRpcData::new("dest", "greet")
+            .with_payload("hi")
+            .with_response_timeout(Duration::from_secs(5)),
     )
     .await;
 
@@ -530,7 +540,8 @@ async fn test_v2_v1_payload_too_large() {
     let large_payload = "x".repeat(MAX_V1_PAYLOAD_BYTES + 1);
     let result = client
         .perform_rpc(
-            PerformRpcData::new("dest", "big", large_payload)
+            PerformRpcData::new("dest", "big")
+                .with_payload(large_payload)
                 .with_response_timeout(Duration::from_secs(5)),
             &transport,
         )
@@ -548,7 +559,8 @@ async fn test_v2_v1_response_timeout() {
 
     let result = client
         .perform_rpc(
-            PerformRpcData::new("dest", "slow", "x")
+            PerformRpcData::new("dest", "slow")
+                .with_payload("x")
                 .with_response_timeout(Duration::from_millis(50)),
             &transport,
         )
@@ -568,7 +580,9 @@ async fn test_v2_v1_error_response() {
     let handle = spawn_perform_rpc(
         client.clone(),
         transport.clone(),
-        PerformRpcData::new("dest", "err", "x").with_response_timeout(Duration::from_secs(5)),
+        PerformRpcData::new("dest", "err")
+            .with_payload("x")
+            .with_response_timeout(Duration::from_secs(5)),
     )
     .await;
 
@@ -598,7 +612,9 @@ async fn test_v2_v1_participant_disconnection() {
     let handle = spawn_perform_rpc(
         client.clone(),
         transport.clone(),
-        PerformRpcData::new("dest", "dc", "x").with_response_timeout(Duration::from_secs(5)),
+        PerformRpcData::new("dest", "dc")
+            .with_payload("x")
+            .with_response_timeout(Duration::from_secs(5)),
     )
     .await;
 

--- a/livekit/src/room/rpc/tests.rs
+++ b/livekit/src/room/rpc/tests.rs
@@ -244,6 +244,7 @@ async fn test_v2_v2_caller_happy_path_short() {
             method: "greet".into(),
             payload: "hello".into(),
             response_timeout: Duration::from_secs(5),
+            ..Default::default()
         },
     )
     .await;
@@ -286,6 +287,7 @@ async fn test_v2_v2_caller_happy_path_large_payload() {
             method: "big".into(),
             payload: large_payload,
             response_timeout: Duration::from_secs(5),
+            ..Default::default()
         },
     )
     .await;
@@ -394,6 +396,7 @@ async fn test_v2_v2_response_timeout() {
                 method: "slow".into(),
                 payload: "x".into(),
                 response_timeout: Duration::from_millis(50),
+                ..Default::default()
             },
             &transport,
         )
@@ -419,6 +422,7 @@ async fn test_v2_v2_error_response() {
             method: "err".into(),
             payload: "x".into(),
             response_timeout: Duration::from_secs(5),
+            ..Default::default()
         },
     )
     .await;
@@ -456,6 +460,7 @@ async fn test_v2_v2_participant_disconnection() {
             method: "dc".into(),
             payload: "x".into(),
             response_timeout: Duration::from_secs(5),
+            ..Default::default()
         },
     )
     .await;
@@ -493,6 +498,7 @@ async fn test_v2_v1_caller_request_fallback() {
             method: "greet".into(),
             payload: "hi".into(),
             response_timeout: Duration::from_secs(5),
+            ..Default::default()
         },
     )
     .await;
@@ -563,6 +569,7 @@ async fn test_v2_v1_payload_too_large() {
                 method: "big".into(),
                 payload: large_payload,
                 response_timeout: Duration::from_secs(5),
+                ..Default::default()
             },
             &transport,
         )
@@ -585,6 +592,7 @@ async fn test_v2_v1_response_timeout() {
                 method: "slow".into(),
                 payload: "x".into(),
                 response_timeout: Duration::from_millis(50),
+                ..Default::default()
             },
             &transport,
         )
@@ -609,6 +617,7 @@ async fn test_v2_v1_error_response() {
             method: "err".into(),
             payload: "x".into(),
             response_timeout: Duration::from_secs(5),
+            ..Default::default()
         },
     )
     .await;
@@ -644,6 +653,7 @@ async fn test_v2_v1_participant_disconnection() {
             method: "dc".into(),
             payload: "x".into(),
             response_timeout: Duration::from_secs(5),
+            ..Default::default()
         },
     )
     .await;

--- a/livekit/src/room/rpc/tests.rs
+++ b/livekit/src/room/rpc/tests.rs
@@ -239,13 +239,8 @@ async fn test_v2_v2_caller_happy_path_short() {
     let handle = spawn_perform_rpc(
         client.clone(),
         transport.clone(),
-        PerformRpcData {
-            destination_identity: "dest".into(),
-            method: "greet".into(),
-            payload: "hello".into(),
-            response_timeout: Duration::from_secs(5),
-            ..Default::default()
-        },
+        PerformRpcData::new("dest", "greet", "hello")
+            .with_response_timeout(Duration::from_secs(5)),
     )
     .await;
 
@@ -282,13 +277,8 @@ async fn test_v2_v2_caller_happy_path_large_payload() {
     let handle = spawn_perform_rpc(
         client.clone(),
         transport.clone(),
-        PerformRpcData {
-            destination_identity: "dest".into(),
-            method: "big".into(),
-            payload: large_payload,
-            response_timeout: Duration::from_secs(5),
-            ..Default::default()
-        },
+        PerformRpcData::new("dest", "big", &large_payload)
+            .with_response_timeout(Duration::from_secs(5)),
     )
     .await;
 
@@ -391,13 +381,8 @@ async fn test_v2_v2_response_timeout() {
     // so connection timeout fires.
     let result = client
         .perform_rpc(
-            PerformRpcData {
-                destination_identity: "dest".into(),
-                method: "slow".into(),
-                payload: "x".into(),
-                response_timeout: Duration::from_millis(50),
-                ..Default::default()
-            },
+            PerformRpcData::new("dest", "slow", "x")
+                .with_response_timeout(Duration::from_millis(50)),
             &transport,
         )
         .await;
@@ -417,13 +402,7 @@ async fn test_v2_v2_error_response() {
     let handle = spawn_perform_rpc(
         client.clone(),
         transport.clone(),
-        PerformRpcData {
-            destination_identity: "dest".into(),
-            method: "err".into(),
-            payload: "x".into(),
-            response_timeout: Duration::from_secs(5),
-            ..Default::default()
-        },
+        PerformRpcData::new("dest", "err", "x").with_response_timeout(Duration::from_secs(5)),
     )
     .await;
 
@@ -455,13 +434,7 @@ async fn test_v2_v2_participant_disconnection() {
     let handle = spawn_perform_rpc(
         client.clone(),
         transport.clone(),
-        PerformRpcData {
-            destination_identity: "dest".into(),
-            method: "dc".into(),
-            payload: "x".into(),
-            response_timeout: Duration::from_secs(5),
-            ..Default::default()
-        },
+        PerformRpcData::new("dest", "dc", "x").with_response_timeout(Duration::from_secs(5)),
     )
     .await;
 
@@ -493,13 +466,8 @@ async fn test_v2_v1_caller_request_fallback() {
     let handle = spawn_perform_rpc(
         client.clone(),
         transport.clone(),
-        PerformRpcData {
-            destination_identity: "dest".into(),
-            method: "greet".into(),
-            payload: "hi".into(),
-            response_timeout: Duration::from_secs(5),
-            ..Default::default()
-        },
+        PerformRpcData::new("dest", "greet", "hi")
+            .with_response_timeout(Duration::from_secs(5)),
     )
     .await;
 
@@ -564,13 +532,8 @@ async fn test_v2_v1_payload_too_large() {
     let large_payload = "x".repeat(MAX_V1_PAYLOAD_BYTES + 1);
     let result = client
         .perform_rpc(
-            PerformRpcData {
-                destination_identity: "dest".into(),
-                method: "big".into(),
-                payload: large_payload,
-                response_timeout: Duration::from_secs(5),
-                ..Default::default()
-            },
+            PerformRpcData::new("dest", "big", &large_payload)
+                .with_response_timeout(Duration::from_secs(5)),
             &transport,
         )
         .await;
@@ -587,13 +550,8 @@ async fn test_v2_v1_response_timeout() {
 
     let result = client
         .perform_rpc(
-            PerformRpcData {
-                destination_identity: "dest".into(),
-                method: "slow".into(),
-                payload: "x".into(),
-                response_timeout: Duration::from_millis(50),
-                ..Default::default()
-            },
+            PerformRpcData::new("dest", "slow", "x")
+                .with_response_timeout(Duration::from_millis(50)),
             &transport,
         )
         .await;
@@ -612,13 +570,7 @@ async fn test_v2_v1_error_response() {
     let handle = spawn_perform_rpc(
         client.clone(),
         transport.clone(),
-        PerformRpcData {
-            destination_identity: "dest".into(),
-            method: "err".into(),
-            payload: "x".into(),
-            response_timeout: Duration::from_secs(5),
-            ..Default::default()
-        },
+        PerformRpcData::new("dest", "err", "x").with_response_timeout(Duration::from_secs(5)),
     )
     .await;
 
@@ -648,13 +600,7 @@ async fn test_v2_v1_participant_disconnection() {
     let handle = spawn_perform_rpc(
         client.clone(),
         transport.clone(),
-        PerformRpcData {
-            destination_identity: "dest".into(),
-            method: "dc".into(),
-            payload: "x".into(),
-            response_timeout: Duration::from_secs(5),
-            ..Default::default()
-        },
+        PerformRpcData::new("dest", "dc", "x").with_response_timeout(Duration::from_secs(5)),
     )
     .await;
 

--- a/livekit/src/room/rpc/tests.rs
+++ b/livekit/src/room/rpc/tests.rs
@@ -239,8 +239,7 @@ async fn test_v2_v2_caller_happy_path_short() {
     let handle = spawn_perform_rpc(
         client.clone(),
         transport.clone(),
-        PerformRpcData::new("dest", "greet", "hello")
-            .with_response_timeout(Duration::from_secs(5)),
+        PerformRpcData::new("dest", "greet", "hello").with_response_timeout(Duration::from_secs(5)),
     )
     .await;
 
@@ -466,8 +465,7 @@ async fn test_v2_v1_caller_request_fallback() {
     let handle = spawn_perform_rpc(
         client.clone(),
         transport.clone(),
-        PerformRpcData::new("dest", "greet", "hi")
-            .with_response_timeout(Duration::from_secs(5)),
+        PerformRpcData::new("dest", "greet", "hi").with_response_timeout(Duration::from_secs(5)),
     )
     .await;
 

--- a/livekit/tests/rpc_test.rs
+++ b/livekit/tests/rpc_test.rs
@@ -39,7 +39,7 @@ pub async fn test_rpc_invocation() -> Result<()> {
         Box::pin(async move { Ok(data.payload.to_string()) })
     });
 
-    let perform_data = PerformRpcData::new(&callee_identity.to_string(), METHOD_NAME, PAYLOAD)
+    let perform_data = PerformRpcData::new(callee_identity.clone(), METHOD_NAME, PAYLOAD)
         .with_response_timeout(Duration::from_millis(500));
     let return_payload = caller_room
         .local_participant()
@@ -61,7 +61,7 @@ pub async fn test_rpc_unregistered() -> Result<()> {
     const METHOD_NAME: &str = "unregistered-method";
     const PAYLOAD: &str = "test-payload";
 
-    let perform_data = PerformRpcData::new(&callee_identity.to_string(), METHOD_NAME, PAYLOAD)
+    let perform_data = PerformRpcData::new(callee_identity.clone(), METHOD_NAME, PAYLOAD)
         .with_response_timeout(Duration::from_millis(500));
     let result = caller_room.local_participant().perform_rpc(perform_data).await;
     assert!(result.is_err(), "Expected error");
@@ -84,7 +84,7 @@ pub async fn test_rpc_large_payload() -> Result<()> {
         Box::pin(async move { Ok(data.payload.to_string()) })
     });
 
-    let perform_data = PerformRpcData::new(&callee_identity.to_string(), METHOD_NAME, &large_payload)
+    let perform_data = PerformRpcData::new(callee_identity.clone(), METHOD_NAME, large_payload.clone())
         .with_response_timeout(Duration::from_secs(5));
     let return_payload = caller_room
         .local_participant()
@@ -113,7 +113,7 @@ pub async fn test_rpc_error_response() -> Result<()> {
         })
     });
 
-    let perform_data = PerformRpcData::new(&callee_identity.to_string(), METHOD_NAME, "test")
+    let perform_data = PerformRpcData::new(callee_identity.clone(), METHOD_NAME, "test")
         .with_response_timeout(Duration::from_secs(5));
     let result = caller_room.local_participant().perform_rpc(perform_data).await;
     assert!(result.is_err(), "Expected error response");
@@ -159,7 +159,7 @@ pub async fn test_rpc_v2_does_not_emit_data_stream_events() -> Result<()> {
     let caller_handle = tokio::spawn(collect(caller_events));
     let callee_handle = tokio::spawn(collect(callee_events));
 
-    let perform_data = PerformRpcData::new(&callee_identity.to_string(), "echo", "hi")
+    let perform_data = PerformRpcData::new(callee_identity.clone(), "echo", "hi")
         .with_response_timeout(Duration::from_millis(500));
     let resp = caller_room
         .local_participant()

--- a/livekit/tests/rpc_test.rs
+++ b/livekit/tests/rpc_test.rs
@@ -84,8 +84,9 @@ pub async fn test_rpc_large_payload() -> Result<()> {
         Box::pin(async move { Ok(data.payload.to_string()) })
     });
 
-    let perform_data = PerformRpcData::new(callee_identity.clone(), METHOD_NAME, large_payload.clone())
-        .with_response_timeout(Duration::from_secs(5));
+    let perform_data =
+        PerformRpcData::new(callee_identity.clone(), METHOD_NAME, large_payload.clone())
+            .with_response_timeout(Duration::from_secs(5));
     let return_payload = caller_room
         .local_participant()
         .perform_rpc(perform_data)

--- a/livekit/tests/rpc_test.rs
+++ b/livekit/tests/rpc_test.rs
@@ -160,7 +160,8 @@ pub async fn test_rpc_v2_does_not_emit_data_stream_events() -> Result<()> {
     let caller_handle = tokio::spawn(collect(caller_events));
     let callee_handle = tokio::spawn(collect(callee_events));
 
-    let perform_data = PerformRpcData::new(callee_identity.clone(), "echo", "hi")
+    let perform_data = PerformRpcData::new(callee_identity.clone(), "echo")
+        .with_payload("hi")
         .with_response_timeout(Duration::from_millis(500));
     let resp = caller_room
         .local_participant()

--- a/livekit/tests/rpc_test.rs
+++ b/livekit/tests/rpc_test.rs
@@ -39,7 +39,8 @@ pub async fn test_rpc_invocation() -> Result<()> {
         Box::pin(async move { Ok(data.payload.to_string()) })
     });
 
-    let perform_data = PerformRpcData::new(callee_identity.clone(), METHOD_NAME, PAYLOAD)
+    let perform_data = PerformRpcData::new(callee_identity.clone(), METHOD_NAME)
+        .with_payload(PAYLOAD)
         .with_response_timeout(Duration::from_millis(500));
     let return_payload = caller_room
         .local_participant()
@@ -61,7 +62,8 @@ pub async fn test_rpc_unregistered() -> Result<()> {
     const METHOD_NAME: &str = "unregistered-method";
     const PAYLOAD: &str = "test-payload";
 
-    let perform_data = PerformRpcData::new(callee_identity.clone(), METHOD_NAME, PAYLOAD)
+    let perform_data = PerformRpcData::new(callee_identity.clone(), METHOD_NAME)
+        .with_payload(PAYLOAD)
         .with_response_timeout(Duration::from_millis(500));
     let result = caller_room.local_participant().perform_rpc(perform_data).await;
     assert!(result.is_err(), "Expected error");
@@ -85,7 +87,8 @@ pub async fn test_rpc_large_payload() -> Result<()> {
     });
 
     let perform_data =
-        PerformRpcData::new(callee_identity.clone(), METHOD_NAME, large_payload.clone())
+        PerformRpcData::new(callee_identity.clone(), METHOD_NAME)
+            .with_payload(large_payload.clone())
             .with_response_timeout(Duration::from_secs(5));
     let return_payload = caller_room
         .local_participant()
@@ -114,7 +117,8 @@ pub async fn test_rpc_error_response() -> Result<()> {
         })
     });
 
-    let perform_data = PerformRpcData::new(callee_identity.clone(), METHOD_NAME, "test")
+    let perform_data = PerformRpcData::new(callee_identity.clone(), METHOD_NAME)
+        .with_payload("test")
         .with_response_timeout(Duration::from_secs(5));
     let result = caller_room.local_participant().perform_rpc(perform_data).await;
     assert!(result.is_err(), "Expected error response");
@@ -131,7 +135,8 @@ pub async fn test_rpc_unknown_destination() -> Result<()> {
     let (caller_room, _) = rooms.pop().unwrap();
 
     let perform_data =
-        PerformRpcData::new("unknown-participant", "unregistered-method", "test-payload")
+        PerformRpcData::new("unknown-participant", "unregistered-method")
+            .with_payload("test-payload")
             .with_response_timeout(Duration::from_millis(500));
     let result = caller_room.local_participant().perform_rpc(perform_data).await;
     assert!(result.is_err(), "Expected error");

--- a/livekit/tests/rpc_test.rs
+++ b/livekit/tests/rpc_test.rs
@@ -39,13 +39,8 @@ pub async fn test_rpc_invocation() -> Result<()> {
         Box::pin(async move { Ok(data.payload.to_string()) })
     });
 
-    let perform_data = PerformRpcData {
-        method: METHOD_NAME.to_string(),
-        destination_identity: callee_identity.to_string(),
-        payload: PAYLOAD.to_string(),
-        response_timeout: Duration::from_millis(500),
-        ..Default::default()
-    };
+    let perform_data = PerformRpcData::new(&callee_identity.to_string(), METHOD_NAME, PAYLOAD)
+        .with_response_timeout(Duration::from_millis(500));
     let return_payload = caller_room
         .local_participant()
         .perform_rpc(perform_data)
@@ -66,13 +61,8 @@ pub async fn test_rpc_unregistered() -> Result<()> {
     const METHOD_NAME: &str = "unregistered-method";
     const PAYLOAD: &str = "test-payload";
 
-    let perform_data = PerformRpcData {
-        method: METHOD_NAME.to_string(),
-        destination_identity: callee_identity.to_string(),
-        payload: PAYLOAD.to_string(),
-        response_timeout: Duration::from_millis(500),
-        ..Default::default()
-    };
+    let perform_data = PerformRpcData::new(&callee_identity.to_string(), METHOD_NAME, PAYLOAD)
+        .with_response_timeout(Duration::from_millis(500));
     let result = caller_room.local_participant().perform_rpc(perform_data).await;
     assert!(result.is_err(), "Expected error");
     Ok(())
@@ -94,13 +84,8 @@ pub async fn test_rpc_large_payload() -> Result<()> {
         Box::pin(async move { Ok(data.payload.to_string()) })
     });
 
-    let perform_data = PerformRpcData {
-        method: METHOD_NAME.to_string(),
-        destination_identity: callee_identity.to_string(),
-        payload: large_payload.clone(),
-        response_timeout: Duration::from_secs(5),
-        ..Default::default()
-    };
+    let perform_data = PerformRpcData::new(&callee_identity.to_string(), METHOD_NAME, &large_payload)
+        .with_response_timeout(Duration::from_secs(5));
     let return_payload = caller_room
         .local_participant()
         .perform_rpc(perform_data)
@@ -128,13 +113,8 @@ pub async fn test_rpc_error_response() -> Result<()> {
         })
     });
 
-    let perform_data = PerformRpcData {
-        method: METHOD_NAME.to_string(),
-        destination_identity: callee_identity.to_string(),
-        payload: "test".to_string(),
-        response_timeout: Duration::from_secs(5),
-        ..Default::default()
-    };
+    let perform_data = PerformRpcData::new(&callee_identity.to_string(), METHOD_NAME, "test")
+        .with_response_timeout(Duration::from_secs(5));
     let result = caller_room.local_participant().perform_rpc(perform_data).await;
     assert!(result.is_err(), "Expected error response");
     let err = result.unwrap_err();
@@ -149,13 +129,9 @@ pub async fn test_rpc_unknown_destination() -> Result<()> {
     let mut rooms = test_rooms(1).await?;
     let (caller_room, _) = rooms.pop().unwrap();
 
-    let perform_data = PerformRpcData {
-        method: "unregistered-method".to_string(),
-        destination_identity: "unknown-participant".to_string(),
-        payload: "test-payload".to_string(),
-        response_timeout: Duration::from_millis(500),
-        ..Default::default()
-    };
+    let perform_data =
+        PerformRpcData::new("unknown-participant", "unregistered-method", "test-payload")
+            .with_response_timeout(Duration::from_millis(500));
     let result = caller_room.local_participant().perform_rpc(perform_data).await;
     assert!(result.is_err(), "Expected error");
     Ok(())
@@ -183,13 +159,8 @@ pub async fn test_rpc_v2_does_not_emit_data_stream_events() -> Result<()> {
     let caller_handle = tokio::spawn(collect(caller_events));
     let callee_handle = tokio::spawn(collect(callee_events));
 
-    let perform_data = PerformRpcData {
-        method: "echo".to_string(),
-        destination_identity: callee_identity.to_string(),
-        payload: "hi".to_string(),
-        response_timeout: Duration::from_millis(500),
-        ..Default::default()
-    };
+    let perform_data = PerformRpcData::new(&callee_identity.to_string(), "echo", "hi")
+        .with_response_timeout(Duration::from_millis(500));
     let resp = caller_room
         .local_participant()
         .perform_rpc(perform_data)

--- a/livekit/tests/rpc_test.rs
+++ b/livekit/tests/rpc_test.rs
@@ -86,10 +86,9 @@ pub async fn test_rpc_large_payload() -> Result<()> {
         Box::pin(async move { Ok(data.payload.to_string()) })
     });
 
-    let perform_data =
-        PerformRpcData::new(callee_identity.clone(), METHOD_NAME)
-            .with_payload(large_payload.clone())
-            .with_response_timeout(Duration::from_secs(5));
+    let perform_data = PerformRpcData::new(callee_identity.clone(), METHOD_NAME)
+        .with_payload(large_payload.clone())
+        .with_response_timeout(Duration::from_secs(5));
     let return_payload = caller_room
         .local_participant()
         .perform_rpc(perform_data)
@@ -134,10 +133,9 @@ pub async fn test_rpc_unknown_destination() -> Result<()> {
     let mut rooms = test_rooms(1).await?;
     let (caller_room, _) = rooms.pop().unwrap();
 
-    let perform_data =
-        PerformRpcData::new("unknown-participant", "unregistered-method")
-            .with_payload("test-payload")
-            .with_response_timeout(Duration::from_millis(500));
+    let perform_data = PerformRpcData::new("unknown-participant", "unregistered-method")
+        .with_payload("test-payload")
+        .with_response_timeout(Duration::from_millis(500));
     let result = caller_room.local_participant().perform_rpc(perform_data).await;
     assert!(result.is_err(), "Expected error");
     Ok(())


### PR DESCRIPTION
Adds a new `max_round_trip_latency` field to `PerformRpcData`, adding similar behavior as was added to the corresponding [swift](https://github.com/livekit/client-sdk-swift/pull/1023) and [android](https://github.com/livekit/client-sdk-android/pull/953) pull requests.

Note that this is a **breaking api change**. Per @ladvoc's guidance, this was deemed to be ok because there isn't really a great way to add this new field to the `PerformRpcData` struct in a backwards compatible way.

Given this is a breaking change, I opted to break it in a way where if we have to add _more_ fields in here in the future, it could be done in a non breaking way by making `PerformRpcData` use a builder pattern. That results in something that looks like:
```rust
let output = caller_room.local_participant().perform_rpc(
    PerformRpcData::new("identity", "method") // <-- New builder
        .with_payload("payload")
        .with_response_timeout(Duration::from_secs(5))
).await?;
```
