### PR TITLE
Fix occasional green artifact when using NVENC and uvc camera

### DIFF
--- a/.changeset/fix-local-video-publisher-buffer-lifetime.md
+++ b/.changeset/fix-local-video-publisher-buffer-lifetime.md
@@ -1,0 +1,7 @@
+---
+webrtc-sys: patch
+libwebrtc: patch
+livekit: patch
+---
+
+Fix NVIDIA encoder I420 uploads to copy each plane using its actual source stride, avoiding chroma corruption when source frames use padded YUV planes. Also fix the `local_video` publisher reusing mutable I420 frame storage after handing frames to WebRTC.

--- a/examples/local_video/src/publisher.rs
+++ b/examples/local_video/src/publisher.rs
@@ -953,16 +953,6 @@ async fn run_capture_loop(
         .then(|| TimestampOverlay::new(width, height));
     let align_buffers_for_display = display_shared.is_some();
 
-    // Reuse a single I420 buffer
-    let mut frame = VideoFrame {
-        rotation: VideoRotation::VideoRotation0,
-        timestamp_us: 0,
-        frame_metadata: None,
-        buffer: create_i420_buffer(width, height, align_buffers_for_display),
-    };
-    let (stride_y, stride_u, stride_v) = frame.buffer.strides();
-    let stride_y_usize = stride_y as usize;
-
     loop {
         if ctrl_c_received.load(Ordering::Acquire) {
             break;
@@ -971,6 +961,18 @@ async fn run_capture_loop(
         let paced_wait_started_at = Instant::now();
         ticker.tick().await;
         let paced_wait_finished_at = Instant::now();
+
+        // WebRTC may queue the frame and hardware encoders may upload it asynchronously.
+        // Give each submitted frame unique backing storage so later captures cannot
+        // overwrite buffers that are still in-flight.
+        let mut frame = VideoFrame {
+            rotation: VideoRotation::VideoRotation0,
+            timestamp_us: 0,
+            frame_metadata: None,
+            buffer: create_i420_buffer(width, height, align_buffers_for_display),
+        };
+        let (stride_y, stride_u, stride_v) = frame.buffer.strides();
+        let stride_y_usize = stride_y as usize;
 
         let source_frame_started_at = Instant::now();
         let frame_wall_time_us = unix_time_us_now();

--- a/webrtc-sys/src/nvidia/h264_encoder_impl.cpp
+++ b/webrtc-sys/src/nvidia/h264_encoder_impl.cpp
@@ -1,10 +1,10 @@
 #include "h264_encoder_impl.h"
 
-
 #include <algorithm>
 #include <limits>
 #include <string>
 
+#include "i420_buffer_cuda.h"
 #include "absl/strings/match.h"
 #include "absl/types/optional.h"
 #include "api/video/video_codec_constants.h"
@@ -326,12 +326,8 @@ int32_t NvidiaH264EncoderImpl::Encode(
     const NvEncInputFrame* nv_enc_input_frame = encoder_->GetNextInputFrame();
 
     if (cu_memory_type_ == CU_MEMORYTYPE_DEVICE) {
-      NvEncoderCuda::CopyToDeviceFrame(
-          cu_context_, (void*)frame_buffer->DataY(), frame_buffer->StrideY(),
-          reinterpret_cast<CUdeviceptr>(nv_enc_input_frame->inputPtr),
-          nv_enc_input_frame->pitch, input_frame.width(), input_frame.height(),
-          CU_MEMORYTYPE_HOST, nv_enc_input_frame->bufferFormat,
-          nv_enc_input_frame->chromaOffsets, nv_enc_input_frame->numChromaPlanes);
+      CopyI420BufferToDeviceFrame(cu_context_, *frame_buffer,
+                                  *nv_enc_input_frame);
     }
 
     NV_ENC_PIC_PARAMS pic_params = NV_ENC_PIC_PARAMS();

--- a/webrtc-sys/src/nvidia/h265_encoder_impl.cpp
+++ b/webrtc-sys/src/nvidia/h265_encoder_impl.cpp
@@ -4,6 +4,7 @@
 #include <limits>
 #include <string>
 
+#include "i420_buffer_cuda.h"
 #include "absl/strings/match.h"
 #include "absl/types/optional.h"
 #include "api/video/video_codec_constants.h"
@@ -254,12 +255,8 @@ int32_t NvidiaH265EncoderImpl::Encode(
     const NvEncInputFrame* nv_enc_input_frame = encoder_->GetNextInputFrame();
 
     if (cu_memory_type_ == CU_MEMORYTYPE_DEVICE) {
-      NvEncoderCuda::CopyToDeviceFrame(
-          cu_context_, (void*)frame_buffer->DataY(), frame_buffer->StrideY(),
-          reinterpret_cast<CUdeviceptr>(nv_enc_input_frame->inputPtr),
-          nv_enc_input_frame->pitch, input_frame.width(), input_frame.height(),
-          CU_MEMORYTYPE_HOST, nv_enc_input_frame->bufferFormat,
-          nv_enc_input_frame->chromaOffsets, nv_enc_input_frame->numChromaPlanes);
+      CopyI420BufferToDeviceFrame(cu_context_, *frame_buffer,
+                                  *nv_enc_input_frame);
     }
 
     NV_ENC_PIC_PARAMS pic_params = NV_ENC_PIC_PARAMS();
@@ -377,5 +374,4 @@ void NvidiaH265EncoderImpl::LayerConfig::SetStreamState(bool send_stream) {
 }
 
 }  // namespace webrtc
-
 

--- a/webrtc-sys/src/nvidia/i420_buffer_cuda.h
+++ b/webrtc-sys/src/nvidia/i420_buffer_cuda.h
@@ -1,0 +1,60 @@
+#ifndef WEBRTC_NVIDIA_I420_BUFFER_CUDA_H_
+#define WEBRTC_NVIDIA_I420_BUFFER_CUDA_H_
+
+#include <cuda.h>
+
+#include <cstdint>
+
+#include "NvEncoder/NvEncoderCuda.h"
+#include "api/video/i420_buffer.h"
+
+namespace webrtc {
+
+inline void CopyHostPlaneToDevice(CUdeviceptr dst,
+                                  uint32_t dst_pitch,
+                                  const uint8_t* src,
+                                  uint32_t src_pitch,
+                                  uint32_t width_bytes,
+                                  uint32_t height) {
+  CUDA_MEMCPY2D copy = {0};
+  copy.srcMemoryType = CU_MEMORYTYPE_HOST;
+  copy.srcHost = src;
+  copy.srcPitch = src_pitch;
+  copy.dstMemoryType = CU_MEMORYTYPE_DEVICE;
+  copy.dstDevice = dst;
+  copy.dstPitch = dst_pitch;
+  copy.WidthInBytes = width_bytes;
+  copy.Height = height;
+  CUDA_DRVAPI_CALL(cuMemcpy2D(&copy));
+}
+
+inline void CopyI420BufferToDeviceFrame(CUcontext context,
+                                        const I420BufferInterface& buffer,
+                                        const NvEncInputFrame& input_frame) {
+  if (input_frame.bufferFormat != NV_ENC_BUFFER_FORMAT_IYUV ||
+      input_frame.numChromaPlanes != 2) {
+    NVENC_THROW_ERROR("NVENC I420 upload requires an IYUV input frame",
+                      NV_ENC_ERR_INVALID_PARAM);
+  }
+
+  CUDA_DRVAPI_CALL(cuCtxPushCurrent(context));
+
+  const CUdeviceptr dst_y = reinterpret_cast<CUdeviceptr>(input_frame.inputPtr);
+  const CUdeviceptr dst_u = dst_y + input_frame.chromaOffsets[0];
+  const CUdeviceptr dst_v = dst_y + input_frame.chromaOffsets[1];
+
+  CopyHostPlaneToDevice(dst_y, input_frame.pitch, buffer.DataY(),
+                        buffer.StrideY(), buffer.width(), buffer.height());
+  CopyHostPlaneToDevice(dst_u, input_frame.chromaPitch, buffer.DataU(),
+                        buffer.StrideU(), buffer.ChromaWidth(),
+                        buffer.ChromaHeight());
+  CopyHostPlaneToDevice(dst_v, input_frame.chromaPitch, buffer.DataV(),
+                        buffer.StrideV(), buffer.ChromaWidth(),
+                        buffer.ChromaHeight());
+
+  CUDA_DRVAPI_CALL(cuCtxPopCurrent(NULL));
+}
+
+}  // namespace webrtc
+
+#endif  // WEBRTC_NVIDIA_I420_BUFFER_CUDA_H_


### PR DESCRIPTION
## Summary

Fixes NVIDIA hardware-encoded `local_video` publisher corruption that showed up as green stripes or intermittent green artifacts on subscribers.

## What changed

- Stop reusing the same mutable I420 frame buffer after handing frames to WebRTC.
- Copy NVENC I420 input planes independently using each plane’s actual stride instead of assuming Y/U/V are tightly packed from `DataY()` and `StrideY()`.
- Applies the NVENC plane-copy fix to both H.264 and H.265 encoders.

## Why

WebRTC/NVENC can consume captured frames asynchronously, so reusing the same backing buffer could overwrite frames still in flight. Separately, padded I420 buffers, such as frames prepared for local preview/display, can have UV strides that do not derive from the Y stride. The old NVENC upload path could therefore read the wrong chroma data.