### PR TITLE
Platform Audio: device-selection capability + explicit mobile no-op

### DIFF
--- a/.changeset/platform_audio_device_selection_capability_explicit_mobile_n.md
+++ b/.changeset/platform_audio_device_selection_capability_explicit_mobile_n.md
@@ -1,0 +1,8 @@
+---
+libwebrtc: patch
+livekit: patch
+livekit-ffi: patch
+webrtc-sys: patch
+---
+
+platform audio: return device-selection capability + explicit mobile no-op - #1156 (@MaxHeimbrock)

--- a/livekit-ffi-node-bindings/proto/audio_frame_pb.d.ts
+++ b/livekit-ffi-node-bindings/proto/audio_frame_pb.d.ts
@@ -1719,6 +1719,15 @@ export declare class PlatformAudioInfo extends Message<PlatformAudioInfo> {
    */
   playoutDeviceCount?: number;
 
+  /**
+   * Whether per-device selection is honored on this platform. False on iOS/Android,
+   * where audio routing is controlled by the OS (AVAudioSession / AudioManager) rather
+   * than through WebRTC device selection.
+   *
+   * @generated from field: required bool device_selection_supported = 3;
+   */
+  deviceSelectionSupported?: boolean;
+
   constructor(data?: PartialMessage<PlatformAudioInfo>);
 
   static readonly runtime: typeof proto2;

--- a/livekit-ffi-node-bindings/proto/audio_frame_pb.js
+++ b/livekit-ffi-node-bindings/proto/audio_frame_pb.js
@@ -640,6 +640,7 @@ const PlatformAudioInfo = /*@__PURE__*/ proto2.makeMessageType(
   () => [
     { no: 1, name: "recording_device_count", kind: "scalar", T: 5 /* ScalarType.INT32 */, req: true },
     { no: 2, name: "playout_device_count", kind: "scalar", T: 5 /* ScalarType.INT32 */, req: true },
+    { no: 3, name: "device_selection_supported", kind: "scalar", T: 8 /* ScalarType.BOOL */, req: true },
   ],
 );
 

--- a/livekit-ffi/protocol/audio_frame.proto
+++ b/livekit-ffi/protocol/audio_frame.proto
@@ -397,6 +397,10 @@ message PlatformAudioInfo {
   required int32 recording_device_count = 1;
   // Number of available playout (speaker) devices.
   required int32 playout_device_count = 2;
+  // Whether per-device selection is honored on this platform. False on iOS/Android,
+  // where audio routing is controlled by the OS (AVAudioSession / AudioManager) rather
+  // than through WebRTC device selection.
+  required bool device_selection_supported = 3;
 }
 
 // Owned PlatformAudio handle with info.

--- a/livekit-ffi/src/server/platform_audio.rs
+++ b/livekit-ffi/src/server/platform_audio.rs
@@ -46,6 +46,7 @@ pub fn on_new_platform_audio(
             let info = proto::PlatformAudioInfo {
                 recording_device_count: recording_count,
                 playout_device_count: playout_count,
+                device_selection_supported: audio.supports_device_selection(),
             };
 
             server.store_handle(handle_id, FfiPlatformAudio { audio });

--- a/livekit/src/platform_audio/mod.rs
+++ b/livekit/src/platform_audio/mod.rs
@@ -639,6 +639,25 @@ impl PlatformAudio {
     // Device Selection
     // =========================================================================
 
+    /// Returns whether per-device selection is honored on this platform.
+    ///
+    /// - **Desktop (Windows, macOS, Linux):** `true`. Devices enumerated via
+    ///   [`recording_devices()`]/[`playout_devices()`] can be selected by ID.
+    /// - **Mobile (iOS/Android):** `false`. Audio routing is controlled by the OS
+    ///   (AVAudioSession on iOS, AudioManager on Android), not by WebRTC device
+    ///   selection. [`set_recording_device()`]/[`set_playout_device()`] are accepted
+    ///   but have no effect.
+    ///
+    /// Clients can use this to decide whether to present a device-picker UI.
+    ///
+    /// [`recording_devices()`]: Self::recording_devices
+    /// [`playout_devices()`]: Self::playout_devices
+    /// [`set_recording_device()`]: Self::set_recording_device
+    /// [`set_playout_device()`]: Self::set_playout_device
+    pub fn supports_device_selection(&self) -> bool {
+        cfg!(not(any(target_os = "ios", target_os = "android")))
+    }
+
     /// Selects a recording (microphone) device by ID.
     ///
     /// This is the preferred method for device selection as IDs are stable
@@ -668,6 +687,14 @@ impl PlatformAudio {
     /// }
     /// ```
     pub fn set_recording_device(&self, id: &RecordingDeviceId) -> AudioResult<()> {
+        // On mobile the OS owns input routing; selection is an explicit no-op. We
+        // short-circuit here rather than relying on the native layer's device-reporting
+        // quirks (iOS RecordingDeviceName returns -1; Android reports a single GUID-less
+        // device), which would otherwise make the result platform-dependent.
+        if !self.supports_device_selection() {
+            return Ok(());
+        }
+
         if self.handle.runtime.set_recording_device_by_guid(id.as_str()) {
             Ok(())
         } else {
@@ -704,6 +731,11 @@ impl PlatformAudio {
     /// }
     /// ```
     pub fn set_playout_device(&self, id: &PlayoutDeviceId) -> AudioResult<()> {
+        // On mobile the OS owns output routing; selection is an explicit no-op.
+        if !self.supports_device_selection() {
+            return Ok(());
+        }
+
         let runtime = &self.handle.runtime;
         if !runtime.set_playout_device_by_guid(id.as_str()) {
             return Err(AudioError::DeviceNotFound);
@@ -743,6 +775,11 @@ impl PlatformAudio {
     ///
     /// [`set_recording_device`]: Self::set_recording_device
     pub fn switch_recording_device(&self, id: &RecordingDeviceId) -> AudioResult<()> {
+        // On mobile the OS owns input routing; hot-swapping is an explicit no-op.
+        if !self.supports_device_selection() {
+            return Ok(());
+        }
+
         let runtime = &self.handle.runtime;
         let was_initialized = runtime.recording_is_initialized();
 
@@ -793,6 +830,11 @@ impl PlatformAudio {
     ///
     /// [`set_playout_device`]: Self::set_playout_device
     pub fn switch_playout_device(&self, id: &PlayoutDeviceId) -> AudioResult<()> {
+        // On mobile the OS owns output routing; hot-swapping is an explicit no-op.
+        if !self.supports_device_selection() {
+            return Ok(());
+        }
+
         let runtime = &self.handle.runtime;
         let was_initialized = runtime.playout_is_initialized();
 

--- a/webrtc-sys/src/audio_device_controller.cpp
+++ b/webrtc-sys/src/audio_device_controller.cpp
@@ -83,13 +83,11 @@ bool AudioDeviceController::set_playout_device_by_guid(rust::String guid) const 
     }
   }
 
-  // No match found - fall back to default device (index 0).
-  // This handles mobile platforms (iOS/Android) where:
-  // - GUIDs may be empty or not meaningful
-  // - Device selection is a no-op (system handles routing)
-  if (count > 0) {
-    return adm_proxy_->SetPlayoutDevice(0) == 0;
-  }
+  // No match found. We intentionally do NOT fall back to the default device:
+  // an unknown GUID is a genuine error on desktop (the saved device is gone),
+  // and the caller can surface that. Mobile platforms never reach this code -
+  // the Rust layer short-circuits selection there (device selection is a no-op
+  // on iOS/Android, where the OS controls routing).
   return false;
 }
 
@@ -107,13 +105,11 @@ bool AudioDeviceController::set_recording_device_by_guid(rust::String guid) cons
     }
   }
 
-  // No match found - fall back to default device (index 0).
-  // This handles mobile platforms (iOS/Android) where:
-  // - GUIDs may be empty or not meaningful
-  // - Device selection is a no-op (system handles routing)
-  if (count > 0) {
-    return adm_proxy_->SetRecordingDevice(0) == 0;
-  }
+  // No match found. We intentionally do NOT fall back to the default device:
+  // an unknown GUID is a genuine error on desktop (the saved device is gone),
+  // and the caller can surface that. Mobile platforms never reach this code -
+  // the Rust layer short-circuits selection there (device selection is a no-op
+  // on iOS/Android, where the OS controls routing).
   return false;
 }
 


### PR DESCRIPTION
## Summary

Makes platform-audio device selection behave explicitly per platform and exposes a capability flag clients can query.

- **`PlatformAudioInfo.device_selection_supported`** (new proto field) — surfaced so bindings/clients can hide device-picker UI where selection has no effect.
- **`PlatformAudio::supports_device_selection()`** — `false` on iOS/Android, `true` on desktop.
- **Explicit mobile no-op:** `set_recording_device` / `set_playout_device` / `switch_recording_device` / `switch_playout_device` short-circuit to `Ok(())` on iOS/Android *before* touching native, instead of relying on native device-reporting quirks (iOS `RecordingDeviceName` returns -1; Android reports a single GUID-less device).
- **Desktop is now strict:** `webrtc-sys` `set_*_device_by_guid` no longer falls back to index 0 on a GUID miss — an unknown GUID returns `false` → `DeviceNotFound`. This lets a caller detect "the saved device is gone" instead of silently landing on the default. Mobile never reaches this path now.

## Why

The previous "no-op on mobile" was accidental — it fell out of the index-0 fallback in `audio_device_controller.cpp`, which conflated the mobile-unsupported case with a legitimate desktop error (stale GUID).

## Notes

- Branch is based on the commit currently pinned by the Unity SDK submodule (an ancestor of `main`); may need a rebase onto `main` before merge.
- The Unity-side consumer (regenerated C# proto, `PlatformAudio.IsDeviceSelectionSupported`, sample + tests) is a stacked PR in `client-sdk-unity` that bumps the submodule to this commit.
- `cargo fmt` applied; `cargo build -p livekit-ffi` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)