### PR TITLE
fix: escalate to full reconnect if connection failed during a resume

### DIFF
--- a/.changeset/fix_escalate_to_full_reconnect_if_connection_failed_during_a.md
+++ b/.changeset/fix_escalate_to_full_reconnect_if_connection_failed_during_a.md
@@ -1,0 +1,6 @@
+---
+livekit: patch
+livekit-ffi: patch
+---
+
+fix: escalate to full reconnect if connection failed during a resume - #1175 (@davidzhao)

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -830,6 +830,21 @@ impl Room {
         self.inner.rtc_engine.simulate_scenario(scenario).await
     }
 
+    /// Test-only: force the next `count` resume attempts to fail, exercising the
+    /// resume-failure → full-reconnect escalation path end-to-end.
+    #[cfg(feature = "__lk-e2e-test")]
+    pub fn fail_next_resume_attempts(&self, count: u32) {
+        self.inner.rtc_engine.fail_next_resume_attempts(count);
+    }
+
+    /// Test-only: arm a one-shot fault so the next resume simulates a concurrent
+    /// transport failure (then still succeeds), reproducing the resume-reports-
+    /// success-while-a-failure-was-pending race.
+    #[cfg(feature = "__lk-e2e-test")]
+    pub fn escalate_during_next_resume(&self) {
+        self.inner.rtc_engine.escalate_during_next_resume();
+    }
+
     pub async fn get_stats(&self) -> EngineResult<SessionStats> {
         self.inner.rtc_engine.get_stats().await
     }

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -841,8 +841,8 @@ impl Room {
     /// transport failure (then still succeeds), reproducing the resume-reports-
     /// success-while-a-failure-was-pending race.
     #[cfg(feature = "__lk-e2e-test")]
-    pub fn escalate_during_next_resume(&self) {
-        self.inner.rtc_engine.escalate_during_next_resume();
+    pub fn fail_transport_during_next_resume(&self) {
+        self.inner.rtc_engine.fail_transport_during_next_resume();
     }
 
     pub async fn get_stats(&self) -> EngineResult<SessionStats> {

--- a/livekit/src/rtc_engine/mod.rs
+++ b/livekit/src/rtc_engine/mod.rs
@@ -258,7 +258,7 @@ struct EngineInner {
     /// while a failure was pending — the failure must escalate the *next* cycle to
     /// a full reconnect. Always false in production builds.
     #[cfg(feature = "__lk-e2e-test")]
-    escalate_during_next_resume: std::sync::atomic::AtomicBool,
+    fail_transport_during_next_resume: std::sync::atomic::AtomicBool,
 }
 
 pub struct RtcEngine {
@@ -414,8 +414,8 @@ impl RtcEngine {
     /// concurrent transport failure (then still succeeds), reproducing a resume
     /// that reports success while a failure was pending.
     #[cfg(feature = "__lk-e2e-test")]
-    pub fn escalate_during_next_resume(&self) {
-        self.inner.escalate_during_next_resume.store(true, std::sync::atomic::Ordering::Release);
+    pub fn fail_transport_during_next_resume(&self) {
+        self.inner.fail_transport_during_next_resume.store(true, std::sync::atomic::Ordering::Release);
     }
 }
 
@@ -460,7 +460,7 @@ impl EngineInner {
                         #[cfg(feature = "__lk-e2e-test")]
                         fail_resume_attempts: std::sync::atomic::AtomicU32::new(0),
                         #[cfg(feature = "__lk-e2e-test")]
-                        escalate_during_next_resume: std::sync::atomic::AtomicBool::new(false),
+                        fail_transport_during_next_resume: std::sync::atomic::AtomicBool::new(false),
                     });
 
                     // Start initial tasks
@@ -988,7 +988,7 @@ impl EngineInner {
             // proceeds and succeeds — reproducing a resume that reports success while a
             // failure was pending. Post-fix this sticks a full-reconnect escalation onto
             // the next cycle; pre-fix it was dropped and the engine resumed again.
-            if self.escalate_during_next_resume.swap(false, Ordering::AcqRel) {
+            if self.fail_transport_during_next_resume.swap(false, Ordering::AcqRel) {
                 log::warn!("test fault injection: simulating concurrent failure during resume");
                 self.reconnection_needed(false, false);
             }

--- a/livekit/src/rtc_engine/mod.rs
+++ b/livekit/src/rtc_engine/mod.rs
@@ -415,7 +415,9 @@ impl RtcEngine {
     /// that reports success while a failure was pending.
     #[cfg(feature = "__lk-e2e-test")]
     pub fn fail_transport_during_next_resume(&self) {
-        self.inner.fail_transport_during_next_resume.store(true, std::sync::atomic::Ordering::Release);
+        self.inner
+            .fail_transport_during_next_resume
+            .store(true, std::sync::atomic::Ordering::Release);
     }
 }
 
@@ -460,7 +462,9 @@ impl EngineInner {
                         #[cfg(feature = "__lk-e2e-test")]
                         fail_resume_attempts: std::sync::atomic::AtomicU32::new(0),
                         #[cfg(feature = "__lk-e2e-test")]
-                        fail_transport_during_next_resume: std::sync::atomic::AtomicBool::new(false),
+                        fail_transport_during_next_resume: std::sync::atomic::AtomicBool::new(
+                            false,
+                        ),
                     });
 
                     // Start initial tasks

--- a/livekit/src/rtc_engine/mod.rs
+++ b/livekit/src/rtc_engine/mod.rs
@@ -243,6 +243,22 @@ struct EngineInner {
     // (This also prevents new reconnection to happens if a read guard is still held)
     reconnecting_lock: AsyncRwLock<()>,
     reconnecting_interval: AsyncMutex<Interval>,
+
+    /// Test-only fault injection: number of upcoming resume attempts to force to
+    /// fail. Each forced failure decrements this counter and makes
+    /// `try_resume_connection` return an error, which exercises the escalation to a
+    /// full reconnect. Always 0 in production builds.
+    #[cfg(feature = "__lk-e2e-test")]
+    fail_resume_attempts: std::sync::atomic::AtomicU32,
+
+    /// Test-only fault injection: when set, the next resume attempt simulates a
+    /// transport failure (a server `Leave{Resume}` / PeerConnection `Failed`)
+    /// arriving *concurrently* with the in-flight resume, then proceeds and
+    /// succeeds. Reproduces the production race where a resume reports success
+    /// while a failure was pending — the failure must escalate the *next* cycle to
+    /// a full reconnect. Always false in production builds.
+    #[cfg(feature = "__lk-e2e-test")]
+    escalate_during_next_resume: std::sync::atomic::AtomicBool,
 }
 
 pub struct RtcEngine {
@@ -386,6 +402,21 @@ impl RtcEngine {
     pub fn session(&self) -> Arc<RtcSession> {
         self.inner.running_handle.read().session.clone()
     }
+
+    /// Test-only: force the next `count` resume attempts to fail, so tests can
+    /// deterministically exercise the resume-failure → full-reconnect escalation.
+    #[cfg(feature = "__lk-e2e-test")]
+    pub fn fail_next_resume_attempts(&self, count: u32) {
+        self.inner.fail_resume_attempts.store(count, std::sync::atomic::Ordering::Release);
+    }
+
+    /// Test-only: arm a one-shot fault so the next resume attempt simulates a
+    /// concurrent transport failure (then still succeeds), reproducing a resume
+    /// that reports success while a failure was pending.
+    #[cfg(feature = "__lk-e2e-test")]
+    pub fn escalate_during_next_resume(&self) {
+        self.inner.escalate_during_next_resume.store(true, std::sync::atomic::Ordering::Release);
+    }
 }
 
 impl EngineInner {
@@ -426,6 +457,10 @@ impl EngineInner {
                         options,
                         reconnecting_lock: AsyncRwLock::default(),
                         reconnecting_interval: AsyncMutex::new(interval),
+                        #[cfg(feature = "__lk-e2e-test")]
+                        fail_resume_attempts: std::sync::atomic::AtomicU32::new(0),
+                        #[cfg(feature = "__lk-e2e-test")]
+                        escalate_during_next_resume: std::sync::atomic::AtomicBool::new(false),
                     });
 
                     // Start initial tasks
@@ -718,16 +753,19 @@ impl EngineInner {
         }
 
         if running_handle.reconnecting {
-            // If we're already reconnecting just update the interval to restart a new attempt
-            // ASAP
+            // A new failure surfaced while we're already reconnecting. That means the
+            // in-progress resume isn't holding — e.g. a PeerConnection moved to `Failed`
+            // mid-resume, or a stale resume reported a false success and the transport
+            // died again. A single resume failure is enough: escalate to a full
+            // reconnect instead of looping on resume forever.
+            //
+            // This escalation is sticky — it survives into the next cycle (see the
+            // cycle-start below) so a resume that spuriously reports success can't reset
+            // us back to resuming. It's cleared only once a full reconnect installs a
+            // fresh session (see `try_restart_connection`).
+            running_handle.full_reconnect = true;
 
-            // Only escalate to full reconnect, never downgrade. Stale signal-close
-            // events (which request resume) must not override a full reconnect decision
-            // made by the reconnect loop after a failed resume attempt.
-            if full_reconnect {
-                running_handle.full_reconnect = true;
-            }
-
+            // Retry as soon as possible when asked, rather than waiting out the backoff.
             if retry_now {
                 let inner = self.clone();
                 livekit_runtime::spawn(async move {
@@ -739,7 +777,10 @@ impl EngineInner {
         }
 
         running_handle.reconnecting = true;
-        running_handle.full_reconnect = full_reconnect;
+        // Never downgrade a sticky escalation: if a prior cycle decided we need a full
+        // reconnect (a failed/false-successful resume), keep it. Cleared on a successful
+        // full reconnect in `try_restart_connection`.
+        running_handle.full_reconnect |= full_reconnect;
 
         livekit_runtime::spawn({
             let inner = self.clone();
@@ -918,6 +959,7 @@ impl EngineInner {
         // event.
         let mut handle = self.running_handle.write();
         handle.session = Arc::new(new_session);
+        handle.full_reconnect = false;
 
         let (close_tx, close_rx) = oneshot::channel();
         let task = livekit_runtime::spawn(self.clone().engine_task(session_events, close_rx));
@@ -927,7 +969,31 @@ impl EngineInner {
     }
 
     /// Try to restart the current session
-    async fn try_resume_connection(&self) -> EngineResult<()> {
+    async fn try_resume_connection(self: &Arc<Self>) -> EngineResult<()> {
+        // Test-only: force the configured number of resume attempts to fail so tests
+        // can exercise the resume-failure → full-reconnect escalation deterministically.
+        #[cfg(feature = "__lk-e2e-test")]
+        {
+            use std::sync::atomic::Ordering;
+            let remaining = self.fail_resume_attempts.load(Ordering::Acquire);
+            if remaining > 0 {
+                self.fail_resume_attempts.store(remaining - 1, Ordering::Release);
+                log::warn!("test fault injection: forcing resume attempt to fail");
+                return Err(EngineError::Connection("forced resume failure (test)".into()));
+            }
+
+            // Simulate a transport failure (server Leave{Resume} / PC Failed) arriving
+            // while this resume is in flight. We're already reconnecting, so this drives
+            // the "already reconnecting" branch of `reconnection_needed`. The resume then
+            // proceeds and succeeds — reproducing a resume that reports success while a
+            // failure was pending. Post-fix this sticks a full-reconnect escalation onto
+            // the next cycle; pre-fix it was dropped and the engine resumed again.
+            if self.escalate_during_next_resume.swap(false, Ordering::AcqRel) {
+                log::warn!("test fault injection: simulating concurrent failure during resume");
+                self.reconnection_needed(false, false);
+            }
+        }
+
         let session = self.running_handle.read().session.clone();
         let reconnect_response = session.restart().await?;
 

--- a/livekit/tests/peer_connection_signaling_test.rs
+++ b/livekit/tests/peer_connection_signaling_test.rs
@@ -1124,10 +1124,7 @@ async fn test_resume_failure_escalates_impl(mode: SignalingMode) -> Result<()> {
                     log::info!("[{}] Reconnecting...", mode.name());
                 }
                 RoomEvent::LocalTrackRepublished { .. } => {
-                    log::info!(
-                        "[{}] Track republished — escalated to full reconnect",
-                        mode.name()
-                    );
+                    log::info!("[{}] Track republished — escalated to full reconnect", mode.name());
                     saw_republish = true;
                 }
                 RoomEvent::Reconnected => {

--- a/livekit/tests/peer_connection_signaling_test.rs
+++ b/livekit/tests/peer_connection_signaling_test.rs
@@ -312,6 +312,33 @@ async fn test_v1_double_reconnect() -> Result<()> {
     test_double_reconnect_impl(SignalingMode::SinglePC).await
 }
 
+/// A resume that fails once must escalate to a full reconnect (not loop on
+/// resume). The first resume attempt is forced to fail via fault injection; the
+/// engine must then recover by doing a full reconnect.
+#[test_log::test(tokio::test)]
+async fn test_v0_resume_failure_escalates_to_full_reconnect() -> Result<()> {
+    test_resume_failure_escalates_impl(SignalingMode::DualPC).await
+}
+
+#[test_log::test(tokio::test)]
+async fn test_v1_resume_failure_escalates_to_full_reconnect() -> Result<()> {
+    test_resume_failure_escalates_impl(SignalingMode::SinglePC).await
+}
+
+/// A failure surfacing during an in-flight resume must escalate the *next* resume
+/// cycle to a full reconnect (sticky escalation), instead of looping on resume.
+/// Reproduces the production migration loop. The mid-resume failure is injected via
+/// the same `reconnection_needed` path a server `Leave{Resume}` takes.
+#[test_log::test(tokio::test)]
+async fn test_v0_resume_escalation_sticks_across_cycles() -> Result<()> {
+    test_resume_escalation_sticks_across_cycles_impl(SignalingMode::DualPC).await
+}
+
+#[test_log::test(tokio::test)]
+async fn test_v1_resume_escalation_sticks_across_cycles() -> Result<()> {
+    test_resume_escalation_sticks_across_cycles_impl(SignalingMode::SinglePC).await
+}
+
 /// Corner case: resume without ever having published a track. In single-PC mode
 /// this exercises the publisher ICE restart even though `has_published=false`
 /// (the fix for the single-PC publisher gating bug). In dual-PC subscriber-
@@ -1045,6 +1072,230 @@ async fn test_double_reconnect_impl(mode: SignalingMode) -> Result<()> {
         assert_eq!(room.connection_state(), ConnectionState::Connected);
     }
 
+    Ok(())
+}
+
+/// Verify that a single resume failure escalates to a full reconnect.
+///
+/// Forces the first resume attempt to fail via fault injection, then asserts the
+/// engine recovers by escalating to a full reconnect — observed via
+/// `LocalTrackRepublished`, which only the full-reconnect path emits (a resume
+/// preserves publications and never republishes). Without escalation the engine
+/// would keep retrying resume and the connection would never recover. Covers both
+/// dual-PC and single-PC signaling.
+async fn test_resume_failure_escalates_impl(mode: SignalingMode) -> Result<()> {
+    let (url, api_key, api_secret) = get_env_for_mode(mode);
+    let room_name = format!("test_{:?}_resume_fail_escalate_{}", mode, create_random_uuid());
+    let token = create_token(&api_key, &api_secret, &room_name, "resume_fail_tester")?;
+
+    let (room, mut events) = connect_room(&url, &token, mode).await?;
+    assert_signaling_mode_state(&room, mode, &url);
+
+    let room_arc = Arc::new(room);
+
+    // Publish a track so the full-reconnect path has something to republish (the
+    // `LocalTrackRepublished` event is our proof that escalation occurred).
+    let sine_params =
+        SineParameters { freq: 440.0, amplitude: 1.0, sample_rate: 48000, num_channels: 1 };
+    let mut sine_track = SineTrack::new(room_arc.clone(), sine_params);
+    sine_track.publish().await?;
+
+    let tracks_before = room_arc.local_participant().track_publications().len();
+    assert_eq!(tracks_before, 1, "precondition: one track published");
+
+    // Arm the fault: the next resume attempt fails. The engine must escalate to a
+    // full reconnect instead of looping on resume.
+    room_arc.fail_next_resume_attempts(1);
+
+    log::info!("[{}] Triggering reconnect with the first resume forced to fail", mode.name());
+    room_arc.simulate_scenario(SimulateScenario::SignalReconnect).await?;
+
+    // Recovery must come via the full-reconnect path. `LocalTrackRepublished` is
+    // dispatched before `Reconnected` within the same restart task, so by the time
+    // we observe `Reconnected` we will already have flipped `saw_republish`.
+    let mut saw_republish = false;
+    let wait_recovered = async {
+        loop {
+            let Some(event) = events.recv().await else {
+                return Err(anyhow!("Event channel closed"));
+            };
+            match event {
+                RoomEvent::Reconnecting => {
+                    log::info!("[{}] Reconnecting...", mode.name());
+                }
+                RoomEvent::LocalTrackRepublished { .. } => {
+                    log::info!(
+                        "[{}] Track republished — escalated to full reconnect",
+                        mode.name()
+                    );
+                    saw_republish = true;
+                }
+                RoomEvent::Reconnected => {
+                    log::info!("[{}] Reconnected", mode.name());
+                    return Ok(());
+                }
+                RoomEvent::Disconnected { reason } => {
+                    return Err(anyhow!("unexpected disconnect during recovery: {:?}", reason));
+                }
+                _ => {}
+            }
+        }
+    };
+
+    // Generous timeout: a forced resume failure ticks the reconnect interval
+    // (RECONNECT_INTERVAL = 5s) before the escalated full reconnect runs.
+    timeout(Duration::from_secs(40), wait_recovered)
+        .await
+        .context("Timeout waiting for full-reconnect recovery after forced resume failure")??;
+
+    assert!(
+        saw_republish,
+        "expected a full reconnect (LocalTrackRepublished) after the resume failure; \
+         recovery without escalation means the resume failure was not escalated"
+    );
+    assert_eq!(room_arc.connection_state(), ConnectionState::Connected);
+
+    let tracks_after = room_arc.local_participant().track_publications().len();
+    assert_eq!(
+        tracks_before, tracks_after,
+        "track should be restored after the escalated full reconnect"
+    );
+
+    log::info!("[{}] Test passed - resume failure escalated to full reconnect!", mode.name());
+    Ok(())
+}
+
+/// Verify the resume-failure escalation is *sticky across reconnect cycles*.
+///
+/// Reproduces the production migration loop: a transport failure (a server
+/// `Leave{Resume}` / PeerConnection `Failed`) arrives while a resume is in flight,
+/// the resume reports success anyway, and the follow-up resume cycle must escalate
+/// to a full reconnect rather than resuming again forever.
+///
+/// The concurrent failure is injected via fault injection during the FIRST resume —
+/// `escalate_during_next_resume` drives the exact same `reconnection_needed` path a
+/// real server `Leave{Resume}` takes — and the resume still succeeds as a plain
+/// resume (no republish). Post-fix, the SECOND resume cycle escalates to a full
+/// reconnect, observed via `LocalTrackRepublished` (only the full-reconnect path
+/// republishes). Pre-fix the pending escalation is dropped, the second cycle resumes
+/// again with no republish, and the final assertion fails.
+///
+/// The two cycles are driven by `SignalReconnect` rather than the `Migration`
+/// (server `Leave{Resume}`) scenario on purpose: a single-node `livekit-server
+/// --dev` has no node to migrate to, so a migration resume fails immediately and
+/// escalates on its own — which would mask the cross-cycle behavior under test.
+/// `SignalReconnect` resumes cleanly, keeping the pre-fix path on resume so the
+/// regression is observable.
+async fn test_resume_escalation_sticks_across_cycles_impl(mode: SignalingMode) -> Result<()> {
+    // Two participants: a lone publisher's resume can fail with a webrtc error on a
+    // `--dev` server, so we pair the publisher with a subscriber (as in the reconnect
+    // test) to keep the resume path healthy. The cross-cycle escalation needs cycle 1
+    // to succeed *as a resume*, so a reliable resume is essential.
+    let mut rooms = test_rooms_with_options([room_options(mode), room_options(mode)]).await?;
+    let (sub_room, mut sub_events) = rooms.pop().unwrap();
+    let (pub_room, mut events) = rooms.pop().unwrap();
+    let _sub_room = sub_room; // keep the subscriber alive for the duration of the test
+
+    let pub_room_arc = Arc::new(pub_room);
+
+    let sine_params =
+        SineParameters { freq: 440.0, amplitude: 1.0, sample_rate: 48000, num_channels: 1 };
+    let mut sine_track = SineTrack::new(pub_room_arc.clone(), sine_params);
+    sine_track.publish().await?;
+    assert_eq!(pub_room_arc.local_participant().track_publications().len(), 1);
+
+    // Wait for the subscriber to receive the track, ensuring the publisher PC is fully
+    // connected before we start tearing the signal connection down.
+    let wait_subscribed = async {
+        loop {
+            let Some(event) = sub_events.recv().await else {
+                return Err(anyhow!("Subscriber event channel closed"));
+            };
+            if let RoomEvent::TrackSubscribed { .. } = event {
+                return Ok(());
+            }
+        }
+    };
+    timeout(Duration::from_secs(15), wait_subscribed)
+        .await
+        .context("Timeout waiting for subscriber to receive the published track")??;
+
+    let room_arc = pub_room_arc;
+
+    // --- Cycle 1: a resume with a concurrent failure injected mid-resume. The resume
+    // must still succeed as a plain resume (no republish). ---
+    room_arc.escalate_during_next_resume();
+    log::info!("[{}] Cycle 1: resume + concurrent failure injected mid-resume", mode.name());
+    room_arc.simulate_scenario(SimulateScenario::SignalReconnect).await?;
+
+    let mut cycle1_republished = false;
+    let wait_cycle1 = async {
+        loop {
+            let Some(event) = events.recv().await else {
+                return Err(anyhow!("Event channel closed"));
+            };
+            match event {
+                RoomEvent::LocalTrackRepublished { .. } => cycle1_republished = true,
+                RoomEvent::Reconnected => return Ok(()),
+                RoomEvent::Disconnected { reason } => {
+                    return Err(anyhow!("unexpected disconnect in cycle 1: {:?}", reason));
+                }
+                _ => {}
+            }
+        }
+    };
+    timeout(Duration::from_secs(40), wait_cycle1)
+        .await
+        .context("Timeout waiting for cycle 1 (resume) to recover")??;
+
+    // Premise check: cycle 1 must have been a resume, not a full reconnect. If the
+    // server's resume failed it would escalate here, voiding the cross-cycle test.
+    assert!(
+        !cycle1_republished,
+        "cycle 1 republished (full reconnect) — the resume did not complete as a resume, \
+         so the cross-cycle escalation premise does not hold"
+    );
+    assert_eq!(room_arc.connection_state(), ConnectionState::Connected);
+
+    // Let the reconnect cycle fully unwind (the `reconnecting` flag clears just after
+    // the Reconnected event) before triggering the next one.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // --- Cycle 2: another server Leave{Resume}. The failure pending from cycle 1 must
+    // now escalate this cycle to a full reconnect. ---
+    log::info!("[{}] Cycle 2: resume — must escalate to full reconnect", mode.name());
+    room_arc.simulate_scenario(SimulateScenario::SignalReconnect).await?;
+
+    let mut cycle2_republished = false;
+    let wait_cycle2 = async {
+        loop {
+            let Some(event) = events.recv().await else {
+                return Err(anyhow!("Event channel closed"));
+            };
+            match event {
+                RoomEvent::LocalTrackRepublished { .. } => cycle2_republished = true,
+                RoomEvent::Reconnected => return Ok(()),
+                RoomEvent::Disconnected { reason } => {
+                    return Err(anyhow!("unexpected disconnect in cycle 2: {:?}", reason));
+                }
+                _ => {}
+            }
+        }
+    };
+    timeout(Duration::from_secs(40), wait_cycle2)
+        .await
+        .context("Timeout waiting for cycle 2 recovery")??;
+
+    assert!(
+        cycle2_republished,
+        "cycle 2 did not escalate to a full reconnect (no LocalTrackRepublished): the \
+         failure pending from cycle 1's resume was dropped instead of sticking — this is \
+         the pre-fix resume-loop bug"
+    );
+    assert_eq!(room_arc.connection_state(), ConnectionState::Connected);
+    assert_eq!(room_arc.local_participant().track_publications().len(), 1);
+
+    log::info!("[{}] Test passed - escalation persisted across resume cycles!", mode.name());
     Ok(())
 }
 

--- a/livekit/tests/peer_connection_signaling_test.rs
+++ b/livekit/tests/peer_connection_signaling_test.rs
@@ -1170,7 +1170,7 @@ async fn test_resume_failure_escalates_impl(mode: SignalingMode) -> Result<()> {
 /// to a full reconnect rather than resuming again forever.
 ///
 /// The concurrent failure is injected via fault injection during the FIRST resume —
-/// `escalate_during_next_resume` drives the exact same `reconnection_needed` path a
+/// `fail_transport_during_next_resume` drives the exact same `reconnection_needed` path a
 /// real server `Leave{Resume}` takes — and the resume still succeeds as a plain
 /// resume (no republish). Post-fix, the SECOND resume cycle escalates to a full
 /// reconnect, observed via `LocalTrackRepublished` (only the full-reconnect path
@@ -1221,7 +1221,7 @@ async fn test_resume_escalation_sticks_across_cycles_impl(mode: SignalingMode) -
 
     // --- Cycle 1: a resume with a concurrent failure injected mid-resume. The resume
     // must still succeed as a plain resume (no republish). ---
-    room_arc.escalate_during_next_resume();
+    room_arc.fail_transport_during_next_resume();
     log::info!("[{}] Cycle 1: resume + concurrent failure injected mid-resume", mode.name());
     room_arc.simulate_scenario(SimulateScenario::SignalReconnect).await?;
 


### PR DESCRIPTION
if connections cannot be successfully resumed, previously it could be stuck in a resume cycle without correctly escalating it to a full reconnect loop.

added test cases to cover this scenario. the tests were failing before the fix
