### PR TITLE
add SetRate to nvenc encoder implementations

### DIFF
--- a/webrtc-sys/src/nvidia/NvCodec/NvCodec/NvEncoder/NvEncoder.cpp
+++ b/webrtc-sys/src/nvidia/NvCodec/NvCodec/NvEncoder/NvEncoder.cpp
@@ -683,6 +683,38 @@ bool NvEncoder::Reconfigure(
   return true;
 }
 
+bool NvEncoder::SetRates(uint32_t frameRate, uint32_t averageBitrate) {
+  if (!IsHWEncoderInitialized()) {
+    return false;
+  }
+  if (frameRate == 0) {
+    frameRate = 1;
+  }
+
+  NV_ENC_RECONFIGURE_PARAMS reconfigureParams = {};
+  reconfigureParams.version = NV_ENC_RECONFIGURE_PARAMS_VER;
+
+  NV_ENC_CONFIG encodeConfig = {};
+  encodeConfig.version = NV_ENC_CONFIG_VER;
+  reconfigureParams.reInitEncodeParams.version = NV_ENC_INITIALIZE_PARAMS_VER;
+  reconfigureParams.reInitEncodeParams.encodeConfig = &encodeConfig;
+
+  GetInitializeParams(&reconfigureParams.reInitEncodeParams);
+
+  reconfigureParams.reInitEncodeParams.frameRateNum = frameRate;
+  reconfigureParams.reInitEncodeParams.frameRateDen = 1;
+
+  encodeConfig.rcParams.averageBitRate = averageBitrate;
+  encodeConfig.rcParams.vbvBufferSize = (averageBitrate / frameRate) * 5;
+  encodeConfig.rcParams.vbvInitialDelay = encodeConfig.rcParams.vbvBufferSize;
+
+  try {
+    return Reconfigure(&reconfigureParams);
+  } catch (const NVENCException&) {
+    return false;
+  }
+}
+
 NV_ENC_REGISTERED_PTR NvEncoder::RegisterResource(
     void* pBuffer,
     NV_ENC_INPUT_RESOURCE_TYPE eResourceType,

--- a/webrtc-sys/src/nvidia/NvCodec/NvCodec/NvEncoder/NvEncoder.h
+++ b/webrtc-sys/src/nvidia/NvCodec/NvCodec/NvEncoder/NvEncoder.h
@@ -115,6 +115,13 @@ class NvEncoder {
   bool Reconfigure(const NV_ENC_RECONFIGURE_PARAMS* pReconfigureParams);
 
   /**
+   *  @brief  Dynamically updates the encode bitrate and framerate on the live
+   *  session. Returns false if the encoder is not initialized or reconfigure
+   *  fails.
+   */
+  bool SetRates(uint32_t frameRate, uint32_t averageBitrate);
+
+  /**
    *  @brief  This function is used to get the next available input buffer.
    *  Applications must call this function to obtain a pointer to the next
    *  input buffer. The application must copy the uncompressed data to the

--- a/webrtc-sys/src/nvidia/av1_encoder_impl.cpp
+++ b/webrtc-sys/src/nvidia/av1_encoder_impl.cpp
@@ -454,6 +454,8 @@ void NvidiaAV1EncoderImpl::SetRates(
   configuration_.target_bps = parameters.bitrate.GetSpatialLayerSum(0);
   configuration_.max_frame_rate = parameters.framerate_fps;
 
+  encoder_->SetRates(codec_.maxFramerate, configuration_.target_bps);
+
   if (configuration_.target_bps) {
     configuration_.SetStreamState(true);
   } else {

--- a/webrtc-sys/src/nvidia/av1_encoder_impl.cpp
+++ b/webrtc-sys/src/nvidia/av1_encoder_impl.cpp
@@ -454,7 +454,9 @@ void NvidiaAV1EncoderImpl::SetRates(
   configuration_.target_bps = parameters.bitrate.GetSpatialLayerSum(0);
   configuration_.max_frame_rate = parameters.framerate_fps;
 
-  encoder_->SetRates(codec_.maxFramerate, configuration_.target_bps);
+  if (!encoder_->SetRates(codec_.maxFramerate, configuration_.target_bps)) {
+    RTC_LOG(LS_WARNING) << "Failed to reconfigure NVENC rates.";
+  }
 
   if (configuration_.target_bps) {
     configuration_.SetStreamState(true);

--- a/webrtc-sys/src/nvidia/h264_encoder_impl.cpp
+++ b/webrtc-sys/src/nvidia/h264_encoder_impl.cpp
@@ -439,6 +439,8 @@ void NvidiaH264EncoderImpl::SetRates(
   configuration_.target_bps = parameters.bitrate.GetSpatialLayerSum(0);
   configuration_.max_frame_rate = parameters.framerate_fps;
 
+  encoder_->SetRates(codec_.maxFramerate, configuration_.target_bps);
+
   if (configuration_.target_bps) {
     configuration_.SetStreamState(true);
   } else {

--- a/webrtc-sys/src/nvidia/h264_encoder_impl.cpp
+++ b/webrtc-sys/src/nvidia/h264_encoder_impl.cpp
@@ -439,7 +439,9 @@ void NvidiaH264EncoderImpl::SetRates(
   configuration_.target_bps = parameters.bitrate.GetSpatialLayerSum(0);
   configuration_.max_frame_rate = parameters.framerate_fps;
 
-  encoder_->SetRates(codec_.maxFramerate, configuration_.target_bps);
+  if (!encoder_->SetRates(codec_.maxFramerate, configuration_.target_bps)) {
+    RTC_LOG(LS_WARNING) << "Failed to reconfigure NVENC rates.";
+  }
 
   if (configuration_.target_bps) {
     configuration_.SetStreamState(true);

--- a/webrtc-sys/src/nvidia/h265_encoder_impl.cpp
+++ b/webrtc-sys/src/nvidia/h265_encoder_impl.cpp
@@ -360,7 +360,9 @@ void NvidiaH265EncoderImpl::SetRates(
   configuration_.target_bps = parameters.bitrate.GetSpatialLayerSum(0);
   configuration_.max_frame_rate = parameters.framerate_fps;
 
-  encoder_->SetRates(codec_.maxFramerate, configuration_.target_bps);
+  if (!encoder_->SetRates(codec_.maxFramerate, configuration_.target_bps)) {
+    RTC_LOG(LS_WARNING) << "Failed to reconfigure NVENC rates.";
+  }
 
   if (configuration_.target_bps) {
     configuration_.SetStreamState(true);

--- a/webrtc-sys/src/nvidia/h265_encoder_impl.cpp
+++ b/webrtc-sys/src/nvidia/h265_encoder_impl.cpp
@@ -360,6 +360,8 @@ void NvidiaH265EncoderImpl::SetRates(
   configuration_.target_bps = parameters.bitrate.GetSpatialLayerSum(0);
   configuration_.max_frame_rate = parameters.framerate_fps;
 
+  encoder_->SetRates(codec_.maxFramerate, configuration_.target_bps);
+
   if (configuration_.target_bps) {
     configuration_.SetStreamState(true);
   } else {


### PR DESCRIPTION
- NVENC encoders were not correctly updating encode bitrate and was stuck at the initial rate set by webrtc, this fixes the problem by properly implementing SetRate on the encoder implementation to properly handle requests to change encode config.