### PR TITLE
Fix transceiver reusing problem in single-pc mode 

### DIFF
--- a/.changeset/blink-style-track-event-diff.md
+++ b/.changeset/blink-style-track-event-diff.md
@@ -1,6 +1,7 @@
 ---
+webrtc-sys: patch
 libwebrtc: patch
 livekit: patch
 ---
 
-Fix silent subscription failures in single-pc mode when the SFU reuses an existing empty transceiver for a new remote track.
+Fix silent subscription failures in single-pc mode when the SFU reuses an existing empty transceiver for a new remote track. Also make `RtpTransceiver::mid()` safe to call on transceivers that haven't been negotiated yet — libwebrtc is built with `-fno-exceptions`, so `std::optional::value()` aborted the process instead of throwing.

--- a/.changeset/blink-style-track-event-diff.md
+++ b/.changeset/blink-style-track-event-diff.md
@@ -1,0 +1,6 @@
+---
+libwebrtc: patch
+livekit: patch
+---
+
+Fix silent subscription failures in single-pc mode when the SFU reuses an existing empty transceiver for a new remote track.

--- a/libwebrtc/src/native/rtp_receiver.rs
+++ b/libwebrtc/src/native/rtp_receiver.rs
@@ -17,8 +17,12 @@ use tokio::sync::oneshot;
 use webrtc_sys::rtp_receiver as sys_rr;
 
 use crate::{
-    imp::media_stream_track::new_media_stream_track, media_stream_track::MediaStreamTrack,
-    rtp_parameters::RtpParameters, stats::RtcStats, RtcError, RtcErrorType,
+    imp::{media_stream as imp_ms, media_stream_track::new_media_stream_track},
+    media_stream::MediaStream,
+    media_stream_track::MediaStreamTrack,
+    rtp_parameters::RtpParameters,
+    stats::RtcStats,
+    RtcError, RtcErrorType,
 };
 
 #[derive(Clone)]
@@ -34,6 +38,18 @@ impl RtpReceiver {
         }
 
         Some(new_media_stream_track(track_handle))
+    }
+
+    pub fn stream_ids(&self) -> Vec<String> {
+        self.sys_handle.stream_ids()
+    }
+
+    pub fn streams(&self) -> Vec<MediaStream> {
+        self.sys_handle
+            .streams()
+            .into_iter()
+            .map(|s| MediaStream { handle: imp_ms::MediaStream { sys_handle: s.ptr } })
+            .collect()
     }
 
     pub async fn get_stats(&self) -> Result<Vec<RtcStats>, RtcError> {

--- a/libwebrtc/src/native/rtp_transceiver.rs
+++ b/libwebrtc/src/native/rtp_transceiver.rs
@@ -65,7 +65,9 @@ pub struct RtpTransceiver {
 
 impl RtpTransceiver {
     pub fn mid(&self) -> Option<String> {
-        self.sys_handle.mid().ok()
+        // The C++ shim returns "" when libwebrtc has no mid yet (instead of
+        // calling std::optional::value() which would abort under -fno-exceptions).
+        self.sys_handle.mid().ok().filter(|s| !s.is_empty())
     }
 
     pub fn current_direction(&self) -> Option<RtpTransceiverDirection> {

--- a/libwebrtc/src/rtp_receiver.rs
+++ b/libwebrtc/src/rtp_receiver.rs
@@ -15,8 +15,8 @@
 use std::fmt::Debug;
 
 use crate::{
-    imp::rtp_receiver as imp_rr, media_stream::MediaStream,
-    media_stream_track::MediaStreamTrack, rtp_parameters::RtpParameters, stats::RtcStats, RtcError,
+    imp::rtp_receiver as imp_rr, media_stream::MediaStream, media_stream_track::MediaStreamTrack,
+    rtp_parameters::RtpParameters, stats::RtcStats, RtcError,
 };
 
 #[derive(Clone)]

--- a/libwebrtc/src/rtp_receiver.rs
+++ b/libwebrtc/src/rtp_receiver.rs
@@ -15,8 +15,8 @@
 use std::fmt::Debug;
 
 use crate::{
-    imp::rtp_receiver as imp_rr, media_stream_track::MediaStreamTrack,
-    rtp_parameters::RtpParameters, stats::RtcStats, RtcError,
+    imp::rtp_receiver as imp_rr, media_stream::MediaStream,
+    media_stream_track::MediaStreamTrack, rtp_parameters::RtpParameters, stats::RtcStats, RtcError,
 };
 
 #[derive(Clone)]
@@ -27,6 +27,14 @@ pub struct RtpReceiver {
 impl RtpReceiver {
     pub fn track(&self) -> Option<MediaStreamTrack> {
         self.handle.track()
+    }
+
+    pub fn stream_ids(&self) -> Vec<String> {
+        self.handle.stream_ids()
+    }
+
+    pub fn streams(&self) -> Vec<MediaStream> {
+        self.handle.streams()
     }
 
     pub async fn get_stats(&self) -> Result<Vec<RtcStats>, RtcError> {

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     convert::TryInto,
     fmt::Debug,
     sync::{
@@ -357,6 +357,20 @@ struct SessionInner {
     /// Mapping from SDP mid to track ID, used for track resolution in single PC mode
     mid_to_track_id: Mutex<HashMap<String, String>>,
 
+    /// `(mid, stream_id)` pairs we've already dispatched as
+    /// `SessionEvent::MediaTrack`.
+    ///
+    /// libwebrtc-native's `OnTrack` callback only fires when a transceiver is
+    /// first created — it does NOT refire when an existing transceiver's
+    /// receiver gains a new associated `MediaStream` via an msid update
+    /// (e.g. an SFU reusing an empty transceiver slot for a new subscription).
+    /// Browsers paper over this by running the W3C "process the addition of
+    /// remote tracks" algorithm in blink (RTCPeerConnection::DidModifyTransceivers
+    /// in third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc),
+    /// diffing receiver streams across each setRemoteDescription and dispatching
+    /// `track` events for newly-added streams.
+    dispatched_streams: Mutex<HashSet<(String, String)>>,
+
     pending_tracks: Mutex<HashMap<String, oneshot::Sender<proto::TrackInfo>>>,
 
     // Publisher data channels
@@ -463,20 +477,7 @@ impl RtcSession {
 
             let dcs = Self::create_data_channels(&publisher_pc, &emitter)?;
 
-            // The JS SDK creates recv media sections in the initial offer to receive
-            // existing tracks as soon as possible. Rust cannot do this due to
-            // different `ontrack` behavior between browsers and libwebrtc:
-            // 1. The client sends an initial offer with recv sections.
-            // 2. The server responds with an answer, but with sendonly media
-            //    sections without msid because no new track has been published.
-            // 3. Later, after a track is published and subscribed to by the client,
-            //    the server may reuse the media section from step 2 with the actual
-            //    track ID.
-            // 4. Browsers fire `ontrack`:
-            //    https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc;l=2447
-            //    This is browser behavior, not libwebrtc core behavior.
-            // 5. libwebrtc does not fire `ontrack`, so the track subscription fails.
-            // Self::add_recv_media_sections(&publisher_pc.peer_connection(), 3, 3)?;
+            Self::add_recv_media_sections(&publisher_pc.peer_connection(), 3, 3)?;
 
             match publisher_pc.create_initial_offer().await {
                 Ok(Some(offer)) => {
@@ -583,6 +584,7 @@ impl RtcSession {
             subscriber_pc,
             single_pc_mode,
             mid_to_track_id: Mutex::new(HashMap::new()),
+            dispatched_streams: Mutex::new(HashSet::new()),
             pending_tracks: Default::default(),
             lossy_dc,
             lossy_dc_buffered_amount_low_threshold: AtomicU64::new(
@@ -912,6 +914,44 @@ impl RtcSession {
 }
 
 impl SessionInner {
+    /// Walks the given peer connection's transceivers and synthesizes a
+    /// `SessionEvent::MediaTrack` for any `(mid, stream_id)` pair we
+    /// haven't already dispatched. 
+    ///
+    /// Mirrors `RTCPeerConnection::DidModifyTransceivers` in Chromium's
+    /// blink renderer:
+    /// `third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc`.
+    fn process_remote_track_addition(&self, pc: &libwebrtc::peer_connection::PeerConnection) {
+        let mut current = HashMap::<(String, String), (MediaStream, MediaStreamTrack, RtpTransceiver)>::new();
+        for transceiver in pc.transceivers() {
+            let Some(mid) = transceiver.mid() else { continue };
+            let receiver = transceiver.receiver();
+            let Some(track) = receiver.track() else { continue };
+            for stream in receiver.streams() {
+                let stream_id = stream.id();
+                current
+                    .entry((mid.clone(), stream_id))
+                    .or_insert_with(|| (stream, track.clone(), transceiver.clone()));
+            }
+        }
+
+        let mut dispatched = self.dispatched_streams.lock();
+        dispatched.retain(|key| current.contains_key(key));
+
+        for (key, (stream, track, transceiver)) in current {
+            if dispatched.insert(key.clone()) {
+                log::debug!(
+                    "blink-diff: synthesizing MediaTrack for mid={}, stream_id={}",
+                    key.0,
+                    key.1
+                );
+                let _ = self
+                    .emitter
+                    .send(SessionEvent::MediaTrack { stream, track, transceiver });
+            }
+        }
+    }
+
     async fn rtc_session_task(
         self: Arc<Self>,
         mut rtc_events: RtcEvents,
@@ -1192,6 +1232,10 @@ impl SessionInner {
                     SessionDescription::parse(&answer.sdp, answer.r#type.parse().unwrap()).unwrap(); // Unwrap is ok, the server shouldn't give us an invalid sdp
                 self.publisher_pc.set_remote_description(answer).await?;
 
+                if self.single_pc_mode {
+                    self.process_remote_track_addition(&self.publisher_pc.peer_connection());
+                }
+
                 if self.fast_publish.load(Ordering::Acquire) {
                     if self.negotiation_queue.waiting_for_answer.swap(false, Ordering::AcqRel) {
                         log::debug!("answer received, notifying negotiation loop");
@@ -1429,11 +1473,17 @@ impl SessionInner {
             }
             RtcEvent::Track { mut streams, track, transceiver, target: _ } => {
                 if !streams.is_empty() {
-                    let _ = self.emitter.send(SessionEvent::MediaTrack {
-                        stream: streams.remove(0),
-                        track,
-                        transceiver,
-                    });
+                    let stream = streams.remove(0);
+                    let mid = transceiver.mid().unwrap_or_default();
+                    let already_dispatched = !mid.is_empty()
+                        && !self.dispatched_streams.lock().insert((mid, stream.id()));
+                    if !already_dispatched {
+                        let _ = self.emitter.send(SessionEvent::MediaTrack {
+                            stream,
+                            track,
+                            transceiver,
+                        });
+                    }
                 }
             }
             RtcEvent::Data { data, binary, kind } => {

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -947,13 +947,14 @@ impl RtcSession {
 impl SessionInner {
     /// Walks the given peer connection's transceivers and synthesizes a
     /// `SessionEvent::MediaTrack` for any `(mid, stream_id)` pair we
-    /// haven't already dispatched. 
+    /// haven't already dispatched.
     ///
     /// Mirrors `RTCPeerConnection::DidModifyTransceivers` in Chromium's
     /// blink renderer:
     /// `third_party/blink/renderer/modules/peerconnection/rtc_peer_connection.cc`.
     fn process_remote_track_addition(&self, pc: &libwebrtc::peer_connection::PeerConnection) {
-        let mut current = HashMap::<(String, String), (MediaStream, MediaStreamTrack, RtpTransceiver)>::new();
+        let mut current =
+            HashMap::<(String, String), (MediaStream, MediaStreamTrack, RtpTransceiver)>::new();
         for transceiver in pc.transceivers() {
             let Some(mid) = transceiver.mid() else { continue };
             let receiver = transceiver.receiver();
@@ -976,9 +977,7 @@ impl SessionInner {
                     key.0,
                     key.1
                 );
-                let _ = self
-                    .emitter
-                    .send(SessionEvent::MediaTrack { stream, track, transceiver });
+                let _ = self.emitter.send(SessionEvent::MediaTrack { stream, track, transceiver });
             }
         }
     }

--- a/livekit/tests/peer_connection_signaling_test.rs
+++ b/livekit/tests/peer_connection_signaling_test.rs
@@ -344,6 +344,23 @@ async fn test_v1_mute_during_reconnect_lands_on_server() -> Result<()> {
     test_mute_during_reconnect_impl(SignalingMode::SinglePC).await
 }
 
+/// Regression test for the publisher-offer pre-allocation path.
+///
+/// A connects first with single-PC + publisher_offer. Its initial offer
+/// includes 3 audio + 3 video recvonly transceivers pre-allocated, so the
+/// SFU's answer to A has empty `sendonly` slots with no `a=msid`. Later B
+/// joins and publishes a track; the SFU binds that track to one of A's
+/// pre-allocated recvonly slots, populating msid on an existing client-side
+/// transceiver — exactly the path libwebrtc-native's `OnTrack` does NOT
+/// refire for.
+///
+/// Without the blink-style diff this test fails (A never receives
+/// `TrackSubscribed`). With the diff, A subscribes successfully.
+#[test_log::test(tokio::test)]
+async fn test_v1_publisher_offer_subscribes_late_publish() -> Result<()> {
+    test_publisher_offer_late_publish_impl(SignalingMode::SinglePC).await
+}
+
 // ==================== Test Implementations ====================
 
 /// Test basic connection
@@ -1028,5 +1045,72 @@ async fn test_double_reconnect_impl(mode: SignalingMode) -> Result<()> {
         assert_eq!(room.connection_state(), ConnectionState::Connected);
     }
 
+    Ok(())
+}
+
+async fn test_publisher_offer_late_publish_impl(mode: SignalingMode) -> Result<()> {
+    let (url, api_key, api_secret) = get_env_for_mode(mode);
+    let room_name = format!("test_{:?}_pubofflate_{}", mode, create_random_uuid());
+
+    // 1. A joins first with auto_subscribe=true + single_pc.
+    //    Its initial offer pre-allocates 3+3 recvonly transceivers. The SFU
+    //    answers them all as empty `sendonly` slots (no msid, no ssrc) — the
+    //    exact shape that, without the blink-diff fix, would silently drop
+    //    incoming subscriptions later landed on those slots.
+    let a_opts = {
+        let mut o = room_options(mode);
+        o.room.auto_subscribe = true;
+        o
+    };
+    let a_token = create_token(&api_key, &api_secret, &room_name, "p_a")?;
+    let (a_room, mut a_events) = Room::connect(&url, &a_token, a_opts.room.clone()).await?;
+    log::info!("[pubofflate] A connected");
+    assert_signaling_mode_state(&a_room, mode, &url);
+
+    // Wait A is fully settled (initial SDP applied, pre-allocated
+    // empty slots negotiated) before B joins.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // 2. B joins and publishes a track. The SFU forwards to A on one of A's
+    //    pre-allocated recvonly slots — populating msid on an EXISTING
+    //    client-side transceiver. Without the blink-diff fix libwebrtc would
+    //    not refire OnTrack for this and A would silently miss the
+    //    subscription.
+    let b_token = create_token(&api_key, &api_secret, &room_name, "p_b")?;
+    let (b_room, _b_events) = connect_room(&url, &b_token, mode).await?;
+    let b_room_arc = Arc::new(b_room);
+    let mut b_track = SineTrack::new(
+        b_room_arc.clone(),
+        SineParameters { freq: 440.0, amplitude: 1.0, sample_rate: 48000, num_channels: 1 },
+    );
+    b_track.publish().await?;
+    let b_sid = b_room_arc
+        .local_participant()
+        .track_publications()
+        .keys()
+        .next()
+        .cloned()
+        .ok_or_else(|| anyhow!("B has no publication after publish"))?;
+    log::info!("[pubofflate] B published track {}", b_sid);
+
+    // 3. A must observe `TrackSubscribed` for B's track within 10s.
+    let wait = async {
+        loop {
+            let Some(event) = a_events.recv().await else {
+                return Err(anyhow!("event channel closed"));
+            };
+            if let RoomEvent::TrackSubscribed { publication, .. } = event {
+                if publication.sid() == b_sid {
+                    return Ok(());
+                }
+            }
+        }
+    };
+    timeout(Duration::from_secs(10), wait).await.context(format!(
+        "A never received TrackSubscribed for B's track {} — the blink-diff fix did not deliver",
+        b_sid
+    ))??;
+
+    log::info!("[pubofflate] A subscribed to {} via pre-allocated slot — fix works", b_sid);
     Ok(())
 }

--- a/webrtc-sys/src/rtp_transceiver.cpp
+++ b/webrtc-sys/src/rtp_transceiver.cpp
@@ -49,9 +49,11 @@ MediaType RtpTransceiver::media_type() const {
 }
 
 rust::String RtpTransceiver::mid() const {
-  // The error/Result is converted into an Option in Rust (Wait for Option
-  // suport in cxx.rs) (value throws an error if there's no value)
-  return transceiver_->mid().value();
+  // libwebrtc is typically built with -fno-exceptions, so calling
+  // std::optional::value() on an empty optional aborts the process instead of
+  // throwing. Use value_or("") and treat empty string as "no mid yet" on the
+  // Rust side (see libwebrtc/src/native/rtp_transceiver.rs::mid).
+  return transceiver_->mid().value_or("");
 }
 
 std::shared_ptr<RtpSender> RtpTransceiver::sender() const {


### PR DESCRIPTION
Sfu could send empty transceiver to subscriber in single pc
mode when publisher unbpulishes track before answer sdp is
created. The empty transceiver can be reused in later subscription
that changes msid in renegotiation, libwebrtc will not fire
onTrack event in the msid changed case cause subscrption failure.
Chrome detects the msid change and synthsize onTrack event to handle
this case. This PR do the same thing as browser.

