### PR TITLE
Upgrade dashmap to v6 for livekit-ffi

### DIFF
--- a/.changeset/upgrade_dashmap_to_v6.md
+++ b/.changeset/upgrade_dashmap_to_v6.md
@@ -1,0 +1,5 @@
+---
+livekit-ffi: patch
+---
+
+# Upgrade dashmap to v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,11 +1772,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if 1.0.4",
+ "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",

--- a/livekit-ffi/Cargo.toml
+++ b/livekit-ffi/Cargo.toml
@@ -32,7 +32,7 @@ prost = { workspace = true }
 lazy_static = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }
-dashmap = "5.4"
+dashmap = "6.2"
 env_logger = { workspace = true }
 downcast-rs = "1.2"
 console-subscriber = { workspace = true, features = ["parking_lot"], optional = true }


### PR DESCRIPTION
From v6 [release notes](https://github.com/xacrimon/dashmap/releases/tag/v6.0.0):
> This release contains performance optimizations, most notably 10-40% gains on Apple Silicon but also 5-10% gains when measured in Intel Sapphire Rapids.

Should be tested for regressions in FFI clients before merging.