### PR TITLE
perf(livekit-uniffi): omit Android unwind tables in release builds

### DIFF
--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -51,14 +51,26 @@ else
 end
 """
 
+[tasks.android-shared]
+private = true
+
+[tasks.android-shared.env]
+ANDROID_CARGO_OUT_DIR = { source = "${CARGO_MAKE_PROFILE}", mapping = { development = "debug", release = "release", default = "debug" } }
+ANDROID_AAR_BASENAME = "livekit-uniffi-android-release"
+
 [tasks.build-android]
+extend = "android-shared"
 install_crate = { crate_name = "cargo-ndk", binary = "cargo-ndk", test_arg = "--help" }
-script_runner = "@duckscript"
+script_runner = "@shell"
 script = """
 echo "TARGET: ${TARGET}"
-exec rustup target add ${TARGET}
-exec cargo ndk --target ${TARGET} build --release
+rustup target add "${TARGET}"
+cargo ndk --target "${TARGET}" build ${ANDROID_RELEASE_FLAG}
 """
+
+[tasks.build-android.env]
+ANDROID_RELEASE_FLAG = { value = "--release", condition = { profiles = ["release"] } }
+RUSTFLAGS = { value = "-C force-unwind-tables=no", condition = { profiles = ["release"] } }
 
 # MARK: - Build, specific platforms
 
@@ -79,14 +91,17 @@ extend = "build"
 env = { TARGET = "x86_64-unknown-linux-gnu" }
 
 [tasks.build-android-aarch64]
+private = false
 extend = "build-android"
 env = { TARGET = "aarch64-linux-android" }
 
 [tasks.build-android-armv7]
+private = false
 extend = "build-android"
 env = { TARGET = "armv7-linux-androideabi" }
 
 [tasks.build-android-x64]
+private = false
 extend = "build-android"
 env = { TARGET = "x86_64-linux-android" }
 
@@ -474,10 +489,15 @@ run_task = "swift-package-flow"
 #
 # Output: ${PACKAGES_DIR}/android/livekit-uniffi-android-release.aar
 #
-# Full flow: cargo make android-package
+# Debugging:   cargo make android-package
+#              → debug .so files packaged into the release AAR (unstripped Rust
+#                libs for local iteration).
 #
-# Local dev: cargo make android-package-local
-#            → additionally publishes the package to local maven for local use
+# Release:     cargo make --profile release android-package
+#              → release .so files, size gate, release AAR for publishing.
+#
+# Local Maven: cargo make android-package-local
+#              → same AAR flow, published to ~/.m2/repository (Maven Local).
 
 # Enforce a size budget on the arm64-v8a native library an Android user actually
 # downloads. arm64-v8a is the primary shipping arch, so it's the most meaningful 
@@ -489,11 +509,12 @@ run_task = "swift-package-flow"
 ANDROID_SIZE_LIMIT_BYTES = { value = "1572864", condition = { env_not_set = ["ANDROID_SIZE_LIMIT_BYTES"] } }
 
 [tasks.android-check-size]
+extend = "android-shared"
 private = true
 condition = { profiles = ["release"] }
 script_runner = "@shell"
 script = """
-aar="${SUPPORT_DIR}/android/build/outputs/aar/livekit-uniffi-android-release.aar"
+aar="${SUPPORT_DIR}/android/build/outputs/aar/${ANDROID_AAR_BASENAME}.aar"
 
 if [ ! -f "${aar}" ]; then
   echo "android-check-size: release AAR not found at ${aar}" >&2
@@ -521,36 +542,39 @@ echo "${LIB_NAME} (arm64-v8a) ${kib} KiB / ${limit_kib} KiB budget"
 """
 
 [tasks.android-copy-jniLibs]
+extend = "android-shared"
 private = true
-description = "Copy release Android .so files into support/android jniLibs"
+description = "Copy Android .so files into support/android jniLibs"
 script_runner = "@shell"
 script = """
 JNI_LIBS="${SUPPORT_DIR}/android/src/main/jniLibs"
-cp "${TARGET_DIR}/aarch64-linux-android/release/${LIB_NAME}.so" "${JNI_LIBS}/arm64-v8a/"
-cp "${TARGET_DIR}/armv7-linux-androideabi/release/${LIB_NAME}.so" "${JNI_LIBS}/armeabi-v7a/"
-cp "${TARGET_DIR}/x86_64-linux-android/release/${LIB_NAME}.so" "${JNI_LIBS}/x86_64/"
+cp "${TARGET_DIR}/aarch64-linux-android/${ANDROID_CARGO_OUT_DIR}/${LIB_NAME}.so" "${JNI_LIBS}/arm64-v8a/"
+cp "${TARGET_DIR}/armv7-linux-androideabi/${ANDROID_CARGO_OUT_DIR}/${LIB_NAME}.so" "${JNI_LIBS}/armeabi-v7a/"
+cp "${TARGET_DIR}/x86_64-linux-android/${ANDROID_CARGO_OUT_DIR}/${LIB_NAME}.so" "${JNI_LIBS}/x86_64/"
 """
 
 [tasks.android-assemble]
+extend = "android-shared"
 private = true
-description = "Build the release AAR from support/android"
+description = "Build the AAR from support/android"
 script_runner = "@shell"
 script = """
 cd "${SUPPORT_DIR}/android"
 ./gradlew assembleRelease
-echo "AAR: ${SUPPORT_DIR}/android/build/outputs/aar/livekit-uniffi-android-release.aar"
+echo "AAR: ${SUPPORT_DIR}/android/build/outputs/aar/${ANDROID_AAR_BASENAME}.aar"
 """
 
 [tasks.android-copy-to-packages]
+extend = "android-shared"
 private = true
-description = "Copy the release AAR into packages/android"
+description = "Copy the AAR into packages/android"
 script_runner = "@shell"
 script = """
 out_dir="${PACKAGES_DIR}/android"
-aar="${SUPPORT_DIR}/android/build/outputs/aar/livekit-uniffi-android-release.aar"
+aar="${SUPPORT_DIR}/android/build/outputs/aar/${ANDROID_AAR_BASENAME}.aar"
 mkdir -p "${out_dir}"
 cp "${aar}" "${out_dir}/"
-echo "AAR: ${out_dir}/livekit-uniffi-android-release.aar"
+echo "AAR: ${out_dir}/${ANDROID_AAR_BASENAME}.aar"
 """
 
 [tasks.android-package-flow]

--- a/livekit-uniffi/README.md
+++ b/livekit-uniffi/README.md
@@ -36,8 +36,11 @@ To test them out, run `cd node_test && npx tsx index.ts`
 ### Android
 
 Build native libraries, Kotlin bindings, and a release AAR:
+
 ```
-cargo make android-package
+cargo make android-package                              # debug .so in release AAR
+cargo make --profile release android-package            # release .so (CI / publishing)
+cargo make android-package-local                        # + publish to Maven Local
 ```
 
 See [support/android/README.md](./support/android/README.md) for prerequisites (Android SDK/NDK).

--- a/livekit-uniffi/support/android/README.md
+++ b/livekit-uniffi/support/android/README.md
@@ -12,10 +12,14 @@ Gradle Android library module that packages UniFFI Kotlin bindings and native `l
 From the crate root:
 
 ```bash
-cargo make android-package
+cargo make android-package                              # debug .so in release AAR
+cargo make --profile release android-package            # release .so (CI / publishing)
 ```
 
-The built AAR library is located at: `packages/android/livekit-uniffi-android-release.aar`
+The built AAR is located at: `packages/android/livekit-uniffi-android-release.aar`
+
+In the default (development) profile, Rust builds are unoptimized debug artifacts;
+`--profile release` additionally applies release Rust flags and runs the size gate.
 
 ### Local Dev
 
@@ -23,9 +27,8 @@ The built AAR library is located at: `packages/android/livekit-uniffi-android-re
 cargo make android-package-local
 ```
 
-Additionally publishes the package to the local maven repo for local dev use.
-AARs are not yet easily consumed directly by dev tooling, so consuming through 
-local maven is simplest.
+Builds the release AAR (with debug or release `.so` files per profile above) and
+publishes it to the local Maven repo for app integration.
 
 ## Kotlin sources
 

--- a/livekit-uniffi/support/android/build.gradle.kts
+++ b/livekit-uniffi/support/android/build.gradle.kts
@@ -59,6 +59,7 @@ android {
 }
 
 dependencies {
+    implementation("androidx.annotation:annotation:1.9.0")
     implementation("net.java.dev.jna:jna:5.16.0@aar")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
 }


### PR DESCRIPTION
## Summary

- Add **`-C force-unwind-tables=no`** for livekit-uniffi **Android release** native builds to reduce `.eh_frame` / unwind metadata in shipped `.so` files.
- Scope the flag to **`cargo make --profile release`** (via `RUSTFLAGS` on `build-android`) so the default development profile still emits unwind tables — better for local crash backtraces when iterating on Rust code.
- Make Android packaging **profile-aware** (mirroring iOS): development builds debug Rust artifacts; release builds optimized artifacts and run the existing arm64 size gate. Gradle continues to produce the **release AAR** in both cases.

## Why

Modern Rust may emit unwind tables even with `panic = "abort"`. For mobile SDKs that trade crash-time unwinding for binary size, `force-unwind-tables=no` is a standard knob. The change only affects release builds, development builds still keep the tables for debuggability.

## Size impact

Measured on **`blaze/uniffi-size-trim`** branch (due to some of the savings overlapping) with symmetric `aarch64-linux-android` release builds:
| Variant | Size |
|---------|------|
| Baseline (no flag) | **836,136 B (816.5 KiB)** |
| `-C force-unwind-tables=no` | **718,744 B (701.9 KiB)** |
| **Savings** | **117,392 B (114.6 KiB, ~14%)** |

## Tradeoff

Release Android `.so` files may produce **sparser on-device crash stacks** before symbolication. Acceptable for a `panic = "abort"` UniFFI library optimized for size; debug builds are unaffected.

## Validation

* `cargo make --profile release android-package` passes `android-check-size`
* Release arm64-v8a `.so` in the AAR is smaller than without the flag
* `cargo make android-package` (development) still builds debug `.so` files without the flag
