### PR TITLE
webrtc-sys: forward-declare PeerContext as struct (fixes 4x LNK2019 on windows-msvc)

### DIFF
--- a/webrtc-sys/include/livekit/jsep.h
+++ b/webrtc-sys/include/livekit/jsep.h
@@ -35,7 +35,7 @@ class SessionDescription;
 
 namespace livekit_ffi {
 
-class PeerContext;
+struct PeerContext;
 
 class IceCandidate {
  public:


### PR DESCRIPTION
## Summary
`webrtc-sys/include/livekit/jsep.h` forward-declares `class PeerContext;`, but `PeerContext` is a cxx shared type defined on the Rust side as `pub struct PeerContext` (`src/peer_connection.rs`), so cxx emits `struct PeerContext` everywhere it generates C++.

Under the **MSVC ABI** (clang-cl / cl), the `class` vs `struct` tag is part of the mangled name, so `rust::Box<class PeerContext>` (from `jsep.cpp`, which includes `jsep.h`) and `rust::Box<struct PeerContext>` (from the cxx-generated `peer_connection.cc`) mangle to **different symbols** → 4 unresolved externals at link on `x86_64-pc-windows-msvc`:

```
LNK2019: unresolved external symbol ... rust::Box<PeerContext>::drop / ::from_raw / ...
```

GCC/Clang on Linux/macOS use the Itanium ABI, which ignores the class/struct tag in mangling, so this never surfaces there — only the MSVC ABI is affected. Verified identical in webrtc-sys 0.3.21 and 0.3.32.

## Fix (1 word)
```diff
-class PeerContext;
+struct PeerContext;
```
`jsep.h` is the only place in the crate that tags `PeerContext` as `class`; every other reference uses `rust::Box<PeerContext>` (untagged) and the cxx bridge declares it `struct`. Making the forward declaration `struct` makes the tag consistent crate-wide. **No-op on Linux/macOS; fixes the link on windows-msvc.**

## Verification
With this change applied (via `[patch.crates-io]`), `omnynet-agent` links clean with the `livekit-av` feature ON on `x86_64-pc-windows-msvc` (clang-cl), in combination with `+crt-static` for the libwebrtc `/MT` prebuilt, and runtime-connects to a LiveKit room (rust SDK 0.7.42).

Closes the windows-msvc build failure tracked in #1154.