### PR TITLE
#[allow(dead_code)] for dead functions

### DIFF
--- a/.changeset/allow_dead_code_for_passing_windows_build.md
+++ b/.changeset/allow_dead_code_for_passing_windows_build.md
@@ -1,0 +1,6 @@
+---
+livekit: patch
+livekit-ffi: patch
+---
+
+#[allow(dead_code)] for dead function in room module - #1128 (@stephen-derosa)

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -356,6 +356,7 @@ pub struct RpcRequest {
 }
 
 #[deprecated(note = "RPC responses are now handled internally; see the `rpc` module.")]
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct RpcResponse {
     destination_identity: String,
@@ -365,6 +366,7 @@ pub struct RpcResponse {
 }
 
 #[deprecated(note = "RPC acks are now handled internally; see the `rpc` module.")]
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct RpcAck {
     destination_identity: String,


### PR DESCRIPTION
### PR description
`#[allow(dead_code)]` for `room/mod.rs` dead functions


### Testing
This enables passing the c++ sdk windows builds

