### PR TITLE
Remove default link-time dependency on GLib

### DIFF
--- a/.changeset/remove-default-glib-dependency.md
+++ b/.changeset/remove-default-glib-dependency.md
@@ -1,0 +1,11 @@
+---
+webrtc-sys: patch
+libwebrtc: minor
+livekit: minor
+---
+
+# Make GLib an opt-in dependency
+
+`webrtc-sys` no longer links against `glib-2.0`/`gobject-2.0`/`gio-2.0` by default.
+
+Breaking: Wayland screen sharing now requires the `glib-main-loop` feature on `livekit` (or `libwebrtc`).

--- a/examples/screensharing/Cargo.toml
+++ b/examples/screensharing/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 tokio = { workspace = true, features = ["full"] }
 env_logger = { workspace = true }
-livekit = { workspace = true, features = ["rustls-tls-native-roots"] }
+livekit = { workspace = true, features = ["glib-main-loop", "rustls-tls-native-roots"] }
 livekit-api = { workspace = true }
 log = { workspace = true }
 clap = { workspace = true, features = ["derive"] }

--- a/libwebrtc/Cargo.toml
+++ b/libwebrtc/Cargo.toml
@@ -8,11 +8,12 @@ description = "Livekit safe bindings to libwebrtc"
 repository.workspace = true
 
 [features]
-default = [ "glib-main-loop" ]
+default = []
+
 # On Wayland, libwebrtc uses GDBus to communicate with the XDG Desktop Portal.
-# GDBus requires a GLib event loop to be running. If you already have a GLib
-# event loop running in your application, for example if you are using the
-# GTK or GStreamer Rust bindings, disable this feature.
+# GDBus requires a GLib event loop to be running. Enable this feature if you
+# wish to use screensharing, and you do not already have a GLib event loop
+# running in your application.
 glib-main-loop = [ "dep:glib" ]
 
 [dependencies]

--- a/livekit/Cargo.toml
+++ b/livekit/Cargo.toml
@@ -14,6 +14,11 @@ async = ["livekit-api/signal-client-async"]
 tokio = ["livekit-api/signal-client-tokio"]
 dispatcher = ["livekit-api/signal-client-dispatcher"]
 
+# On Wayland, libwebrtc uses GDBus to communicate with the XDG Desktop Portal.
+# GDBus requires a GLib event loop to be running. Enable this feature if you
+# wish to use screensharing, and you do not already have a GLib event loop
+# running in your application.
+glib-main-loop = [ "libwebrtc/glib-main-loop" ]
 
 # Note that the following features only change the behavior of tokio-tungstenite.
 # It doesn't change the behavior of libwebrtc/webrtc-sys

--- a/webrtc-sys/build.rs
+++ b/webrtc-sys/build.rs
@@ -174,8 +174,12 @@ fn main() {
             // In order to avoid any ABI mismatches we use the sysroot's headers.
             add_gio_headers(&mut builder);
 
+            // Do not use pkg_config::probe_library, because we only require headers.
             for lib_name in ["glib-2.0", "gobject-2.0", "gio-2.0"] {
-                pkg_config::probe_library(lib_name).unwrap();
+                let lib = pkg_config::Config::new().cargo_metadata(false).probe(lib_name).unwrap();
+                for path in lib.include_paths {
+                    builder.include(path);
+                }
             }
 
             add_lazy_load_so(


### PR DESCRIPTION
### Before you submit your PR

Make sure the following is true before submitting your PR:

- [x] I have read the [contributing guidelines](https://github.com/livekit/rust-sdks/blob/main/CONTRIBUTING.md) and validated that this PR will be accepted.
- [x] I have read and followed the principles regarding breaking changes, testing, and code quality.

### PR Description

The webrtc-sys build script used pkg_config::probe_library for glib-2.0/gobject-2.0/gio-2.0, which emitted cargo:rustc-link-lib directives even though only the headers are required at build time. Switch to pkg_config::Config::new().cargo_metadata(false) so the include paths are still discovered but no link metadata is emitted.

Drop glib-main-loop from libwebrtc's default features and re-expose it as an opt-in passthrough on the top-level livekit crate. The screensharing example enables it explicitly. Note that the original change (https://github.com/livekit/rust-sdks/commit/ca86d4c5d7f05c3fbd402e112f466575489dbe6f) was somewhat broken on arrival, since it did not provide any way for a `livekit` consumer to opt out of the internal GLib main loop.

Fixes: https://github.com/livekit/rust-sdks/issues/1129

### Breaking changes

Consumers of `livekit` or `libwebrtc` that rely on Wayland screen sharing must now enable the `glib-main-loop` feature (if they do not have their own GLib main loop).

### MSRV

No change.

### Testing

Validated that a trivial crate that depends on `livekit` no longer pulls in `glib` as a dependency.

Built a cdylib on Linux aarch64 in a build environment where the linker does not use `--as-needed` (or it simply does not work as expected), and validated that the resulting binary does not include library dependencies on GLib. See the [build artifacts](https://github.com/foxglove/foxglove-sdk/actions/runs/27042873647) from https://github.com/foxglove/foxglove-sdk/pull/1292 (`lib/libfoxglove.so`).