### PR TITLE
docs: add deployment field documentation for agent dispatch

### DIFF
--- a/.changeset/agent-deployment-docs.md
+++ b/.changeset/agent-deployment-docs.md
@@ -1,0 +1,5 @@
+---
+"livekit-api": patch
+---
+
+Add deployment field documentation for agent dispatch

--- a/examples/agent_dispatch/src/main.rs
+++ b/examples/agent_dispatch/src/main.rs
@@ -25,6 +25,10 @@ struct Args {
     /// Registered agent name to dispatch
     #[arg(long, default_value = "my-agent")]
     agent_name: String,
+
+    /// Optional deployment to target. Leave empty to target production deployment.
+    #[arg(long, default_value = "")]
+    deployment: String,
 }
 
 #[tokio::main]
@@ -36,10 +40,13 @@ async fn main() {
     // Instantiate the AgentDispatch service client
     let client = AgentDispatchClient::with_api_key(&host, &args.api_key, &args.api_secret);
 
-    // Create a dispatch for the given agent into the room
+    // Create a dispatch for the given agent into the room.
+    // The `deployment` field can be used to target a specific agent deployment.
+    // Leave empty to target the production deployment.
     let req = proto::CreateAgentDispatchRequest {
         agent_name: args.agent_name,
         room: args.room_name,
+        deployment: args.deployment,
         ..Default::default()
     };
 

--- a/livekit-api/src/services/agent_dispatch.rs
+++ b/livekit-api/src/services/agent_dispatch.rs
@@ -46,7 +46,9 @@ impl AgentDispatchClient {
     /// To use explicit dispatch, your agent must be registered with an `agent_name`.
     ///
     /// # Arguments
-    /// * `req` - Request containing dispatch creation parameters
+    /// * `req` - Request containing dispatch creation parameters. The request can include
+    ///   an optional `deployment` field to target a specific agent deployment.
+    ///   Leave empty to target the production deployment.
     ///
     /// # Returns
     /// The created agent dispatch object


### PR DESCRIPTION
## Summary
- Update docstrings to document the `deployment` field in `create_dispatch`
- Update agent_dispatch example to support the `--deployment` argument
- Add changeset

The `deployment` field allows targeting a specific agent deployment (e.g., "staging"). Leave empty to target the production deployment.

Related PRs:
- node-sdks: https://github.com/livekit/node-sdks/pull/675
- python-sdks: https://github.com/livekit/python-sdks/pull/722
- client-sdk-js: https://github.com/livekit/client-sdk-js/pull/1971

## Test plan

### Unit Tests
```bash
cd /path/to/rust-sdks
cargo test -p livekit-api
```

### Manual Verification

**1. Run example with deployment flag:**
```bash
cd examples/agent_dispatch
cargo run -- \
  --url $LIVEKIT_URL \
  --key $LIVEKIT_API_KEY \
  --secret $LIVEKIT_API_SECRET \
  --room-name test-room \
  --agent-name my-agent \
  --deployment staging
```

**2. Verify response contains deployment:**
```rust
let dispatch = client.create_dispatch(CreateAgentDispatchRequest {
    agent_name: "my-agent".into(),
    room: "test-room".into(),
    deployment: "staging".into(),
    ..Default::default()
}).await?;

println!("Dispatch ID: {}", dispatch.id);
println!("Deployment: {}", dispatch.deployment);  // Should print "staging"
```

**3. Verify via list_dispatch:**
```rust
let dispatches = client.list_dispatch("test-room").await?;
for d in dispatches {
    println!("Dispatch {}: deployment={}", d.id, d.deployment);
}
```

### End-to-End Verification
1. Register an agent worker with `deployment="staging"`
2. Create a dispatch targeting `deployment="staging"` using the example
3. Verify only the staging agent receives the job

🤖 Generated with [Claude Code](https://claude.com/claude-code)