### PR TITLE
return DeviceNotFound when device is not there for set_recording_devi…

### DIFF
--- a/.changeset/return_devicenotfound_when_device_is_not_there_for_set_recor.md
+++ b/.changeset/return_devicenotfound_when_device_is_not_there_for_set_recor.md
@@ -1,0 +1,6 @@
+---
+livekit: patch
+livekit-ffi: patch
+---
+
+return DeviceNotFound when device is not there for set_recording_devi… - #1155 (@xianshijing-lk)

--- a/livekit/src/platform_audio/mod.rs
+++ b/livekit/src/platform_audio/mod.rs
@@ -657,6 +657,11 @@ impl PlatformAudio {
     ///
     /// * `id` - Device identifier from [`RecordingDeviceInfo::id`]
     ///
+    /// # Errors
+    ///
+    /// Returns [`AudioError::DeviceNotFound`] if the device ID does not exist
+    /// in the current list of available recording devices.
+    ///
     /// # Example
     ///
     /// ```rust,ignore
@@ -668,6 +673,13 @@ impl PlatformAudio {
     /// }
     /// ```
     pub fn set_recording_device(&self, id: &RecordingDeviceId) -> AudioResult<()> {
+        // Validate that the device ID exists in the current device list
+        // Skip validation on mobile where device selection is a no-op
+        #[cfg(not(any(target_os = "ios", target_os = "android")))]
+        if !self.recording_devices().any(|d| &d.id == id) {
+            return Err(AudioError::DeviceNotFound);
+        }
+
         if self.handle.runtime.set_recording_device_by_guid(id.as_str()) {
             Ok(())
         } else {
@@ -693,6 +705,11 @@ impl PlatformAudio {
     ///
     /// * `id` - Device identifier from [`PlayoutDeviceInfo::id`]
     ///
+    /// # Errors
+    ///
+    /// Returns [`AudioError::DeviceNotFound`] if the device ID does not exist
+    /// in the current list of available playout devices.
+    ///
     /// # Example
     ///
     /// ```rust,ignore
@@ -704,6 +721,13 @@ impl PlatformAudio {
     /// }
     /// ```
     pub fn set_playout_device(&self, id: &PlayoutDeviceId) -> AudioResult<()> {
+        // Validate that the device ID exists in the current device list
+        // Skip validation on mobile where device selection is a no-op
+        #[cfg(not(any(target_os = "ios", target_os = "android")))]
+        if !self.playout_devices().any(|d| &d.id == id) {
+            return Err(AudioError::DeviceNotFound);
+        }
+
         let runtime = &self.handle.runtime;
         if !runtime.set_playout_device_by_guid(id.as_str()) {
             return Err(AudioError::DeviceNotFound);

--- a/livekit/src/platform_audio/mod.rs
+++ b/livekit/src/platform_audio/mod.rs
@@ -635,6 +635,18 @@ impl PlatformAudio {
         })
     }
 
+    #[cfg(not(any(target_os = "ios", target_os = "android")))]
+    fn ensure_device_exists<Device>(
+        devices: impl IntoIterator<Item = Device>,
+        mut is_match: impl FnMut(&Device) -> bool,
+    ) -> AudioResult<()> {
+        if devices.into_iter().any(|device| is_match(&device)) {
+            Ok(())
+        } else {
+            Err(AudioError::DeviceNotFound)
+        }
+    }
+
     // =========================================================================
     // Device Selection
     // =========================================================================
@@ -673,12 +685,8 @@ impl PlatformAudio {
     /// }
     /// ```
     pub fn set_recording_device(&self, id: &RecordingDeviceId) -> AudioResult<()> {
-        // Validate that the device ID exists in the current device list
-        // Skip validation on mobile where device selection is a no-op
         #[cfg(not(any(target_os = "ios", target_os = "android")))]
-        if !self.recording_devices().any(|d| &d.id == id) {
-            return Err(AudioError::DeviceNotFound);
-        }
+        Self::ensure_device_exists(self.recording_devices(), |device| &device.id == id)?;
 
         if self.handle.runtime.set_recording_device_by_guid(id.as_str()) {
             Ok(())
@@ -721,12 +729,8 @@ impl PlatformAudio {
     /// }
     /// ```
     pub fn set_playout_device(&self, id: &PlayoutDeviceId) -> AudioResult<()> {
-        // Validate that the device ID exists in the current device list
-        // Skip validation on mobile where device selection is a no-op
         #[cfg(not(any(target_os = "ios", target_os = "android")))]
-        if !self.playout_devices().any(|d| &d.id == id) {
-            return Err(AudioError::DeviceNotFound);
-        }
+        Self::ensure_device_exists(self.playout_devices(), |device| &device.id == id)?;
 
         let runtime = &self.handle.runtime;
         if !runtime.set_playout_device_by_guid(id.as_str()) {

--- a/livekit/tests/platform_audio_test.rs
+++ b/livekit/tests/platform_audio_test.rs
@@ -335,6 +335,33 @@ async fn test_platform_audio_standalone_device_selection() -> Result<()> {
     Ok(())
 }
 
+/// Test invalid device IDs return DeviceNotFound.
+#[test_log::test(tokio::test)]
+#[serial]
+#[cfg(not(any(target_os = "ios", target_os = "android")))]
+async fn test_platform_audio_invalid_device_id_returns_device_not_found() -> Result<()> {
+    use livekit::{reset_platform_audio, PlayoutDeviceId, RecordingDeviceId};
+
+    reset_platform_audio();
+
+    let Some(audio) =
+        try_create_platform_audio("test_platform_audio_invalid_device_id_returns_device_not_found")
+    else {
+        return Ok(());
+    };
+
+    let invalid_recording_id =
+        RecordingDeviceId::from_unchecked_guid("__livekit_missing_recording_device__");
+    assert_eq!(audio.set_recording_device(&invalid_recording_id), Err(AudioError::DeviceNotFound));
+
+    let invalid_playout_id =
+        PlayoutDeviceId::from_unchecked_guid("__livekit_missing_playout_device__");
+    assert_eq!(audio.set_playout_device(&invalid_playout_id), Err(AudioError::DeviceNotFound));
+
+    drop(audio);
+    Ok(())
+}
+
 /// Test audio processing configuration without room connection.
 #[test_log::test(tokio::test)]
 #[serial]


### PR DESCRIPTION
…ce() / set_playout_device()

### Before you submit your PR

Make sure the following is true before submitting your PR:

- [x] I have read the [contributing guidelines](https://github.com/livekit/rust-sdks/blob/main/CONTRIBUTING.md) and validated that this PR will be accepted.
- [x] I have read and followed the principles regarding breaking changes, testing, and code quality.

### PR description

Return  return DeviceNotFound when device is not there for set_recording_device() and set_playout_device()

Otherwise, the API will behave differently on different platforms.

### Breaking changes

If this PR introduces breaking changes, list them here and document the rationale for introducing such a change.

### MSRV

N/A

### Testing

CI

### Async

N/A


