### PR TITLE
introduce LiveKitAPI construct, added smoke tests

### DIFF
--- a/.changeset/introduce_livekitapi_construct_added_smoke_tests.md
+++ b/.changeset/introduce_livekitapi_construct_added_smoke_tests.md
@@ -1,0 +1,9 @@
+---
+libwebrtc: patch
+livekit: patch
+livekit-api: minor
+livekit-datatrack: patch
+livekit-ffi: patch
+---
+
+introduce LiveKitAPI construct, added smoke tests - #1220 (@davidzhao)

--- a/.github/workflows/test-api.yml
+++ b/.github/workflows/test-api.yml
@@ -25,8 +25,30 @@ on:
     branches: [main]
 
 jobs:
-  failover:
+  # Exercise every runtime backend so a regression in one (e.g. the async/isahc
+  # server API silently failing to compile) is caught. Each leg pins a single
+  # runtime via --no-default-features; the mock server backs the legs that make
+  # real requests (services-*), and is a harmless no-op for the signal-client
+  # legs, which spin up their own ephemeral listeners.
+  livekit-api:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: services (tokio)
+            cmd: cargo test -p livekit-api --no-default-features --features services-tokio,access-token --lib services::api_test -- --nocapture
+          - name: services (async / isahc)
+            cmd: cargo test -p livekit-api --no-default-features --features services-async,access-token --test services_async -- --nocapture
+          - name: signal-client (tokio)
+            cmd: cargo test -p livekit-api --no-default-features --features signal-client-tokio --lib signal_client -- --nocapture
+          - name: signal-client (async)
+            cmd: cargo test -p livekit-api --no-default-features --features signal-client-async --lib signal_client -- --nocapture
+          # The dispatcher runtime uses a caller-driven executor that a standalone
+          # test harness doesn't pump, so compile it (catches the regressions we
+          # care about) rather than run it.
+          - name: signal-client (dispatcher, build only)
+            cmd: cargo test -p livekit-api --no-default-features --features signal-client-dispatcher --no-run
     services:
       mock-server:
         image: livekit/test-server:latest
@@ -60,5 +82,5 @@ jobs:
           done
           echo "mock server did not become ready" && exit 1
 
-      - name: Run API tests
-        run: cargo test -p livekit-api --lib services::api_test -- --nocapture
+      - name: ${{ matrix.name }}
+        run: ${{ matrix.cmd }}

--- a/.github/workflows/test-api.yml
+++ b/.github/workflows/test-api.yml
@@ -44,11 +44,6 @@ jobs:
             cmd: cargo test -p livekit-api --no-default-features --features signal-client-tokio --lib signal_client -- --nocapture
           - name: signal-client (async)
             cmd: cargo test -p livekit-api --no-default-features --features signal-client-async --lib signal_client -- --nocapture
-          # The dispatcher runtime uses a caller-driven executor that a standalone
-          # test harness doesn't pump, so compile it (catches the regressions we
-          # care about) rather than run it.
-          - name: signal-client (dispatcher, build only)
-            cmd: cargo test -p livekit-api --no-default-features --features signal-client-dispatcher --no-run
     services:
       mock-server:
         image: livekit/test-server:latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -232,7 +232,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1206,7 +1206,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2157,7 +2157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2549,12 +2549,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
-
-[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,7 +2651,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3927,7 +3921,7 @@ dependencies = [
  "bytes",
  "device-info",
  "flate2",
- "futures-timer",
+ "futures",
  "futures-util",
  "hmac",
  "http 1.4.0",
@@ -4617,7 +4611,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6344,7 +6338,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6907,7 +6901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7077,7 +7071,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8776,7 +8770,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,10 @@ livekit-api = { version = "0.5.4", path = "livekit-api" }
 livekit-ffi = { version = "0.12.68", path = "livekit-ffi" }
 livekit-datatrack = { version = "0.1.9", path = "livekit-datatrack" }
 livekit-protocol = { version = "0.7.10", path = "livekit-protocol" }
-livekit-runtime = { version = "0.4.0", path = "livekit-runtime" }
+# default-features off so each consumer selects its runtime explicitly
+# (livekit-runtime/tokio | /async | /dispatcher); otherwise the default `tokio`
+# feature is forced on everywhere and collides with `async`/`dispatcher` builds.
+livekit-runtime = { version = "0.4.0", path = "livekit-runtime", default-features = false }
 soxr-sys = { version = "0.1.3", path = "soxr-sys" }
 webrtc-sys = { version = "0.3.36", path = "webrtc-sys" }
 webrtc-sys-build = { version = "0.3.18", path = "webrtc-sys/build" }

--- a/libwebrtc/Cargo.toml
+++ b/libwebrtc/Cargo.toml
@@ -30,7 +30,7 @@ jni = "0.21"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 webrtc-sys = { workspace = true }
-livekit-runtime = { workspace = true }
+livekit-runtime = { workspace = true, features = ["tokio"] }
 lazy_static = { workspace = true }
 parking_lot = { workspace = true }
 tokio = { workspace = true, default-features = false, features = ["sync", "macros"] }

--- a/livekit-api/Cargo.toml
+++ b/livekit-api/Cargo.toml
@@ -45,8 +45,8 @@ __signal-client-async-compatible = [
 ]
 
 
-services-tokio = ["dep:reqwest", "dep:tokio", "tokio/time"]
-services-async = ["dep:isahc", "dep:futures-timer"]
+services-tokio = ["dep:reqwest", "dep:tokio", "tokio/time", "dep:livekit-runtime", "livekit-runtime/tokio"]
+services-async = ["dep:isahc", "dep:livekit-runtime", "livekit-runtime/async"]
 access-token = ["dep:jsonwebtoken", "dep:hmac", "dep:signature"]
 webhooks = ["access-token", "dep:serde_json", "dep:base64"]
 
@@ -121,7 +121,7 @@ hmac = { version = "0.12", optional = true }
 signature = { version = "2", optional = true }
 
 # signal_client
-livekit-runtime = { workspace = true, optional = true}
+livekit-runtime = { workspace = true, optional = true }
 tokio-tungstenite = { version = "0.29", features = ["url"], optional = true }
 async-tungstenite = { version = "0.29", features = [ "async-std-runtime", "async-native-tls", "url"], optional = true }
 tokio = { workspace = true, default-features = false, features = ["sync", "macros", "signal", "io-util", "net"], optional = true }
@@ -134,8 +134,6 @@ bytes = { workspace = true, optional = true }
 http = "1.1"
 reqwest = { version = "0.12", default-features = false, features = [ "json" ], optional = true }
 isahc = { version = "1.7.2", default-features = false, features = [ "json", "text-decoding" ], optional = true }
-# Runtime-agnostic timer for failover backoff on the non-tokio (isahc) backend.
-futures-timer = { version = "3", optional = true }
 
 flate2 = { version = "1", optional = true }
 scopeguard = "1.2.0"
@@ -145,3 +143,5 @@ device-info = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "net", "time", "macros", "io-util"] }
+# Minimal executor to drive the runtime-agnostic `services-async` (isahc) tests.
+futures = "0.3"

--- a/livekit-api/src/http_client.rs
+++ b/livekit-api/src/http_client.rs
@@ -14,7 +14,9 @@
 
 #[cfg(any(feature = "services-tokio", feature = "signal-client-tokio"))]
 mod tokio {
-    #[cfg(feature = "services-tokio")]
+    // The server-API (services) and signal-client backends share reqwest's
+    // `Client`; the signal client's region provider needs it too.
+    #[cfg(any(feature = "services-tokio", feature = "signal-client-tokio"))]
     pub use reqwest::Client;
 
     /// GET with an `Authorization: Bearer <token>` header attached.
@@ -43,142 +45,151 @@ mod async_std {
     ))]
     compile_error!("the async std compatible libraries do not support these features");
 
-    #[cfg(any(feature = "__signal-client-async-compatible", feature = "services-async"))]
-    pub struct Response(http::Response<isahc::AsyncBody>);
+    use std::io;
 
-    #[cfg(feature = "__signal-client-async-compatible")]
-    mod signal_client {
-        use std::io;
+    use isahc::AsyncReadResponseExt;
 
-        use isahc::AsyncReadResponseExt;
+    // isahc vendors its own `http` 0.2, so the response wraps isahc's type and
+    // its `http` 1.x-facing accessors (`status`, `headers`) convert at the edge.
+    pub struct Response(isahc::http::Response<isahc::AsyncBody>);
 
-        use super::Response;
+    impl Response {
+        /// Status as the workspace's `http` 1.x `StatusCode` (what callers
+        /// compare against), round-tripped from isahc's `http` 0.2 code.
+        pub fn status(&self) -> http::StatusCode {
+            http::StatusCode::from_u16(self.0.status().as_u16()).expect("valid status code")
+        }
 
-        impl Response {
-            pub fn status(&self) -> http::StatusCode {
-                self.0.status()
+        /// Decodes a JSON body. Used by the server-API (twirp error) backend and
+        /// the signal client's region provider.
+        pub async fn json<T: serde::de::DeserializeOwned + Unpin>(mut self) -> io::Result<T> {
+            self.0.json().await.map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+        }
+
+        /// Reads the raw protobuf body. Server-API (twirp) backend only.
+        #[cfg(feature = "services-async")]
+        pub async fn bytes(mut self) -> io::Result<prost::bytes::Bytes> {
+            Ok(self.0.bytes().await?.into())
+        }
+
+        /// Reads a text body. Signal client only (region fetch / validate).
+        #[cfg(feature = "__signal-client-async-compatible")]
+        pub async fn text(mut self) -> io::Result<String> {
+            self.0.text().await
+        }
+
+        /// Response headers as the workspace's `http` 1.x `HeaderMap`, rebuilt
+        /// from isahc's `http` 0.2 map so shared call sites can index it with 1.x
+        /// header names. Signal client only (reads `Cache-Control`).
+        #[cfg(feature = "__signal-client-async-compatible")]
+        pub fn headers(&self) -> http::HeaderMap {
+            let mut out = http::HeaderMap::with_capacity(self.0.headers().len());
+            for (name, value) in self.0.headers() {
+                let name = http::HeaderName::from_bytes(name.as_str().as_bytes())
+                    .expect("valid header name");
+                let value =
+                    http::HeaderValue::from_bytes(value.as_bytes()).expect("valid header value");
+                out.append(name, value);
             }
+            out
+        }
+    }
 
-            pub async fn text(mut self) -> io::Result<String> {
-                self.0.text().await
+    /// GET with an `Authorization: Bearer <token>` header attached.
+    ///
+    /// `isahc::get_async(url)` attaches no auth, which is why
+    /// `SignalInner::validate` — the sole caller — uses this helper: the access
+    /// token must reach the server or the server returns 401 regardless of the
+    /// underlying error. Mirrors the tokio variant.
+    #[cfg(feature = "__signal-client-async-compatible")]
+    pub async fn get_with_token(url: &str, token: &str) -> io::Result<Response> {
+        let request = isahc::Request::get(url)
+            .header("Authorization", format!("Bearer {}", token))
+            .body(())
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        let response = isahc::send_async(request).await?;
+        Ok(Response(response))
+    }
+
+    // Shared isahc HTTP client: the server-API backend POSTs Twirp requests; the
+    // signal client's region provider GETs the region list.
+    #[derive(Debug)]
+    pub struct Client(isahc::HttpClient);
+
+    impl Client {
+        pub fn new() -> Self {
+            Self(isahc::HttpClient::new().unwrap())
+        }
+
+        #[cfg(feature = "services-async")]
+        pub fn post(&self, url: url::Url) -> RequestBuilder {
+            RequestBuilder {
+                body: Vec::new(),
+                builder: isahc::http::Request::post(url.as_str()),
+                client: self.0.clone(),
             }
         }
 
-        /// GET with an `Authorization: Bearer <token>` header attached.
-        ///
-        /// `isahc::get_async(url)` attaches no auth, which is why
-        /// `SignalInner::validate` — the sole caller — uses this helper: the
-        /// access token must reach the server or the server returns 401
-        /// regardless of the underlying error. Mirrors the tokio variant.
-        pub async fn get_with_token(url: &str, token: &str) -> io::Result<Response> {
-            let request = isahc::Request::get(url)
-                .header("Authorization", format!("Bearer {}", token))
-                .body(())
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-            let response = isahc::send_async(request).await?;
+        #[cfg(feature = "__signal-client-async-compatible")]
+        pub fn get(&self, url: &str) -> RequestBuilder {
+            RequestBuilder {
+                body: Vec::new(),
+                builder: isahc::http::Request::get(url),
+                client: self.0.clone(),
+            }
+        }
+    }
+
+    pub struct RequestBuilder {
+        builder: isahc::http::request::Builder,
+        body: Vec<u8>,
+        client: isahc::HttpClient,
+    }
+
+    impl RequestBuilder {
+        pub fn headers(mut self, headers: http::HeaderMap) -> Self {
+            // isahc vendors `http` 0.2, so rebuild the workspace's `http` 1.x
+            // `HeaderMap` into isahc's own type. Names/values round-trip through
+            // bytes to stay agnostic to the `http` version. `HeaderMap`'s iterator
+            // yields `None` keys for repeated values, so carry the last name.
+            let dst = self.builder.headers_mut().unwrap();
+            let mut last_name: Option<isahc::http::HeaderName> = None;
+            for (key, value) in headers {
+                let name = match key {
+                    Some(key) => {
+                        let name = isahc::http::HeaderName::from_bytes(key.as_str().as_bytes())
+                            .expect("valid header name");
+                        last_name = Some(name.clone());
+                        name
+                    }
+                    None => last_name.clone().expect("HeaderMap yielded a value before any key"),
+                };
+                let value = isahc::http::HeaderValue::from_bytes(value.as_bytes())
+                    .expect("valid header value");
+                dst.append(name, value);
+            }
+            self
+        }
+
+        #[cfg(feature = "services-async")]
+        pub fn body(mut self, body: Vec<u8>) -> Self {
+            self.body = body;
+            self
+        }
+
+        #[cfg(feature = "services-async")]
+        pub fn timeout(mut self, timeout: std::time::Duration) -> Self {
+            use isahc::config::Configurable;
+            self.builder = self.builder.timeout(timeout);
+            self
+        }
+
+        pub async fn send(self) -> io::Result<Response> {
+            let request = self.builder.body(self.body).unwrap();
+            let response = self.client.send_async(request).await?;
             Ok(Response(response))
         }
     }
-
-    #[cfg(feature = "__signal-client-async-compatible")]
-    pub use signal_client::*;
-
-    #[cfg(feature = "services-async")]
-    mod services {
-        use std::io;
-
-        use isahc::AsyncReadResponseExt;
-        use prost::bytes::Bytes;
-
-        use super::Response;
-
-        use http::header::{Entry, OccupiedEntry};
-        use url::Url;
-
-        impl Response {
-            pub async fn bytes(self) -> io::Result<Bytes> {
-                Ok(self.0.bytes().await?.into())
-            }
-
-            pub async fn json<T: serde::de::DeserializeOwned + Unpin>(&mut self) -> io::Result<T> {
-                self.0.json().await.map_err(|e| io::Error::new(io::ErrorKind::Other, e))
-            }
-        }
-
-        #[derive(Debug)]
-        pub struct Client(isahc::HttpClient);
-
-        impl Client {
-            pub fn new() -> Self {
-                Self(isahc::HttpClient::new().unwrap())
-            }
-        }
-
-        impl Client {
-            pub fn post(&self, url: Url) -> RequestBuilder {
-                RequestBuilder {
-                    body: Vec::new(),
-                    builder: isahc::http::Request::post(url.as_str()),
-                    client: self.0.clone(),
-                }
-            }
-        }
-
-        pub struct RequestBuilder {
-            builder: isahc::http::request::Builder,
-            body: Vec<u8>,
-            client: isahc::HttpClient,
-        }
-
-        impl RequestBuilder {
-            pub fn headers(mut self, headers: http::HeaderMap) -> Self {
-                // Copied from: https://docs.rs/reqwest/0.11.24/src/reqwest/util.rs.html#62-89
-                let self_headers = self.builder.headers_mut().unwrap();
-                let mut prev_entry: Option<OccupiedEntry<_>> = None;
-                for (key, value) in headers {
-                    match key {
-                        Some(key) => match self_headers.entry(key) {
-                            Entry::Occupied(mut e) => {
-                                e.insert(value);
-                                prev_entry = Some(e);
-                            }
-                            Entry::Vacant(e) => {
-                                let e = e.insert_entry(value);
-                                prev_entry = Some(e);
-                            }
-                        },
-                        None => match prev_entry {
-                            Some(ref mut entry) => {
-                                entry.append(value);
-                            }
-                            None => unreachable!("HeaderMap::into_iter yielded None first"),
-                        },
-                    }
-                }
-                self
-            }
-
-            pub fn body(mut self, body: Vec<u8>) -> Self {
-                self.body = body;
-                self
-            }
-
-            pub fn timeout(mut self, timeout: std::time::Duration) -> Self {
-                use isahc::config::Configurable;
-                self.builder = self.builder.timeout(timeout);
-                self
-            }
-
-            pub async fn send(self) -> io::Result<Response> {
-                let request = self.builder.body(self.body).unwrap();
-                let response = self.client.send_async(request).await?;
-                Ok(Response(response))
-            }
-        }
-    }
-
-    #[cfg(feature = "services-async")]
-    pub use services::*;
 }
 
 #[cfg(any(feature = "__signal-client-async-compatible", feature = "services-async"))]

--- a/livekit-api/src/http_client.rs
+++ b/livekit-api/src/http_client.rs
@@ -113,7 +113,9 @@ mod async_std {
 
     // Shared isahc HTTP client: the server-API backend POSTs Twirp requests; the
     // signal client's region provider GETs the region list.
-    #[derive(Debug)]
+    // Clone is cheap and shares the underlying connection pool (isahc::HttpClient
+    // is reference-counted), so the unified client can hand one to every service.
+    #[derive(Debug, Clone)]
     pub struct Client(isahc::HttpClient);
 
     impl Client {

--- a/livekit-api/src/services/agent_dispatch.rs
+++ b/livekit-api/src/services/agent_dispatch.rs
@@ -29,6 +29,7 @@ pub struct AgentDispatchClient {
 }
 
 impl AgentDispatchClient {
+    /// Authenticates with an API key and secret, signing a short-lived token per request.
     pub fn with_api_key(host: &str, api_key: &str, api_secret: &str) -> Self {
         Self {
             base: ServiceBase::with_api_key(api_key, api_secret),
@@ -36,6 +37,7 @@ impl AgentDispatchClient {
         }
     }
 
+    /// Authenticates with a pre-signed token, sent verbatim on every request.
     pub fn with_token(host: &str, token: &str) -> Self {
         Self {
             base: ServiceBase::with_token(token),
@@ -49,6 +51,8 @@ impl AgentDispatchClient {
         self
     }
 
+    /// Reads the API key and secret from the `LIVEKIT_API_KEY` and
+    /// `LIVEKIT_API_SECRET` environment variables.
     pub fn new(host: &str) -> ServiceResult<Self> {
         let (api_key, api_secret) = get_env_keys()?;
         Ok(Self::with_api_key(host, &api_key, &api_secret))

--- a/livekit-api/src/services/agent_dispatch.rs
+++ b/livekit-api/src/services/agent_dispatch.rs
@@ -25,24 +25,28 @@ const SVC: &str = "AgentDispatchService";
 #[derive(Debug)]
 pub struct AgentDispatchClient {
     base: ServiceBase,
-    pub(crate) client: TwirpClient,
+    client: TwirpClient,
 }
 
 impl AgentDispatchClient {
     /// Authenticates with an API key and secret, signing a short-lived token per request.
     pub fn with_api_key(host: &str, api_key: &str, api_secret: &str) -> Self {
-        Self {
-            base: ServiceBase::with_api_key(api_key, api_secret),
-            client: TwirpClient::new(host, LIVEKIT_PACKAGE, None),
-        }
+        Self::build(
+            host,
+            ServiceBase::with_api_key(api_key, api_secret),
+            crate::http_client::Client::new(),
+        )
     }
 
     /// Authenticates with a pre-signed token, sent verbatim on every request.
     pub fn with_token(host: &str, token: &str) -> Self {
-        Self {
-            base: ServiceBase::with_token(token),
-            client: TwirpClient::new(host, LIVEKIT_PACKAGE, None),
-        }
+        Self::build(host, ServiceBase::with_token(token), crate::http_client::Client::new())
+    }
+
+    /// Builds the client from an already-constructed HTTP client so the unified
+    /// [`LiveKitApi`](super::LiveKitApi) can share one connection pool across services.
+    pub(crate) fn build(host: &str, base: ServiceBase, client: crate::http_client::Client) -> Self {
+        Self { base, client: TwirpClient::with_client(host, LIVEKIT_PACKAGE, None, client) }
     }
 
     #[cfg(test)]

--- a/livekit-api/src/services/agent_dispatch.rs
+++ b/livekit-api/src/services/agent_dispatch.rs
@@ -25,7 +25,7 @@ const SVC: &str = "AgentDispatchService";
 #[derive(Debug)]
 pub struct AgentDispatchClient {
     base: ServiceBase,
-    client: TwirpClient,
+    pub(crate) client: TwirpClient,
 }
 
 impl AgentDispatchClient {

--- a/livekit-api/src/services/agent_dispatch.rs
+++ b/livekit-api/src/services/agent_dispatch.rs
@@ -36,6 +36,19 @@ impl AgentDispatchClient {
         }
     }
 
+    pub fn with_token(host: &str, token: &str) -> Self {
+        Self {
+            base: ServiceBase::with_token(token),
+            client: TwirpClient::new(host, LIVEKIT_PACKAGE, None),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_default_headers(mut self, headers: http::HeaderMap) -> Self {
+        self.client = self.client.with_default_headers(headers);
+        self
+    }
+
     pub fn new(host: &str) -> ServiceResult<Self> {
         let (api_key, api_secret) = get_env_keys()?;
         Ok(Self::with_api_key(host, &api_key, &api_secret))

--- a/livekit-api/src/services/api_test.rs
+++ b/livekit-api/src/services/api_test.rs
@@ -126,9 +126,10 @@ async fn all_unavailable() {
 async fn client_error_not_retried() {
     let base = base_url();
     skip_if_offline!(base);
-    let err = call(&base, config(true, true), r#"{"skipAuth":true,"failRegions":[0],"failStatus":400}"#)
-        .await
-        .expect_err("a 4xx must be returned without failover");
+    let err =
+        call(&base, config(true, true), r#"{"skipAuth":true,"failRegions":[0],"failStatus":400}"#)
+            .await
+            .expect_err("a 4xx must be returned without failover");
     match err {
         ServerError::Twirp(code) => assert_eq!(code.code, "invalid_argument"),
         other => panic!("expected a twirp error, got {other:?}"),
@@ -522,7 +523,13 @@ async fn connector_smoke() {
     let api = api(None);
     let connector = api.connector();
     connector
-        .dial_whatsapp_call("123456789012345", "+15105550100", "wa-secret-key", "23.0", Default::default())
+        .dial_whatsapp_call(
+            "123456789012345",
+            "+15105550100",
+            "wa-secret-key",
+            "23.0",
+            Default::default(),
+        )
         .await
         .expect("dial_whatsapp_call");
     connector
@@ -543,7 +550,14 @@ async fn connector_smoke() {
         .await
         .expect("connect_whatsapp_call");
     connector
-        .accept_whatsapp_call("123456789012345", "wa-secret-key", "23.0", "wacid.HBg", offer, Default::default())
+        .accept_whatsapp_call(
+            "123456789012345",
+            "wa-secret-key",
+            "23.0",
+            "wacid.HBg",
+            offer,
+            Default::default(),
+        )
         .await
         .expect("accept_whatsapp_call");
     connector

--- a/livekit-api/src/services/api_test.rs
+++ b/livekit-api/src/services/api_test.rs
@@ -119,7 +119,7 @@ async fn all_unavailable() {
     let err = call(&base, config(true, true), r#"{"skipAuth":true,"failRegions":[0,1,2,3]}"#)
         .await
         .expect_err("all regions down should surface an error");
-    assert!(matches!(err, ServerError::Response(_)));
+    assert!(matches!(err, ServerError::Twirp(_)));
 }
 
 #[tokio::test]
@@ -131,7 +131,7 @@ async fn client_error_not_retried() {
             .await
             .expect_err("a 4xx must be returned without failover");
     match err {
-        ServerError::Response(code) => assert_eq!(code.code, "invalid_argument"),
+        ServerError::Twirp(code) => assert_eq!(code.code, "invalid_argument"),
         other => panic!("expected a twirp error, got {other:?}"),
     }
 }
@@ -752,5 +752,5 @@ async fn sip_dial_timeout() {
         )
         .await
         .expect_err("the dial should abort before the mock answers");
-    assert!(matches!(err, ServiceError::Server(ServerError::Request(_))), "{err:?}");
+    assert!(matches!(err, ServiceError::Twirp(ServerError::Request(_))), "{err:?}");
 }

--- a/livekit-api/src/services/api_test.rs
+++ b/livekit-api/src/services/api_test.rs
@@ -561,13 +561,17 @@ async fn connector_smoke() {
         .await
         .expect("accept_whatsapp_call");
     connector
-        .disconnect_whatsapp_call(
-            "wacid.HBg",
-            "wa-secret-key",
-            proto::disconnect_whats_app_call_request::DisconnectReason::BusinessInitiated,
-        )
+        .disconnect_whatsapp_call("wacid.HBg", "wa-secret-key")
         .await
         .expect("disconnect_whatsapp_call");
+    connector
+        .disconnect_whatsapp_call_with_reason(
+            "wacid.HBg",
+            "wa-secret-key",
+            proto::disconnect_whats_app_call_request::DisconnectReason::UserInitiated,
+        )
+        .await
+        .expect("disconnect_whatsapp_call_with_reason");
 }
 
 #[tokio::test]
@@ -630,6 +634,9 @@ async fn sip_participant() {
             CreateSIPParticipantOptions {
                 participant_identity: "sip-caller".to_owned(),
                 participant_name: Some("SIP Caller".to_owned()),
+                display_name: Some("Support".to_owned()),
+                dtmf: Some("*123#".to_owned()),
+                play_dialtone: Some(true),
                 wait_until_answered: Some(true),
                 ringing_timeout: Some(Duration::from_secs(2)),
                 ..Default::default()

--- a/livekit-api/src/services/api_test.rs
+++ b/livekit-api/src/services/api_test.rs
@@ -17,18 +17,25 @@
 //! (default http://127.0.0.1:9999); they no-op when no server is reachable. In
 //! CI the server is booted as a Docker container.
 //!
-//! See cmd/test-server/README.md for the X-Lk-Mock-* control protocol. These
-//! tests drive TwirpClient::request() directly because the public service
-//! methods do not expose per-call headers.
+//! See cmd/test-server/README.md for the X-Lk-Mock JSON control protocol. The
+//! mock enforces the same per-method grants as the real server (secret
+//! "secret"), so a call that succeeds also proves the SDK attached the right
+//! grants. The failover tests drive TwirpClient directly because failover
+//! relies on internal test-only knobs the service clients don't expose; the
+//! rest drive the public LiveKitApi, injecting directives as a default X-Lk-Mock
+//! header (the service methods don't take per-call headers).
 
 use std::time::Duration;
 
 use http::header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION};
 use livekit_protocol as proto;
 
+use super::egress::{EgressListOptions, EgressOutput};
 use super::failover::FailoverConfig;
-use super::twirp_client::{TwirpClient, TwirpError, TwirpResult};
-use super::LIVEKIT_PACKAGE;
+use super::sip::CreateSIPParticipantOptions;
+use super::twirp_client::{ServerError, TwirpClient, TwirpResult};
+use super::{LiveKitApi, ServiceError, SipCallError, LIVEKIT_PACKAGE};
+use crate::access_token::{AccessToken, VideoGrants};
 
 fn base_url() -> String {
     std::env::var("LK_TEST_SERVER_URL").unwrap_or_else(|_| "http://127.0.0.1:9999".to_owned())
@@ -43,26 +50,31 @@ async fn reachable(base: &str) -> bool {
         .unwrap_or(false)
 }
 
+macro_rules! skip_if_offline {
+    ($base:expr) => {
+        if !reachable(&$base).await {
+            eprintln!("skipping: mock test server not reachable at {}", $base);
+            return;
+        }
+    };
+}
+
+// -- failover: drives TwirpClient directly for the test-only force/backoff knobs
+
 // `force` bypasses the cloud-host check (the mock is on 127.0.0.1) and the tiny
 // backoff keeps tests fast — both are internal, test-only knobs.
 fn config(enabled: bool, force: bool) -> FailoverConfig {
     FailoverConfig { enabled, force, backoff_base: Duration::from_millis(1) }
 }
 
-async fn call(
-    base: &str,
-    cfg: FailoverConfig,
-    directives: &[(&'static str, &str)],
-) -> TwirpResult<proto::Room> {
+// Issues a CreateRoom through the failover machinery with the given X-Lk-Mock
+// directives. These tests exercise failover, not authz, so they skip the mock's
+// permission check.
+async fn call(base: &str, cfg: FailoverConfig, mock: &str) -> TwirpResult<proto::Room> {
     let client = TwirpClient::new(base, LIVEKIT_PACKAGE, None).with_failover_config(cfg);
     let mut headers = HeaderMap::new();
     headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer test-token"));
-    // These tests exercise failover, not authz; skip the mock's permission check.
-    headers
-        .insert(HeaderName::from_static("x-lk-mock-skip-auth"), HeaderValue::from_static("true"));
-    for (k, v) in directives {
-        headers.insert(HeaderName::from_static(k), HeaderValue::from_str(v).unwrap());
-    }
+    headers.insert(HeaderName::from_static("x-lk-mock"), HeaderValue::from_str(mock).unwrap());
     client
         .request::<proto::CreateRoomRequest, proto::Room>(
             "RoomService",
@@ -73,27 +85,20 @@ async fn call(
         .await
 }
 
-macro_rules! skip_if_offline {
-    ($base:expr) => {
-        if !reachable(&$base).await {
-            eprintln!("skipping: mock test server not reachable at {}", $base);
-            return;
-        }
-    };
-}
-
 #[tokio::test]
 async fn healthy() {
     let base = base_url();
     skip_if_offline!(base);
-    call(&base, config(true, true), &[]).await.expect("healthy request should succeed");
+    call(&base, config(true, true), r#"{"skipAuth":true}"#)
+        .await
+        .expect("healthy request should succeed");
 }
 
 #[tokio::test]
 async fn primary_unavailable() {
     let base = base_url();
     skip_if_offline!(base);
-    call(&base, config(true, true), &[("x-lk-mock-fail-regions", "0")])
+    call(&base, config(true, true), r#"{"skipAuth":true,"failRegions":[0]}"#)
         .await
         .expect("should fail over to a healthy region");
 }
@@ -102,7 +107,7 @@ async fn primary_unavailable() {
 async fn two_regions_unavailable() {
     let base = base_url();
     skip_if_offline!(base);
-    call(&base, config(true, true), &[("x-lk-mock-fail-regions", "0,1")])
+    call(&base, config(true, true), r#"{"skipAuth":true,"failRegions":[0,1]}"#)
         .await
         .expect("should fail over to region 2 on the 3rd attempt");
 }
@@ -111,25 +116,21 @@ async fn two_regions_unavailable() {
 async fn all_unavailable() {
     let base = base_url();
     skip_if_offline!(base);
-    let err = call(&base, config(true, true), &[("x-lk-mock-fail-regions", "0,1,2,3")])
+    let err = call(&base, config(true, true), r#"{"skipAuth":true,"failRegions":[0,1,2,3]}"#)
         .await
         .expect_err("all regions down should surface an error");
-    assert!(matches!(err, TwirpError::Twirp(_)));
+    assert!(matches!(err, ServerError::Twirp(_)));
 }
 
 #[tokio::test]
 async fn client_error_not_retried() {
     let base = base_url();
     skip_if_offline!(base);
-    let err = call(
-        &base,
-        config(true, true),
-        &[("x-lk-mock-fail-regions", "0"), ("x-lk-mock-fail-status", "400")],
-    )
-    .await
-    .expect_err("a 4xx must be returned without failover");
+    let err = call(&base, config(true, true), r#"{"skipAuth":true,"failRegions":[0],"failStatus":400}"#)
+        .await
+        .expect_err("a 4xx must be returned without failover");
     match err {
-        TwirpError::Twirp(code) => assert_eq!(code.code, "invalid_argument"),
+        ServerError::Twirp(code) => assert_eq!(code.code, "invalid_argument"),
         other => panic!("expected a twirp error, got {other:?}"),
     }
 }
@@ -138,26 +139,18 @@ async fn client_error_not_retried() {
 async fn transport_error_failover() {
     let base = base_url();
     skip_if_offline!(base);
-    call(
-        &base,
-        config(true, true),
-        &[("x-lk-mock-fail-regions", "0"), ("x-lk-mock-fail-mode", "drop")],
-    )
-    .await
-    .expect("a dropped connection should fail over to a healthy region");
+    call(&base, config(true, true), r#"{"skipAuth":true,"failRegions":[0],"failMode":"drop"}"#)
+        .await
+        .expect("a dropped connection should fail over to a healthy region");
 }
 
 #[tokio::test]
 async fn region_discovery_unreachable() {
     let base = base_url();
     skip_if_offline!(base);
-    call(
-        &base,
-        config(true, true),
-        &[("x-lk-mock-fail-regions", "0"), ("x-lk-mock-regions-status", "500")],
-    )
-    .await
-    .expect_err("no fallback hosts means the original 5xx is surfaced");
+    call(&base, config(true, true), r#"{"skipAuth":true,"failRegions":[0],"regionsStatus":500}"#)
+        .await
+        .expect_err("no fallback hosts means the original 5xx is surfaced");
 }
 
 #[tokio::test]
@@ -165,7 +158,7 @@ async fn not_cloud_host() {
     let base = base_url();
     skip_if_offline!(base);
     // Enabled but not forced; 127.0.0.1 is not a cloud host, so no failover.
-    call(&base, config(true, false), &[("x-lk-mock-fail-regions", "0")])
+    call(&base, config(true, false), r#"{"skipAuth":true,"failRegions":[0]}"#)
         .await
         .expect_err("failover should be cloud-gated for a non-cloud host");
 }
@@ -174,7 +167,7 @@ async fn not_cloud_host() {
 async fn disabled() {
     let base = base_url();
     skip_if_offline!(base);
-    call(&base, config(false, true), &[("x-lk-mock-fail-regions", "0")])
+    call(&base, config(false, true), r#"{"skipAuth":true,"failRegions":[0]}"#)
         .await
         .expect_err("disabled failover should not retry");
 }
@@ -208,4 +201,434 @@ fn attempts_gating_and_timeout_guard() {
     let below = MIN_FAILOVER_TIMEOUT - Duration::from_millis(1);
     assert_eq!(config(true, true).attempts(Some(cloud), below), 1);
     assert_eq!(config(true, true).attempts(Some(cloud), MIN_FAILOVER_TIMEOUT), MAX_ATTEMPTS);
+}
+
+// -- LiveKitApi: smoke calls across every service, plus token auth and SIP errors
+
+fn api(mock: Option<&str>) -> LiveKitApi {
+    let api = LiveKitApi::with_api_key(&base_url(), "devkey", "secret");
+    match mock {
+        Some(m) => api.with_mock(m),
+        None => api,
+    }
+}
+
+#[tokio::test]
+async fn room_smoke() {
+    let base = base_url();
+    skip_if_offline!(base);
+    let api = api(None);
+    let room = api.room();
+    room.create_room(
+        "test-room",
+        super::room::CreateRoomOptions {
+            empty_timeout: 300,
+            max_participants: 50,
+            metadata: "{}".to_owned(),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("create_room");
+    room.list_rooms(vec!["test-room".to_owned(), "lobby".to_owned()]).await.expect("list_rooms");
+    room.update_room_metadata("test-room", "{}").await.expect("update_room_metadata");
+    room.list_participants("test-room").await.expect("list_participants");
+    room.get_participant("test-room", "participant-42").await.expect("get_participant");
+    room.remove_participant("test-room", "participant-42").await.expect("remove_participant");
+    room.forward_participant("test-room", "participant-42", "overflow-room")
+        .await
+        .expect("forward_participant");
+    room.move_participant("test-room", "participant-42", "breakout-room")
+        .await
+        .expect("move_participant");
+    room.update_subscriptions("test-room", "participant-42", vec!["TR_video1".to_owned()], true)
+        .await
+        .expect("update_subscriptions");
+    room.send_data(
+        "test-room",
+        b"hello".to_vec(),
+        super::room::SendDataOptions {
+            kind: proto::data_packet::Kind::Reliable,
+            destination_identities: vec!["participant-42".to_owned()],
+            topic: Some("chat".to_owned()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("send_data");
+    room.delete_room("test-room").await.expect("delete_room");
+}
+
+#[tokio::test]
+async fn egress_smoke() {
+    let base = base_url();
+    skip_if_offline!(base);
+    let api = api(None);
+    let egress = api.egress();
+    let file = proto::EncodedFileOutput {
+        file_type: proto::EncodedFileType::Mp4 as i32,
+        filepath: "room.mp4".to_owned(),
+        ..Default::default()
+    };
+    egress
+        .start_room_composite_egress(
+            "test-room",
+            vec![EgressOutput::File(file)],
+            super::egress::RoomCompositeOptions { layout: "grid".to_owned(), ..Default::default() },
+        )
+        .await
+        .expect("start_room_composite_egress");
+    egress.update_layout("EG_abc123", "speaker").await.expect("update_layout");
+    egress
+        .update_stream("EG_abc123", vec!["rtmps://b.example.com/live/key".to_owned()], vec![])
+        .await
+        .expect("update_stream");
+    egress
+        .list_egress(EgressListOptions {
+            filter: super::egress::EgressListFilter::Room("test-room".to_owned()),
+            active: true,
+            ..Default::default()
+        })
+        .await
+        .expect("list_egress");
+    egress.stop_egress("EG_abc123").await.expect("stop_egress");
+}
+
+#[tokio::test]
+async fn ingress_smoke() {
+    let base = base_url();
+    skip_if_offline!(base);
+    let api = api(None);
+    let ingress = api.ingress();
+    ingress
+        .create_ingress(
+            proto::IngressInput::RtmpInput,
+            super::ingress::CreateIngressOptions {
+                name: "stream-input".to_owned(),
+                room_name: "test-room".to_owned(),
+                participant_identity: "ingress-bot".to_owned(),
+                participant_name: "Live Stream".to_owned(),
+                enable_transcoding: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create_ingress");
+    ingress
+        .update_ingress(
+            "IN_abc123",
+            super::ingress::UpdateIngressOptions {
+                name: "stream-input-v2".to_owned(),
+                room_name: "test-room".to_owned(),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("update_ingress");
+    ingress
+        .list_ingress(super::ingress::IngressListFilter::Room("test-room".to_owned()))
+        .await
+        .expect("list_ingress");
+    ingress.delete_ingress("IN_abc123").await.expect("delete_ingress");
+}
+
+#[tokio::test]
+async fn sip_smoke() {
+    let base = base_url();
+    skip_if_offline!(base);
+    let api = api(None);
+    let sip = api.sip();
+    sip.create_sip_inbound_trunk(
+        "inbound".to_owned(),
+        vec!["+15105550100".to_owned()],
+        Default::default(),
+    )
+    .await
+    .expect("create_sip_inbound_trunk");
+    sip.create_sip_outbound_trunk(
+        "outbound".to_owned(),
+        "sip.telco.example.com".to_owned(),
+        vec!["+15105550100".to_owned()],
+        Default::default(),
+    )
+    .await
+    .expect("create_sip_outbound_trunk");
+    sip.list_sip_inbound_trunk(super::sip::ListSIPInboundTrunkFilter::All)
+        .await
+        .expect("list_sip_inbound_trunk");
+    sip.list_sip_outbound_trunk(super::sip::ListSIPOutboundTrunkFilter::All)
+        .await
+        .expect("list_sip_outbound_trunk");
+    sip.create_sip_dispatch_rule(
+        proto::sip_dispatch_rule::Rule::DispatchRuleDirect(proto::SipDispatchRuleDirect {
+            room_name: "support".to_owned(),
+            pin: "1234".to_owned(),
+        }),
+        Default::default(),
+    )
+    .await
+    .expect("create_sip_dispatch_rule");
+    sip.list_sip_dispatch_rule(super::sip::ListSIPDispatchRuleFilter::All)
+        .await
+        .expect("list_sip_dispatch_rule");
+    sip.update_sip_inbound_trunk(
+        "ST_abc123".to_owned(),
+        proto::SipInboundTrunkUpdate { metadata: Some("{}".to_owned()), ..Default::default() },
+    )
+    .await
+    .expect("update_sip_inbound_trunk");
+    sip.update_sip_inbound_trunk_replace(
+        "ST_abc123".to_owned(),
+        proto::SipInboundTrunkInfo { name: "inbound".to_owned(), ..Default::default() },
+    )
+    .await
+    .expect("update_sip_inbound_trunk_replace");
+    sip.update_sip_outbound_trunk(
+        "ST_abc123".to_owned(),
+        proto::SipOutboundTrunkUpdate { metadata: Some("{}".to_owned()), ..Default::default() },
+    )
+    .await
+    .expect("update_sip_outbound_trunk");
+    sip.update_sip_outbound_trunk_replace(
+        "ST_abc123".to_owned(),
+        proto::SipOutboundTrunkInfo {
+            name: "outbound".to_owned(),
+            address: "sip.telco.example.com".to_owned(),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("update_sip_outbound_trunk_replace");
+    sip.update_sip_dispatch_rule(
+        "SDR_abc123".to_owned(),
+        proto::SipDispatchRuleUpdate { name: Some("rule".to_owned()), ..Default::default() },
+    )
+    .await
+    .expect("update_sip_dispatch_rule");
+    sip.update_sip_dispatch_rule_replace(
+        "SDR_abc123".to_owned(),
+        proto::SipDispatchRuleInfo { name: "rule".to_owned(), ..Default::default() },
+    )
+    .await
+    .expect("update_sip_dispatch_rule_replace");
+    sip.delete_sip_dispatch_rule("SDR_abc123").await.expect("delete_sip_dispatch_rule");
+    sip.delete_sip_trunk("ST_abc123").await.expect("delete_sip_trunk");
+}
+
+// TransferSIPParticipant blocks until the REFER completes; delayMs:0 skips the wait.
+#[tokio::test]
+async fn sip_transfer() {
+    let base = base_url();
+    skip_if_offline!(base);
+    api(Some(r#"{"delayMs":0}"#))
+        .sip()
+        .transfer_sip_participant(
+            "test-room".to_owned(),
+            "sip-caller".to_owned(),
+            "tel:+15105550122".to_owned(),
+            super::sip::TransferSIPParticipantOptions {
+                ringing_timeout: Some(Duration::from_secs(2)),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("transfer_sip_participant");
+}
+
+#[tokio::test]
+async fn connector_smoke() {
+    let base = base_url();
+    skip_if_offline!(base);
+    let api = api(None);
+    let connector = api.connector();
+    connector
+        .dial_whatsapp_call("123456789012345", "+15105550100", "wa-secret-key", "23.0", Default::default())
+        .await
+        .expect("dial_whatsapp_call");
+    connector
+        .connect_twilio_call(
+            proto::connect_twilio_call_request::TwilioCallDirection::Inbound,
+            "test-room",
+            Default::default(),
+        )
+        .await
+        .expect("connect_twilio_call");
+}
+
+#[tokio::test]
+async fn agent_dispatch_smoke() {
+    let base = base_url();
+    skip_if_offline!(base);
+    let api = api(None);
+    let ad = api.agent_dispatch();
+    ad.create_dispatch(proto::CreateAgentDispatchRequest {
+        room: "test-room".to_owned(),
+        agent_name: "inbound-agent".to_owned(),
+        metadata: "{}".to_owned(),
+        ..Default::default()
+    })
+    .await
+    .expect("create_dispatch");
+    ad.list_dispatch("test-room").await.expect("list_dispatch");
+    ad.get_dispatch("AD_abc123", "test-room").await.expect("get_dispatch");
+    ad.delete_dispatch("AD_abc123", "test-room").await.expect("delete_dispatch");
+}
+
+// -- deep: create_room round-trips its fields ------------------------------------
+
+#[tokio::test]
+async fn create_room_echoes_fields() {
+    let base = base_url();
+    skip_if_offline!(base);
+    let room = api(None)
+        .room()
+        .create_room(
+            "echo-room",
+            super::room::CreateRoomOptions {
+                metadata: "{\"scene\":\"lobby\"}".to_owned(),
+                empty_timeout: 300,
+                max_participants: 50,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("create_room");
+    assert_eq!(room.name, "echo-room");
+    assert_eq!(room.metadata, "{\"scene\":\"lobby\"}");
+    assert_eq!(room.empty_timeout, 300);
+    assert_eq!(room.max_participants, 50);
+    assert!(!room.sid.is_empty()); // placeholder assigned by the mock
+}
+
+// -- deep: SIP participant (delayMs:0 skips the mock's answer wait) ---------------
+
+#[tokio::test]
+async fn sip_participant() {
+    let base = base_url();
+    skip_if_offline!(base);
+    let p = api(Some(r#"{"delayMs":0}"#))
+        .sip()
+        .create_sip_participant(
+            "ST_abc123".to_owned(),
+            "+15105550100".to_owned(),
+            "test-room".to_owned(),
+            CreateSIPParticipantOptions {
+                participant_identity: "sip-caller".to_owned(),
+                participant_name: Some("SIP Caller".to_owned()),
+                wait_until_answered: Some(true),
+                ringing_timeout: Some(Duration::from_secs(2)),
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .expect("create_sip_participant");
+    assert_eq!(p.room_name, "test-room");
+    assert_eq!(p.participant_identity, "sip-caller");
+}
+
+// -- cross-cutting: token auth ---------------------------------------------------
+
+#[tokio::test]
+async fn token_auth() {
+    let base = base_url();
+    skip_if_offline!(base);
+    let token = AccessToken::with_api_key("devkey", "secret")
+        .with_grants(VideoGrants { room_create: true, ..Default::default() })
+        .to_jwt()
+        .expect("sign token");
+    let room = LiveKitApi::with_token(&base, &token)
+        .room()
+        .create_room("token-room", Default::default())
+        .await
+        .expect("create_room with token");
+    assert_eq!(room.name, "token-room");
+}
+
+// -- cross-cutting: SIP call errors parse into SipCallError ----------------------
+
+async fn sip_error(sip_status: &str) -> ServiceError {
+    api(Some(&format!(r#"{{"delayMs":0,"sipStatus":{sip_status}}}"#)))
+        .sip()
+        .create_sip_participant(
+            "ST_abc123".to_owned(),
+            "+15105550100".to_owned(),
+            "test-room".to_owned(),
+            Default::default(),
+            None,
+        )
+        .await
+        .expect_err("a SIP status should surface as an error")
+}
+
+#[tokio::test]
+async fn sip_busy() {
+    let base = base_url();
+    skip_if_offline!(base);
+    let err = sip_error(r#"{"code":486,"status":"Busy Here"}"#).await;
+    let e = SipCallError::from_error(&err).expect("should decode a SipCallError");
+    assert_eq!(e.code(), "resource_exhausted");
+    assert_eq!(e.sip_status_code(), Some(486));
+    assert_eq!(e.sip_status(), Some("Busy Here"));
+    let s = e.to_string();
+    assert!(s.contains("486") && s.contains("Busy Here"), "{s}");
+}
+
+#[tokio::test]
+async fn sip_declined() {
+    let base = base_url();
+    skip_if_offline!(base);
+    let err = sip_error(r#"{"code":603,"status":"Decline"}"#).await;
+    let e = SipCallError::from_error(&err).expect("should decode a SipCallError");
+    assert_eq!(e.code(), "permission_denied");
+    assert_eq!(e.sip_status_code(), Some(603));
+}
+
+#[tokio::test]
+async fn sip_no_answer() {
+    let base = base_url();
+    skip_if_offline!(base);
+    let err = sip_error(r#"{"code":408,"status":"Request Timeout"}"#).await;
+    let e = SipCallError::from_error(&err).expect("should decode a SipCallError");
+    assert_eq!(e.code(), "deadline_exceeded");
+    assert_eq!(e.sip_status_code(), Some(408));
+}
+
+// A non-SIP error is not a SipCallError.
+#[tokio::test]
+async fn non_sip_error_not_decoded() {
+    let base = base_url();
+    skip_if_offline!(base);
+    let err = api(Some(r#"{"failRegions":[0],"failStatus":400}"#))
+        .room()
+        .create_room("test-room", Default::default())
+        .await
+        .expect_err("failStatus should surface an error");
+    assert!(SipCallError::from_error(&err).is_none());
+}
+
+// -- cross-cutting: client-side dial timeout -------------------------------------
+
+#[tokio::test]
+async fn sip_dial_timeout() {
+    let base = base_url();
+    skip_if_offline!(base);
+    // ringing_timeout 1s -> ~3s dial budget; the mock delays the answer past it.
+    let err = api(Some(r#"{"delayMs":4000}"#))
+        .sip()
+        .create_sip_participant(
+            "ST_abc123".to_owned(),
+            "+15105550100".to_owned(),
+            "test-room".to_owned(),
+            CreateSIPParticipantOptions {
+                participant_identity: "sip-caller".to_owned(),
+                wait_until_answered: Some(true),
+                ringing_timeout: Some(Duration::from_secs(1)),
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .expect_err("the dial should abort before the mock answers");
+    assert!(matches!(err, ServiceError::Twirp(ServerError::Request(_))), "{err:?}");
 }

--- a/livekit-api/src/services/api_test.rs
+++ b/livekit-api/src/services/api_test.rs
@@ -256,7 +256,38 @@ async fn room_smoke() {
     )
     .await
     .expect("send_data");
+    room.update_participant(
+        "test-room",
+        "participant-42",
+        super::room::UpdateParticipantOptions {
+            metadata: "{}".to_owned(),
+            name: "Alice".to_owned(),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("update_participant");
+    room.remove_participant_with_options(
+        "test-room",
+        "participant-42",
+        super::room::RemoveParticipantOptions { revoke_token_ts: 1_700_000_000_000 },
+    )
+    .await
+    .expect("remove_participant_with_options");
     room.delete_room("test-room").await.expect("delete_room");
+}
+
+// MutePublishedTrack returns the muted track; the mock has no live tracks, so
+// supply one via the `response` directive to exercise the SDK's decode path.
+#[tokio::test]
+async fn room_mute_track() {
+    let base = base_url();
+    skip_if_offline!(base);
+    let api = api(Some(r#"{"response":{"track":{"sid":"TR_video1"}}}"#));
+    api.room()
+        .mute_published_track("test-room", "participant-42", "TR_video1", true)
+        .await
+        .expect("mute_published_track");
 }
 
 #[tokio::test]
@@ -278,6 +309,55 @@ async fn egress_smoke() {
         )
         .await
         .expect("start_room_composite_egress");
+    egress
+        .start_web_egress(
+            "https://example.com/scene",
+            vec![EgressOutput::File(proto::EncodedFileOutput {
+                file_type: proto::EncodedFileType::Mp4 as i32,
+                filepath: "web.mp4".to_owned(),
+                ..Default::default()
+            })],
+            Default::default(),
+        )
+        .await
+        .expect("start_web_egress");
+    egress
+        .start_participant_egress(
+            "test-room",
+            "participant-42",
+            vec![EgressOutput::File(proto::EncodedFileOutput {
+                file_type: proto::EncodedFileType::Mp4 as i32,
+                filepath: "participant.mp4".to_owned(),
+                ..Default::default()
+            })],
+            Default::default(),
+        )
+        .await
+        .expect("start_participant_egress");
+    egress
+        .start_track_composite_egress(
+            "test-room",
+            vec![EgressOutput::File(proto::EncodedFileOutput {
+                file_type: proto::EncodedFileType::Mp4 as i32,
+                filepath: "track-composite.mp4".to_owned(),
+                ..Default::default()
+            })],
+            super::egress::TrackCompositeOptions {
+                audio_track_id: "TR_audio1".to_owned(),
+                video_track_id: "TR_video1".to_owned(),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("start_track_composite_egress");
+    egress
+        .start_track_egress(
+            "test-room",
+            super::egress::TrackEgressOutput::WebSocket("wss://example.com/ws".to_owned()),
+            "TR_video1",
+        )
+        .await
+        .expect("start_track_egress");
     egress.update_layout("EG_abc123", "speaker").await.expect("update_layout");
     egress
         .update_stream("EG_abc123", vec!["rtmps://b.example.com/live/key".to_owned()], vec![])
@@ -453,6 +533,27 @@ async fn connector_smoke() {
         )
         .await
         .expect("connect_twilio_call");
+    let offer = proto::SessionDescription {
+        r#type: "offer".to_owned(),
+        sdp: "v=0\r\n".to_owned(),
+        ..Default::default()
+    };
+    connector
+        .connect_whatsapp_call("wacid.HBg", offer.clone())
+        .await
+        .expect("connect_whatsapp_call");
+    connector
+        .accept_whatsapp_call("123456789012345", "wa-secret-key", "23.0", "wacid.HBg", offer, Default::default())
+        .await
+        .expect("accept_whatsapp_call");
+    connector
+        .disconnect_whatsapp_call(
+            "wacid.HBg",
+            "wa-secret-key",
+            proto::disconnect_whats_app_call_request::DisconnectReason::BusinessInitiated,
+        )
+        .await
+        .expect("disconnect_whatsapp_call");
 }
 
 #[tokio::test]

--- a/livekit-api/src/services/api_test.rs
+++ b/livekit-api/src/services/api_test.rs
@@ -33,7 +33,7 @@ use livekit_protocol as proto;
 use super::egress::{EgressListOptions, EgressOutput};
 use super::failover::FailoverConfig;
 use super::sip::CreateSIPParticipantOptions;
-use super::twirp_client::{ServerError, TwirpClient, TwirpResult};
+use super::twirp_client::{ServerError, ServerResult, TwirpClient};
 use super::{LiveKitApi, ServiceError, SipCallError, LIVEKIT_PACKAGE};
 use crate::access_token::{AccessToken, VideoGrants};
 
@@ -70,7 +70,7 @@ fn config(enabled: bool, force: bool) -> FailoverConfig {
 // Issues a CreateRoom through the failover machinery with the given X-Lk-Mock
 // directives. These tests exercise failover, not authz, so they skip the mock's
 // permission check.
-async fn call(base: &str, cfg: FailoverConfig, mock: &str) -> TwirpResult<proto::Room> {
+async fn call(base: &str, cfg: FailoverConfig, mock: &str) -> ServerResult<proto::Room> {
     let client = TwirpClient::new(base, LIVEKIT_PACKAGE, None).with_failover_config(cfg);
     let mut headers = HeaderMap::new();
     headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer test-token"));
@@ -119,7 +119,7 @@ async fn all_unavailable() {
     let err = call(&base, config(true, true), r#"{"skipAuth":true,"failRegions":[0,1,2,3]}"#)
         .await
         .expect_err("all regions down should surface an error");
-    assert!(matches!(err, ServerError::Twirp(_)));
+    assert!(matches!(err, ServerError::Response(_)));
 }
 
 #[tokio::test]
@@ -131,7 +131,7 @@ async fn client_error_not_retried() {
             .await
             .expect_err("a 4xx must be returned without failover");
     match err {
-        ServerError::Twirp(code) => assert_eq!(code.code, "invalid_argument"),
+        ServerError::Response(code) => assert_eq!(code.code, "invalid_argument"),
         other => panic!("expected a twirp error, got {other:?}"),
     }
 }
@@ -752,5 +752,5 @@ async fn sip_dial_timeout() {
         )
         .await
         .expect_err("the dial should abort before the mock answers");
-    assert!(matches!(err, ServiceError::Twirp(ServerError::Request(_))), "{err:?}");
+    assert!(matches!(err, ServiceError::Server(ServerError::Request(_))), "{err:?}");
 }

--- a/livekit-api/src/services/connector.rs
+++ b/livekit-api/src/services/connector.rs
@@ -89,7 +89,7 @@ pub struct ConnectTwilioCallOptions {
 #[derive(Debug)]
 pub struct ConnectorClient {
     base: ServiceBase,
-    client: TwirpClient,
+    pub(crate) client: TwirpClient,
 }
 
 impl ConnectorClient {

--- a/livekit-api/src/services/connector.rs
+++ b/livekit-api/src/services/connector.rs
@@ -178,7 +178,34 @@ impl ConnectorClient {
             .map_err(Into::into)
     }
 
-    /// Disconnects a WhatsApp call
+    /// Disconnects a WhatsApp call initiated by the business.
+    ///
+    /// This is the `BusinessInitiated` case; use [`disconnect_whatsapp_call_with_reason`]
+    /// to disconnect with a different [`DisconnectReason`].
+    ///
+    /// [`disconnect_whatsapp_call_with_reason`]: Self::disconnect_whatsapp_call_with_reason
+    /// [`DisconnectReason`]: proto::disconnect_whats_app_call_request::DisconnectReason
+    ///
+    /// # Arguments
+    /// * `call_id` - Call ID sent by Meta
+    /// * `api_key` - The API key of the business disconnecting the call
+    ///
+    /// # Returns
+    /// Empty response on success
+    pub async fn disconnect_whatsapp_call(
+        &self,
+        call_id: impl Into<String>,
+        api_key: impl Into<String>,
+    ) -> ServiceResult<proto::DisconnectWhatsAppCallResponse> {
+        self.disconnect_whatsapp_call_with_reason(
+            call_id,
+            api_key,
+            proto::disconnect_whats_app_call_request::DisconnectReason::BusinessInitiated,
+        )
+        .await
+    }
+
+    /// Disconnects a WhatsApp call, specifying why it is being disconnected.
     ///
     /// # Arguments
     /// * `call_id` - Call ID sent by Meta
@@ -188,7 +215,7 @@ impl ConnectorClient {
     ///
     /// # Returns
     /// Empty response on success
-    pub async fn disconnect_whatsapp_call(
+    pub async fn disconnect_whatsapp_call_with_reason(
         &self,
         call_id: impl Into<String>,
         api_key: impl Into<String>,

--- a/livekit-api/src/services/connector.rs
+++ b/livekit-api/src/services/connector.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use livekit_protocol as proto;
-use pbjson_types::Duration as ProtoDuration;
 use std::collections::HashMap;
 use std::time::Duration;
 
@@ -63,14 +62,10 @@ pub struct AcceptWhatsAppCallOptions {
     pub participant_attributes: Option<HashMap<String, String>>,
     /// Optional - Country where the call terminates as ISO 3166-1 alpha-2
     pub destination_country: Option<String>,
-    /// Optional - Max time for the callee to answer the call
-    pub ringing_timeout: Option<Duration>,
-    /// Optional - Wait for the call to be answered before returning. When set,
-    /// the request blocks until the call is answered or fails.
+    /// Optional - Wait until the inbound party joins before returning.
     pub wait_until_answered: Option<bool>,
-    /// Optional - Per-request timeout override. When `wait_until_answered` is
-    /// set, defaults to a longer value (dialing takes time) and is raised, if
-    /// needed, to stay above `ringing_timeout`; otherwise the client default.
+    /// Optional - Per-request timeout override. When `wait_until_answered` is set
+    /// it defaults to the standard ring window; otherwise the client default applies.
     pub timeout: Option<Duration>,
 }
 
@@ -103,6 +98,19 @@ impl ConnectorClient {
             base: ServiceBase::with_api_key(api_key, api_secret),
             client: TwirpClient::new(host, LIVEKIT_PACKAGE, None),
         }
+    }
+
+    pub fn with_token(host: &str, token: &str) -> Self {
+        Self {
+            base: ServiceBase::with_token(token),
+            client: TwirpClient::new(host, LIVEKIT_PACKAGE, None),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_default_headers(mut self, headers: http::HeaderMap) -> Self {
+        self.client = self.client.with_default_headers(headers);
+        self
     }
 
     pub fn new(host: &str) -> ServiceResult<Self> {
@@ -174,7 +182,9 @@ impl ConnectorClient {
     ///
     /// # Arguments
     /// * `call_id` - Call ID sent by Meta
-    /// * `api_key` - The API key of the business disconnecting the call
+    /// * `api_key` - The API key of the business disconnecting the call. Required
+    ///   when `reason` is `BusinessInitiated`; optional for `UserInitiated`.
+    /// * `reason` - Why the call is being disconnected
     ///
     /// # Returns
     /// Empty response on success
@@ -182,6 +192,7 @@ impl ConnectorClient {
         &self,
         call_id: impl Into<String>,
         api_key: impl Into<String>,
+        reason: proto::disconnect_whats_app_call_request::DisconnectReason,
     ) -> ServiceResult<proto::DisconnectWhatsAppCallResponse> {
         self.client
             .request(
@@ -190,7 +201,7 @@ impl ConnectorClient {
                 proto::DisconnectWhatsAppCallRequest {
                     whatsapp_call_id: call_id.into(),
                     whatsapp_api_key: api_key.into(),
-                    ..Default::default()
+                    disconnect_reason: reason as i32,
                 },
                 self.base
                     .auth_header(VideoGrants { room_create: true, ..Default::default() }, None)?,
@@ -263,20 +274,15 @@ impl ConnectorClient {
             participant_metadata: options.participant_metadata.unwrap_or_default(),
             participant_attributes: options.participant_attributes.unwrap_or_default(),
             destination_country: options.destination_country.unwrap_or_default(),
-            ringing_timeout: options.ringing_timeout.map(|d| ProtoDuration {
-                seconds: d.as_secs() as i64,
-                nanos: d.subsec_nanos() as i32,
-            }),
+            ringing_timeout: None,
             wait_until_answered,
         };
         let headers =
             self.base.auth_header(VideoGrants { room_create: true, ..Default::default() }, None)?;
 
-        // Accept can block until the call is answered, so default the request
-        // timeout to the standard ring window; the caller overrides via
-        // `options.timeout` and should set it above the ringing_timeout passed to
-        // `dial_whatsapp_call`. Without waiting, the request returns promptly and
-        // the client default applies.
+        // When waiting for the inbound party to join, the request can block, so
+        // default its timeout to the standard ring window; otherwise the client
+        // default applies.
         let timeout = if wait_until_answered {
             Some(options.timeout.unwrap_or(DEFAULT_RINGING_TIMEOUT))
         } else {

--- a/livekit-api/src/services/connector.rs
+++ b/livekit-api/src/services/connector.rs
@@ -93,6 +93,7 @@ pub struct ConnectorClient {
 }
 
 impl ConnectorClient {
+    /// Authenticates with an API key and secret, signing a short-lived token per request.
     pub fn with_api_key(host: &str, api_key: &str, api_secret: &str) -> Self {
         Self {
             base: ServiceBase::with_api_key(api_key, api_secret),
@@ -100,6 +101,7 @@ impl ConnectorClient {
         }
     }
 
+    /// Authenticates with a pre-signed token, sent verbatim on every request.
     pub fn with_token(host: &str, token: &str) -> Self {
         Self {
             base: ServiceBase::with_token(token),
@@ -113,6 +115,8 @@ impl ConnectorClient {
         self
     }
 
+    /// Reads the API key and secret from the `LIVEKIT_API_KEY` and
+    /// `LIVEKIT_API_SECRET` environment variables.
     pub fn new(host: &str) -> ServiceResult<Self> {
         let (api_key, api_secret) = get_env_keys()?;
         Ok(Self::with_api_key(host, &api_key, &api_secret))

--- a/livekit-api/src/services/connector.rs
+++ b/livekit-api/src/services/connector.rs
@@ -89,24 +89,28 @@ pub struct ConnectTwilioCallOptions {
 #[derive(Debug)]
 pub struct ConnectorClient {
     base: ServiceBase,
-    pub(crate) client: TwirpClient,
+    client: TwirpClient,
 }
 
 impl ConnectorClient {
     /// Authenticates with an API key and secret, signing a short-lived token per request.
     pub fn with_api_key(host: &str, api_key: &str, api_secret: &str) -> Self {
-        Self {
-            base: ServiceBase::with_api_key(api_key, api_secret),
-            client: TwirpClient::new(host, LIVEKIT_PACKAGE, None),
-        }
+        Self::build(
+            host,
+            ServiceBase::with_api_key(api_key, api_secret),
+            crate::http_client::Client::new(),
+        )
     }
 
     /// Authenticates with a pre-signed token, sent verbatim on every request.
     pub fn with_token(host: &str, token: &str) -> Self {
-        Self {
-            base: ServiceBase::with_token(token),
-            client: TwirpClient::new(host, LIVEKIT_PACKAGE, None),
-        }
+        Self::build(host, ServiceBase::with_token(token), crate::http_client::Client::new())
+    }
+
+    /// Builds the client from an already-constructed HTTP client so the unified
+    /// [`LiveKitApi`](super::LiveKitApi) can share one connection pool across services.
+    pub(crate) fn build(host: &str, base: ServiceBase, client: crate::http_client::Client) -> Self {
+        Self { base, client: TwirpClient::with_client(host, LIVEKIT_PACKAGE, None, client) }
     }
 
     #[cfg(test)]

--- a/livekit-api/src/services/dial_timeout.rs
+++ b/livekit-api/src/services/dial_timeout.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Request-timeout handling shared by calls that dial a phone and wait for an
-//! answer (SIP CreateSIPParticipant/TransferSIPParticipant, WhatsApp
+//! Request-timeout handling shared by calls that may block until a call is
+//! answered (SIP CreateSIPParticipant/TransferSIPParticipant, WhatsApp
 //! AcceptWhatsAppCall). These take longer than a normal request, and the request
-//! must outlast ringing or it would abort before the call can be answered.
+//! must outlast the wait or it would abort before the call can be answered.
 
 use std::time::Duration;
 

--- a/livekit-api/src/services/egress.rs
+++ b/livekit-api/src/services/egress.rs
@@ -109,6 +109,7 @@ pub struct EgressClient {
 }
 
 impl EgressClient {
+    /// Authenticates with an API key and secret, signing a short-lived token per request.
     pub fn with_api_key(host: &str, api_key: &str, api_secret: &str) -> Self {
         Self {
             base: ServiceBase::with_api_key(api_key, api_secret),
@@ -116,6 +117,7 @@ impl EgressClient {
         }
     }
 
+    /// Authenticates with a pre-signed token, sent verbatim on every request.
     pub fn with_token(host: &str, token: &str) -> Self {
         Self {
             base: ServiceBase::with_token(token),
@@ -129,6 +131,8 @@ impl EgressClient {
         self
     }
 
+    /// Reads the API key and secret from the `LIVEKIT_API_KEY` and
+    /// `LIVEKIT_API_SECRET` environment variables.
     pub fn new(host: &str) -> ServiceResult<Self> {
         let (api_key, api_secret) = get_env_keys()?;
         Ok(Self::with_api_key(host, &api_key, &api_secret))

--- a/livekit-api/src/services/egress.rs
+++ b/livekit-api/src/services/egress.rs
@@ -105,7 +105,7 @@ const SVC: &str = "Egress";
 #[derive(Debug)]
 pub struct EgressClient {
     base: ServiceBase,
-    client: TwirpClient,
+    pub(crate) client: TwirpClient,
 }
 
 impl EgressClient {

--- a/livekit-api/src/services/egress.rs
+++ b/livekit-api/src/services/egress.rs
@@ -116,6 +116,19 @@ impl EgressClient {
         }
     }
 
+    pub fn with_token(host: &str, token: &str) -> Self {
+        Self {
+            base: ServiceBase::with_token(token),
+            client: TwirpClient::new(host, LIVEKIT_PACKAGE, None),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_default_headers(mut self, headers: http::HeaderMap) -> Self {
+        self.client = self.client.with_default_headers(headers);
+        self
+    }
+
     pub fn new(host: &str) -> ServiceResult<Self> {
         let (api_key, api_secret) = get_env_keys()?;
         Ok(Self::with_api_key(host, &api_key, &api_secret))

--- a/livekit-api/src/services/egress.rs
+++ b/livekit-api/src/services/egress.rs
@@ -105,24 +105,28 @@ const SVC: &str = "Egress";
 #[derive(Debug)]
 pub struct EgressClient {
     base: ServiceBase,
-    pub(crate) client: TwirpClient,
+    client: TwirpClient,
 }
 
 impl EgressClient {
     /// Authenticates with an API key and secret, signing a short-lived token per request.
     pub fn with_api_key(host: &str, api_key: &str, api_secret: &str) -> Self {
-        Self {
-            base: ServiceBase::with_api_key(api_key, api_secret),
-            client: TwirpClient::new(host, LIVEKIT_PACKAGE, None),
-        }
+        Self::build(
+            host,
+            ServiceBase::with_api_key(api_key, api_secret),
+            crate::http_client::Client::new(),
+        )
     }
 
     /// Authenticates with a pre-signed token, sent verbatim on every request.
     pub fn with_token(host: &str, token: &str) -> Self {
-        Self {
-            base: ServiceBase::with_token(token),
-            client: TwirpClient::new(host, LIVEKIT_PACKAGE, None),
-        }
+        Self::build(host, ServiceBase::with_token(token), crate::http_client::Client::new())
+    }
+
+    /// Builds the client from an already-constructed HTTP client so the unified
+    /// [`LiveKitApi`](super::LiveKitApi) can share one connection pool across services.
+    pub(crate) fn build(host: &str, base: ServiceBase, client: crate::http_client::Client) -> Self {
+        Self { base, client: TwirpClient::with_client(host, LIVEKIT_PACKAGE, None, client) }
     }
 
     #[cfg(test)]

--- a/livekit-api/src/services/failover.rs
+++ b/livekit-api/src/services/failover.rs
@@ -105,19 +105,13 @@ pub(crate) fn pick_next(region_urls: &[String], attempted: &[String]) -> Option<
 
 /// Sleeps for `d` before a retry, so failover backs off between attempts on
 /// either backend (retrying with no delay would risk hammering the server).
-/// `futures-timer` keeps the async path runtime-agnostic.
+/// `livekit_runtime::sleep` keeps the async path runtime-agnostic (it maps to
+/// `tokio::time::sleep` or the async-std timer depending on the enabled feature).
 pub(crate) async fn backoff_sleep(d: Duration) {
     if d.is_zero() {
         return;
     }
-    #[cfg(feature = "services-tokio")]
-    {
-        tokio::time::sleep(d).await;
-    }
-    #[cfg(all(feature = "services-async", not(feature = "services-tokio")))]
-    {
-        futures_timer::Delay::new(d).await;
-    }
+    livekit_runtime::sleep(d).await;
 }
 
 /// Region discovery (`/settings/regions`) uses a short timeout so a slow or
@@ -213,8 +207,10 @@ async fn fetch(base: &Url, headers: &HeaderMap) -> Result<(Vec<String>, Option<D
     url.set_path("/settings/regions");
 
     let mut builder = isahc::Request::get(url.as_str()).timeout(DISCOVERY_TIMEOUT);
+    // isahc vendors `http` 0.2, so pass name/value as &str/&[u8] to stay agnostic
+    // to the `http` version the workspace `HeaderMap` (1.x) is built from.
     for (name, value) in forward_headers(headers).iter() {
-        builder = builder.header(name, value);
+        builder = builder.header(name.as_str(), value.as_bytes());
     }
     let request = builder.body(()).map_err(|_| ())?;
     let mut resp = isahc::send_async(request).await.map_err(|_| ())?;

--- a/livekit-api/src/services/ingress.rs
+++ b/livekit-api/src/services/ingress.rs
@@ -56,7 +56,7 @@ const SVC: &str = "Ingress";
 #[derive(Debug)]
 pub struct IngressClient {
     base: ServiceBase,
-    client: TwirpClient,
+    pub(crate) client: TwirpClient,
 }
 
 impl IngressClient {

--- a/livekit-api/src/services/ingress.rs
+++ b/livekit-api/src/services/ingress.rs
@@ -56,24 +56,28 @@ const SVC: &str = "Ingress";
 #[derive(Debug)]
 pub struct IngressClient {
     base: ServiceBase,
-    pub(crate) client: TwirpClient,
+    client: TwirpClient,
 }
 
 impl IngressClient {
     /// Authenticates with an API key and secret, signing a short-lived token per request.
     pub fn with_api_key(host: &str, api_key: &str, api_secret: &str) -> Self {
-        Self {
-            base: ServiceBase::with_api_key(api_key, api_secret),
-            client: TwirpClient::new(host, LIVEKIT_PACKAGE, None),
-        }
+        Self::build(
+            host,
+            ServiceBase::with_api_key(api_key, api_secret),
+            crate::http_client::Client::new(),
+        )
     }
 
     /// Authenticates with a pre-signed token, sent verbatim on every request.
     pub fn with_token(host: &str, token: &str) -> Self {
-        Self {
-            base: ServiceBase::with_token(token),
-            client: TwirpClient::new(host, LIVEKIT_PACKAGE, None),
-        }
+        Self::build(host, ServiceBase::with_token(token), crate::http_client::Client::new())
+    }
+
+    /// Builds the client from an already-constructed HTTP client so the unified
+    /// [`LiveKitApi`](super::LiveKitApi) can share one connection pool across services.
+    pub(crate) fn build(host: &str, base: ServiceBase, client: crate::http_client::Client) -> Self {
+        Self { base, client: TwirpClient::with_client(host, LIVEKIT_PACKAGE, None, client) }
     }
 
     #[cfg(test)]

--- a/livekit-api/src/services/ingress.rs
+++ b/livekit-api/src/services/ingress.rs
@@ -60,6 +60,7 @@ pub struct IngressClient {
 }
 
 impl IngressClient {
+    /// Authenticates with an API key and secret, signing a short-lived token per request.
     pub fn with_api_key(host: &str, api_key: &str, api_secret: &str) -> Self {
         Self {
             base: ServiceBase::with_api_key(api_key, api_secret),
@@ -67,6 +68,7 @@ impl IngressClient {
         }
     }
 
+    /// Authenticates with a pre-signed token, sent verbatim on every request.
     pub fn with_token(host: &str, token: &str) -> Self {
         Self {
             base: ServiceBase::with_token(token),
@@ -80,6 +82,8 @@ impl IngressClient {
         self
     }
 
+    /// Reads the API key and secret from the `LIVEKIT_API_KEY` and
+    /// `LIVEKIT_API_SECRET` environment variables.
     pub fn new(host: &str) -> ServiceResult<Self> {
         let (api_key, api_secret) = get_env_keys()?;
         Ok(Self::with_api_key(host, &api_key, &api_secret))

--- a/livekit-api/src/services/ingress.rs
+++ b/livekit-api/src/services/ingress.rs
@@ -67,6 +67,19 @@ impl IngressClient {
         }
     }
 
+    pub fn with_token(host: &str, token: &str) -> Self {
+        Self {
+            base: ServiceBase::with_token(token),
+            client: TwirpClient::new(host, LIVEKIT_PACKAGE, None),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_default_headers(mut self, headers: http::HeaderMap) -> Self {
+        self.client = self.client.with_default_headers(headers);
+        self
+    }
+
     pub fn new(host: &str) -> ServiceResult<Self> {
         let (api_key, api_secret) = get_env_keys()?;
         Ok(Self::with_api_key(host, &api_key, &api_secret))

--- a/livekit-api/src/services/livekit_api.rs
+++ b/livekit-api/src/services/livekit_api.rs
@@ -20,7 +20,7 @@ use super::egress::EgressClient;
 use super::ingress::IngressClient;
 use super::room::RoomClient;
 use super::sip::SIPClient;
-use super::ServiceResult;
+use super::{ServiceBase, ServiceResult};
 use crate::get_env_keys;
 use crate::http_client;
 
@@ -44,16 +44,18 @@ pub struct LiveKitApi {
 
 impl LiveKitApi {
     pub fn with_api_key(host: &str, api_key: &str, api_secret: &str) -> Self {
-        let mut api = Self {
-            room: RoomClient::with_api_key(host, api_key, api_secret),
-            egress: EgressClient::with_api_key(host, api_key, api_secret),
-            ingress: IngressClient::with_api_key(host, api_key, api_secret),
-            sip: SIPClient::with_api_key(host, api_key, api_secret),
-            agent_dispatch: AgentDispatchClient::with_api_key(host, api_key, api_secret),
-            connector: ConnectorClient::with_api_key(host, api_key, api_secret),
-        };
-        api.share_http_client();
-        api
+        // One HTTP client shared across every service, so they reuse a single
+        // connection pool instead of each opening its own.
+        let http = http_client::Client::new();
+        let base = || ServiceBase::with_api_key(api_key, api_secret);
+        Self {
+            room: RoomClient::build(host, base(), http.clone()),
+            egress: EgressClient::build(host, base(), http.clone()),
+            ingress: IngressClient::build(host, base(), http.clone()),
+            sip: SIPClient::build(host, base(), http.clone()),
+            agent_dispatch: AgentDispatchClient::build(host, base(), http.clone()),
+            connector: ConnectorClient::build(host, base(), http),
+        }
     }
 
     /// Reads the key and secret from the `LIVEKIT_API_KEY` and
@@ -66,28 +68,17 @@ impl LiveKitApi {
     /// Authenticates with a pre-signed token, sent verbatim on every request.
     /// The token's grants must cover the calls made through this client.
     pub fn with_token(host: &str, token: &str) -> Self {
-        let mut api = Self {
-            room: RoomClient::with_token(host, token),
-            egress: EgressClient::with_token(host, token),
-            ingress: IngressClient::with_token(host, token),
-            sip: SIPClient::with_token(host, token),
-            agent_dispatch: AgentDispatchClient::with_token(host, token),
-            connector: ConnectorClient::with_token(host, token),
-        };
-        api.share_http_client();
-        api
-    }
-
-    /// Points every service at one shared HTTP client so they reuse a single
-    /// connection pool instead of each opening its own.
-    fn share_http_client(&mut self) {
+        // One HTTP client shared across every service (see `with_api_key`).
         let http = http_client::Client::new();
-        self.room.client.set_http_client(http.clone());
-        self.egress.client.set_http_client(http.clone());
-        self.ingress.client.set_http_client(http.clone());
-        self.sip.client.set_http_client(http.clone());
-        self.agent_dispatch.client.set_http_client(http.clone());
-        self.connector.client.set_http_client(http);
+        let base = || ServiceBase::with_token(token);
+        Self {
+            room: RoomClient::build(host, base(), http.clone()),
+            egress: EgressClient::build(host, base(), http.clone()),
+            ingress: IngressClient::build(host, base(), http.clone()),
+            sip: SIPClient::build(host, base(), http.clone()),
+            agent_dispatch: AgentDispatchClient::build(host, base(), http.clone()),
+            connector: ConnectorClient::build(host, base(), http),
+        }
     }
 
     /// Enables or disables region failover on every service (enabled by

--- a/livekit-api/src/services/livekit_api.rs
+++ b/livekit-api/src/services/livekit_api.rs
@@ -22,6 +22,7 @@ use super::room::RoomClient;
 use super::sip::SIPClient;
 use super::ServiceResult;
 use crate::get_env_keys;
+use crate::http_client;
 
 /// A single entry point to every LiveKit server API, exposing each service
 /// through an accessor (`room()`, `egress()`, `ingress()`, `sip()`,
@@ -43,14 +44,16 @@ pub struct LiveKitApi {
 
 impl LiveKitApi {
     pub fn with_api_key(host: &str, api_key: &str, api_secret: &str) -> Self {
-        Self {
+        let mut api = Self {
             room: RoomClient::with_api_key(host, api_key, api_secret),
             egress: EgressClient::with_api_key(host, api_key, api_secret),
             ingress: IngressClient::with_api_key(host, api_key, api_secret),
             sip: SIPClient::with_api_key(host, api_key, api_secret),
             agent_dispatch: AgentDispatchClient::with_api_key(host, api_key, api_secret),
             connector: ConnectorClient::with_api_key(host, api_key, api_secret),
-        }
+        };
+        api.share_http_client();
+        api
     }
 
     /// Reads the key and secret from the `LIVEKIT_API_KEY` and
@@ -63,14 +66,28 @@ impl LiveKitApi {
     /// Authenticates with a pre-signed token, sent verbatim on every request.
     /// The token's grants must cover the calls made through this client.
     pub fn with_token(host: &str, token: &str) -> Self {
-        Self {
+        let mut api = Self {
             room: RoomClient::with_token(host, token),
             egress: EgressClient::with_token(host, token),
             ingress: IngressClient::with_token(host, token),
             sip: SIPClient::with_token(host, token),
             agent_dispatch: AgentDispatchClient::with_token(host, token),
             connector: ConnectorClient::with_token(host, token),
-        }
+        };
+        api.share_http_client();
+        api
+    }
+
+    /// Points every service at one shared HTTP client so they reuse a single
+    /// connection pool instead of each opening its own.
+    fn share_http_client(&mut self) {
+        let http = http_client::Client::new();
+        self.room.client.set_http_client(http.clone());
+        self.egress.client.set_http_client(http.clone());
+        self.ingress.client.set_http_client(http.clone());
+        self.sip.client.set_http_client(http.clone());
+        self.agent_dispatch.client.set_http_client(http.clone());
+        self.connector.client.set_http_client(http);
     }
 
     /// Enables or disables region failover on every service (enabled by

--- a/livekit-api/src/services/livekit_api.rs
+++ b/livekit-api/src/services/livekit_api.rs
@@ -1,0 +1,141 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use super::agent_dispatch::AgentDispatchClient;
+use super::connector::ConnectorClient;
+use super::egress::EgressClient;
+use super::ingress::IngressClient;
+use super::room::RoomClient;
+use super::sip::SIPClient;
+use super::ServiceResult;
+use crate::get_env_keys;
+
+/// A single entry point to every LiveKit server API, exposing each service
+/// through an accessor (`room()`, `egress()`, `ingress()`, `sip()`,
+/// `agent_dispatch()`, `connector()`).
+///
+/// Construct it with an API key and secret ([`with_api_key`](Self::with_api_key),
+/// or [`new`](Self::new) to read them from the environment) for backend use, or
+/// with a pre-signed token ([`with_token`](Self::with_token)) for client-side use
+/// where the API secret must not be exposed.
+#[derive(Debug)]
+pub struct LiveKitApi {
+    room: RoomClient,
+    egress: EgressClient,
+    ingress: IngressClient,
+    sip: SIPClient,
+    agent_dispatch: AgentDispatchClient,
+    connector: ConnectorClient,
+}
+
+impl LiveKitApi {
+    pub fn with_api_key(host: &str, api_key: &str, api_secret: &str) -> Self {
+        Self {
+            room: RoomClient::with_api_key(host, api_key, api_secret),
+            egress: EgressClient::with_api_key(host, api_key, api_secret),
+            ingress: IngressClient::with_api_key(host, api_key, api_secret),
+            sip: SIPClient::with_api_key(host, api_key, api_secret),
+            agent_dispatch: AgentDispatchClient::with_api_key(host, api_key, api_secret),
+            connector: ConnectorClient::with_api_key(host, api_key, api_secret),
+        }
+    }
+
+    /// Reads the key and secret from the `LIVEKIT_API_KEY` and
+    /// `LIVEKIT_API_SECRET` environment variables.
+    pub fn new(host: &str) -> ServiceResult<Self> {
+        let (api_key, api_secret) = get_env_keys()?;
+        Ok(Self::with_api_key(host, &api_key, &api_secret))
+    }
+
+    /// Authenticates with a pre-signed token, sent verbatim on every request.
+    /// The token's grants must cover the calls made through this client.
+    pub fn with_token(host: &str, token: &str) -> Self {
+        Self {
+            room: RoomClient::with_token(host, token),
+            egress: EgressClient::with_token(host, token),
+            ingress: IngressClient::with_token(host, token),
+            sip: SIPClient::with_token(host, token),
+            agent_dispatch: AgentDispatchClient::with_token(host, token),
+            connector: ConnectorClient::with_token(host, token),
+        }
+    }
+
+    /// Enables or disables region failover on every service (enabled by
+    /// default). Failover only engages for LiveKit Cloud hosts.
+    pub fn with_failover(mut self, enabled: bool) -> Self {
+        self.room = self.room.with_failover(enabled);
+        self.egress = self.egress.with_failover(enabled);
+        self.ingress = self.ingress.with_failover(enabled);
+        self.sip = self.sip.with_failover(enabled);
+        self.agent_dispatch = self.agent_dispatch.with_failover(enabled);
+        self.connector = self.connector.with_failover(enabled);
+        self
+    }
+
+    /// Overrides the default per-request timeout (10s) on every service.
+    pub fn with_request_timeout(mut self, timeout: Duration) -> Self {
+        self.room = self.room.with_request_timeout(timeout);
+        self.egress = self.egress.with_request_timeout(timeout);
+        self.ingress = self.ingress.with_request_timeout(timeout);
+        self.sip = self.sip.with_request_timeout(timeout);
+        self.agent_dispatch = self.agent_dispatch.with_request_timeout(timeout);
+        self.connector = self.connector.with_request_timeout(timeout);
+        self
+    }
+
+    /// Injects a mock-control header on every service (see the mock test server's
+    /// X-Lk-Mock protocol). Test-only, since the service methods don't expose
+    /// per-call headers.
+    #[cfg(test)]
+    pub(crate) fn with_mock(mut self, mock: &str) -> Self {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::HeaderName::from_static("x-lk-mock"),
+            http::HeaderValue::from_str(mock).unwrap(),
+        );
+        self.room = self.room.with_default_headers(headers.clone());
+        self.egress = self.egress.with_default_headers(headers.clone());
+        self.ingress = self.ingress.with_default_headers(headers.clone());
+        self.sip = self.sip.with_default_headers(headers.clone());
+        self.agent_dispatch = self.agent_dispatch.with_default_headers(headers.clone());
+        self.connector = self.connector.with_default_headers(headers);
+        self
+    }
+
+    pub fn room(&self) -> &RoomClient {
+        &self.room
+    }
+
+    pub fn egress(&self) -> &EgressClient {
+        &self.egress
+    }
+
+    pub fn ingress(&self) -> &IngressClient {
+        &self.ingress
+    }
+
+    pub fn sip(&self) -> &SIPClient {
+        &self.sip
+    }
+
+    pub fn agent_dispatch(&self) -> &AgentDispatchClient {
+        &self.agent_dispatch
+    }
+
+    pub fn connector(&self) -> &ConnectorClient {
+        &self.connector
+    }
+}

--- a/livekit-api/src/services/mod.rs
+++ b/livekit-api/src/services/mod.rs
@@ -60,27 +60,35 @@ pub enum ServiceError {
 
 pub type ServiceResult<T> = Result<T, ServiceError>;
 
-struct ServiceBase {
-    api_key: String,
-    api_secret: String,
-    // When set, requests carry this token verbatim and grants are ignored; the
-    // caller (typically a browser client) signed it out of band.
-    token: Option<String>,
+// The two authentication modes are mutually exclusive, so they're distinct
+// variants rather than a struct where an invalid combination is representable.
+enum ServiceBase {
+    /// Sign a short-lived token per request from an API key and secret.
+    ApiKeySecret { api_key: String, api_secret: String },
+    /// Send a caller-supplied token verbatim; grants are ignored (the caller,
+    /// typically a browser client, signed it out of band).
+    Token(String),
 }
 
 impl Debug for ServiceBase {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ServiceBase").field("api_key", &self.api_key).finish()
+        // Never print the API secret or token.
+        match self {
+            Self::ApiKeySecret { api_key, .. } => {
+                f.debug_struct("ServiceBase").field("api_key", api_key).finish_non_exhaustive()
+            }
+            Self::Token(_) => f.debug_struct("ServiceBase").field("token", &"<redacted>").finish(),
+        }
     }
 }
 
 impl ServiceBase {
     pub fn with_api_key(api_key: &str, api_secret: &str) -> Self {
-        Self { api_key: api_key.to_owned(), api_secret: api_secret.to_owned(), token: None }
+        Self::ApiKeySecret { api_key: api_key.to_owned(), api_secret: api_secret.to_owned() }
     }
 
     pub fn with_token(token: &str) -> Self {
-        Self { api_key: String::new(), api_secret: String::new(), token: Some(token.to_owned()) }
+        Self::Token(token.to_owned())
     }
 
     pub fn auth_header(
@@ -88,15 +96,15 @@ impl ServiceBase {
         grants: VideoGrants,
         sip: Option<SIPGrants>,
     ) -> Result<HeaderMap, AccessTokenError> {
-        let token = if let Some(token) = &self.token {
-            token.clone()
-        } else {
-            let mut tok =
-                AccessToken::with_api_key(&self.api_key, &self.api_secret).with_grants(grants);
-            if let Some(sip_grants) = sip {
-                tok = tok.with_sip_grants(sip_grants);
+        let token = match self {
+            Self::Token(token) => token.clone(),
+            Self::ApiKeySecret { api_key, api_secret } => {
+                let mut tok = AccessToken::with_api_key(api_key, api_secret).with_grants(grants);
+                if let Some(sip_grants) = sip {
+                    tok = tok.with_sip_grants(sip_grants);
+                }
+                tok.to_jwt()?
             }
-            tok.to_jwt()?
         };
 
         let mut headers = HeaderMap::new();

--- a/livekit-api/src/services/mod.rs
+++ b/livekit-api/src/services/mod.rs
@@ -157,7 +157,9 @@ impl Display for SipCallError {
         let mut extra: Vec<_> = self
             .metadata
             .iter()
-            .filter(|(k, _)| !matches!(k.as_str(), "sip_status_code" | "sip_status" | "error_details"))
+            .filter(|(k, _)| {
+                !matches!(k.as_str(), "sip_status_code" | "sip_status" | "error_details")
+            })
             .map(|(k, v)| format!("{}={}", k, v))
             .collect();
         if !extra.is_empty() {

--- a/livekit-api/src/services/mod.rs
+++ b/livekit-api/src/services/mod.rs
@@ -62,7 +62,7 @@ pub type ServiceResult<T> = Result<T, ServiceError>;
 
 // The two authentication modes are mutually exclusive, so they're distinct
 // variants rather than a struct where an invalid combination is representable.
-enum ServiceBase {
+pub(crate) enum ServiceBase {
     /// Sign a short-lived token per request from an API key and secret.
     ApiKeySecret { api_key: String, api_secret: String },
     /// Send a caller-supplied token verbatim; grants are ignored (the caller,

--- a/livekit-api/src/services/mod.rs
+++ b/livekit-api/src/services/mod.rs
@@ -55,7 +55,7 @@ pub enum ServiceError {
     #[error("invalid access token: {0}")]
     AccessToken(#[from] AccessTokenError),
     #[error("server error: {0}")]
-    Server(#[from] ServerError),
+    Twirp(#[from] ServerError),
 }
 
 pub type ServiceResult<T> = Result<T, ServiceError>;
@@ -120,7 +120,7 @@ impl SipCallError {
     /// Returns a `SipCallError` if `err` is a server error carrying a SIP status,
     /// otherwise `None`.
     pub fn from_error(err: &ServiceError) -> Option<Self> {
-        let ServiceError::Server(ServerError::Response(code)) = err else {
+        let ServiceError::Twirp(ServerError::Twirp(code)) = err else {
             return None;
         };
         if !code.meta.contains_key("sip_status_code") && !code.meta.contains_key("sip_status") {

--- a/livekit-api/src/services/mod.rs
+++ b/livekit-api/src/services/mod.rs
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt::Debug;
+use std::collections::HashMap;
+use std::fmt::{Debug, Display};
 
 use http::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use thiserror::Error;
 
 use crate::access_token::{AccessToken, AccessTokenError, SIPGrants, VideoGrants};
 
-pub use twirp_client::{TwirpError, TwirpErrorCode, TwirpResult};
+pub use livekit_api::LiveKitApi;
+pub use twirp_client::{ServerError, TwirpError, TwirpErrorCode, TwirpResult};
 
 pub mod agent_dispatch;
 pub mod connector;
@@ -30,6 +32,7 @@ pub mod sip;
 
 mod dial_timeout;
 mod failover;
+mod livekit_api;
 mod twirp_client;
 
 #[cfg(all(test, feature = "services-tokio"))]
@@ -43,8 +46,8 @@ pub enum ServiceError {
     Env(#[from] std::env::VarError),
     #[error("invalid access token: {0}")]
     AccessToken(#[from] AccessTokenError),
-    #[error("twirp error: {0}")]
-    Twirp(#[from] TwirpError),
+    #[error("server error: {0}")]
+    Twirp(#[from] ServerError),
 }
 
 pub type ServiceResult<T> = Result<T, ServiceError>;
@@ -52,6 +55,9 @@ pub type ServiceResult<T> = Result<T, ServiceError>;
 struct ServiceBase {
     api_key: String,
     api_secret: String,
+    // When set, requests carry this token verbatim and grants are ignored; the
+    // caller (typically a browser client) signed it out of band.
+    token: Option<String>,
 }
 
 impl Debug for ServiceBase {
@@ -62,7 +68,11 @@ impl Debug for ServiceBase {
 
 impl ServiceBase {
     pub fn with_api_key(api_key: &str, api_secret: &str) -> Self {
-        Self { api_key: api_key.to_owned(), api_secret: api_secret.to_owned() }
+        Self { api_key: api_key.to_owned(), api_secret: api_secret.to_owned(), token: None }
+    }
+
+    pub fn with_token(token: &str) -> Self {
+        Self { api_key: String::new(), api_secret: String::new(), token: Some(token.to_owned()) }
     }
 
     pub fn auth_header(
@@ -70,15 +80,92 @@ impl ServiceBase {
         grants: VideoGrants,
         sip: Option<SIPGrants>,
     ) -> Result<HeaderMap, AccessTokenError> {
-        let mut tok =
-            AccessToken::with_api_key(&self.api_key, &self.api_secret).with_grants(grants);
-        if let Some(sip_grants) = sip {
-            tok = tok.with_sip_grants(sip_grants);
-        }
-        let token = tok.to_jwt()?;
+        let token = if let Some(token) = &self.token {
+            token.clone()
+        } else {
+            let mut tok =
+                AccessToken::with_api_key(&self.api_key, &self.api_secret).with_grants(grants);
+            if let Some(sip_grants) = sip {
+                tok = tok.with_sip_grants(sip_grants);
+            }
+            tok.to_jwt()?
+        };
 
         let mut headers = HeaderMap::new();
         headers.insert(AUTHORIZATION, HeaderValue::from_str(&format!("Bearer {}", token)).unwrap());
         Ok(headers)
     }
 }
+
+/// A failed SIP call (e.g. the callee was busy or declined), decoded from the
+/// SIP status the server attaches to the Twirp error metadata. Extract one from
+/// a [`ServiceError`] with [`SipCallError::from_error`].
+#[derive(Debug, Clone)]
+pub struct SipCallError {
+    code: String,
+    sip_status_code: Option<i32>,
+    sip_status: Option<String>,
+    metadata: HashMap<String, String>,
+}
+
+impl SipCallError {
+    /// Returns a `SipCallError` if `err` is a Twirp error carrying a SIP status,
+    /// otherwise `None`.
+    pub fn from_error(err: &ServiceError) -> Option<Self> {
+        let ServiceError::Twirp(ServerError::Twirp(code)) = err else {
+            return None;
+        };
+        if !code.meta.contains_key("sip_status_code") && !code.meta.contains_key("sip_status") {
+            return None;
+        }
+        Some(Self {
+            code: code.code.clone(),
+            sip_status_code: code.meta.get("sip_status_code").and_then(|v| v.parse().ok()),
+            sip_status: code.meta.get("sip_status").cloned(),
+            metadata: code.meta.clone(),
+        })
+    }
+
+    /// The Twirp error code (e.g. `resource_exhausted` for a busy callee).
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+
+    /// The SIP status code (e.g. 486 for Busy Here), if present.
+    pub fn sip_status_code(&self) -> Option<i32> {
+        self.sip_status_code
+    }
+
+    /// The SIP status reason (e.g. "Busy Here"), if present.
+    pub fn sip_status(&self) -> Option<&str> {
+        self.sip_status.as_deref()
+    }
+
+    /// Any additional metadata the server attached to the error.
+    pub fn metadata(&self) -> &HashMap<String, String> {
+        &self.metadata
+    }
+}
+
+impl Display for SipCallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SIP call failed: {}", self.sip_status_code.unwrap_or_default())?;
+        if let Some(reason) = &self.sip_status {
+            write!(f, " {}", reason)?;
+        }
+        write!(f, " ({})", self.code)?;
+        let mut extra: Vec<_> = self
+            .metadata
+            .iter()
+            .filter(|(k, _)| !matches!(k.as_str(), "sip_status_code" | "sip_status" | "error_details"))
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect();
+        if !extra.is_empty() {
+            extra.sort();
+            write!(f, " [{}]", extra.join(", "))?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for SipCallError {}

--- a/livekit-api/src/services/mod.rs
+++ b/livekit-api/src/services/mod.rs
@@ -21,7 +21,15 @@ use thiserror::Error;
 use crate::access_token::{AccessToken, AccessTokenError, SIPGrants, VideoGrants};
 
 pub use livekit_api::LiveKitApi;
-pub use twirp_client::{ServerError, TwirpError, TwirpErrorCode, TwirpResult};
+pub use twirp_client::{
+    ServerError,
+    ServerErrorCode,
+    ServerResult,
+    // Deprecated aliases, kept for backwards compatibility.
+    TwirpError,
+    TwirpErrorCode,
+    TwirpResult,
+};
 
 pub mod agent_dispatch;
 pub mod connector;
@@ -47,7 +55,7 @@ pub enum ServiceError {
     #[error("invalid access token: {0}")]
     AccessToken(#[from] AccessTokenError),
     #[error("server error: {0}")]
-    Twirp(#[from] ServerError),
+    Server(#[from] ServerError),
 }
 
 pub type ServiceResult<T> = Result<T, ServiceError>;
@@ -98,8 +106,8 @@ impl ServiceBase {
 }
 
 /// A failed SIP call (e.g. the callee was busy or declined), decoded from the
-/// SIP status the server attaches to the Twirp error metadata. Extract one from
-/// a [`ServiceError`] with [`SipCallError::from_error`].
+/// SIP status the server attaches to the error metadata. Extract one from a
+/// [`ServiceError`] with [`SipCallError::from_error`].
 #[derive(Debug, Clone)]
 pub struct SipCallError {
     code: String,
@@ -109,10 +117,10 @@ pub struct SipCallError {
 }
 
 impl SipCallError {
-    /// Returns a `SipCallError` if `err` is a Twirp error carrying a SIP status,
+    /// Returns a `SipCallError` if `err` is a server error carrying a SIP status,
     /// otherwise `None`.
     pub fn from_error(err: &ServiceError) -> Option<Self> {
-        let ServiceError::Twirp(ServerError::Twirp(code)) = err else {
+        let ServiceError::Server(ServerError::Response(code)) = err else {
             return None;
         };
         if !code.meta.contains_key("sip_status_code") && !code.meta.contains_key("sip_status") {
@@ -126,7 +134,7 @@ impl SipCallError {
         })
     }
 
-    /// The Twirp error code (e.g. `resource_exhausted` for a busy callee).
+    /// The server error code (e.g. `resource_exhausted` for a busy callee).
     pub fn code(&self) -> &str {
         &self.code
     }

--- a/livekit-api/src/services/room.rs
+++ b/livekit-api/src/services/room.rs
@@ -68,6 +68,19 @@ impl RoomClient {
         }
     }
 
+    pub fn with_token(host: &str, token: &str) -> Self {
+        Self {
+            base: ServiceBase::with_token(token),
+            client: TwirpClient::new(host, LIVEKIT_PACKAGE, None),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_default_headers(mut self, headers: http::HeaderMap) -> Self {
+        self.client = self.client.with_default_headers(headers);
+        self
+    }
+
     pub fn new(host: &str) -> ServiceResult<Self> {
         let (api_key, api_secret) = get_env_keys()?;
         Ok(Self::with_api_key(host, &api_key, &api_secret))

--- a/livekit-api/src/services/room.rs
+++ b/livekit-api/src/services/room.rs
@@ -57,7 +57,7 @@ pub struct SendDataOptions {
 #[derive(Debug)]
 pub struct RoomClient {
     base: ServiceBase,
-    client: TwirpClient,
+    pub(crate) client: TwirpClient,
 }
 
 impl RoomClient {

--- a/livekit-api/src/services/room.rs
+++ b/livekit-api/src/services/room.rs
@@ -57,24 +57,28 @@ pub struct SendDataOptions {
 #[derive(Debug)]
 pub struct RoomClient {
     base: ServiceBase,
-    pub(crate) client: TwirpClient,
+    client: TwirpClient,
 }
 
 impl RoomClient {
     /// Authenticates with an API key and secret, signing a short-lived token per request.
     pub fn with_api_key(host: &str, api_key: &str, api_secret: &str) -> Self {
-        Self {
-            base: ServiceBase::with_api_key(api_key, api_secret),
-            client: TwirpClient::new(host, LIVEKIT_PACKAGE, None),
-        }
+        Self::build(
+            host,
+            ServiceBase::with_api_key(api_key, api_secret),
+            crate::http_client::Client::new(),
+        )
     }
 
     /// Authenticates with a pre-signed token, sent verbatim on every request.
     pub fn with_token(host: &str, token: &str) -> Self {
-        Self {
-            base: ServiceBase::with_token(token),
-            client: TwirpClient::new(host, LIVEKIT_PACKAGE, None),
-        }
+        Self::build(host, ServiceBase::with_token(token), crate::http_client::Client::new())
+    }
+
+    /// Builds the client from an already-constructed HTTP client so the unified
+    /// [`LiveKitApi`](super::LiveKitApi) can share one connection pool across services.
+    pub(crate) fn build(host: &str, base: ServiceBase, client: crate::http_client::Client) -> Self {
+        Self { base, client: TwirpClient::with_client(host, LIVEKIT_PACKAGE, None, client) }
     }
 
     #[cfg(test)]

--- a/livekit-api/src/services/room.rs
+++ b/livekit-api/src/services/room.rs
@@ -61,6 +61,7 @@ pub struct RoomClient {
 }
 
 impl RoomClient {
+    /// Authenticates with an API key and secret, signing a short-lived token per request.
     pub fn with_api_key(host: &str, api_key: &str, api_secret: &str) -> Self {
         Self {
             base: ServiceBase::with_api_key(api_key, api_secret),
@@ -68,6 +69,7 @@ impl RoomClient {
         }
     }
 
+    /// Authenticates with a pre-signed token, sent verbatim on every request.
     pub fn with_token(host: &str, token: &str) -> Self {
         Self {
             base: ServiceBase::with_token(token),
@@ -81,6 +83,8 @@ impl RoomClient {
         self
     }
 
+    /// Reads the API key and secret from the `LIVEKIT_API_KEY` and
+    /// `LIVEKIT_API_SECRET` environment variables.
     pub fn new(host: &str) -> ServiceResult<Self> {
         let (api_key, api_secret) = get_env_keys()?;
         Ok(Self::with_api_key(host, &api_key, &api_secret))

--- a/livekit-api/src/services/sip.rs
+++ b/livekit-api/src/services/sip.rs
@@ -28,7 +28,7 @@ const SVC: &str = "SIP";
 #[derive(Debug)]
 pub struct SIPClient {
     base: ServiceBase,
-    pub(crate) client: TwirpClient,
+    client: TwirpClient,
 }
 
 #[deprecated]
@@ -193,18 +193,22 @@ pub struct TransferSIPParticipantOptions {
 impl SIPClient {
     /// Authenticates with an API key and secret, signing a short-lived token per request.
     pub fn with_api_key(host: &str, api_key: &str, api_secret: &str) -> Self {
-        Self {
-            base: ServiceBase::with_api_key(api_key, api_secret),
-            client: TwirpClient::new(host, LIVEKIT_PACKAGE, None),
-        }
+        Self::build(
+            host,
+            ServiceBase::with_api_key(api_key, api_secret),
+            crate::http_client::Client::new(),
+        )
     }
 
     /// Authenticates with a pre-signed token, sent verbatim on every request.
     pub fn with_token(host: &str, token: &str) -> Self {
-        Self {
-            base: ServiceBase::with_token(token),
-            client: TwirpClient::new(host, LIVEKIT_PACKAGE, None),
-        }
+        Self::build(host, ServiceBase::with_token(token), crate::http_client::Client::new())
+    }
+
+    /// Builds the client from an already-constructed HTTP client so the unified
+    /// [`LiveKitApi`](super::LiveKitApi) can share one connection pool across services.
+    pub(crate) fn build(host: &str, base: ServiceBase, client: crate::http_client::Client) -> Self {
+        Self { base, client: TwirpClient::with_client(host, LIVEKIT_PACKAGE, None, client) }
     }
 
     #[cfg(test)]

--- a/livekit-api/src/services/sip.rs
+++ b/livekit-api/src/services/sip.rs
@@ -191,6 +191,7 @@ pub struct TransferSIPParticipantOptions {
 }
 
 impl SIPClient {
+    /// Authenticates with an API key and secret, signing a short-lived token per request.
     pub fn with_api_key(host: &str, api_key: &str, api_secret: &str) -> Self {
         Self {
             base: ServiceBase::with_api_key(api_key, api_secret),
@@ -198,6 +199,7 @@ impl SIPClient {
         }
     }
 
+    /// Authenticates with a pre-signed token, sent verbatim on every request.
     pub fn with_token(host: &str, token: &str) -> Self {
         Self {
             base: ServiceBase::with_token(token),
@@ -211,6 +213,8 @@ impl SIPClient {
         self
     }
 
+    /// Reads the API key and secret from the `LIVEKIT_API_KEY` and
+    /// `LIVEKIT_API_SECRET` environment variables.
     pub fn new(host: &str) -> ServiceResult<Self> {
         let (api_key, api_secret) = get_env_keys()?;
         Ok(Self::with_api_key(host, &api_key, &api_secret))

--- a/livekit-api/src/services/sip.rs
+++ b/livekit-api/src/services/sip.rs
@@ -141,6 +141,10 @@ pub struct CreateSIPParticipantOptions {
     /// Optionally set the free-form metadata of the participant in a LiveKit room
     pub participant_metadata: Option<String>,
     pub participant_attributes: Option<HashMap<String, String>>,
+    /// Optional custom caller ID shown to the callee. Requires SIP provider
+    /// support. If unset, the phone number is used; set it to an empty string to
+    /// trigger a CNAM lookup on providers that support it.
+    pub display_name: Option<String>,
     // What number should be dialed via SIP
     pub sip_number: Option<String>,
     /// Optionally send following DTMF digits (extension codes) when making a call.
@@ -659,6 +663,7 @@ impl SIPClient {
             participant_name: options.participant_name.to_owned().unwrap_or_default(),
             participant_metadata: options.participant_metadata.to_owned().unwrap_or_default(),
             participant_attributes: options.participant_attributes.to_owned().unwrap_or_default(),
+            display_name: options.display_name.to_owned(),
             dtmf: options.dtmf.to_owned().unwrap_or_default(),
             wait_until_answered,
             play_ringtone: options.play_dialtone.unwrap_or(false),

--- a/livekit-api/src/services/sip.rs
+++ b/livekit-api/src/services/sip.rs
@@ -28,7 +28,7 @@ const SVC: &str = "SIP";
 #[derive(Debug)]
 pub struct SIPClient {
     base: ServiceBase,
-    client: TwirpClient,
+    pub(crate) client: TwirpClient,
 }
 
 #[deprecated]

--- a/livekit-api/src/services/sip.rs
+++ b/livekit-api/src/services/sip.rs
@@ -16,7 +16,7 @@ use livekit_protocol as proto;
 use std::collections::HashMap;
 use std::time::Duration;
 
-use crate::access_token::SIPGrants;
+use crate::access_token::{SIPGrants, VideoGrants};
 use crate::get_env_keys;
 use crate::services::dial_timeout::{dial_timeout, DEFAULT_RINGING_TIMEOUT};
 use crate::services::twirp_client::TwirpClient;
@@ -122,6 +122,9 @@ pub struct CreateSIPDispatchRuleOptions {
     pub trunk_ids: Vec<String>,
     pub allowed_numbers: Vec<String>,
     pub hide_phone_number: bool,
+    /// Room configuration for rooms created by this dispatch rule, including
+    /// agents to dispatch into the room.
+    pub room_config: Option<proto::RoomConfiguration>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -168,12 +171,40 @@ pub struct CreateSIPParticipantOptions {
     pub timeout: Option<Duration>,
 }
 
+#[derive(Default, Clone, Debug)]
+pub struct TransferSIPParticipantOptions {
+    /// Optionally play a dialtone to the SIP participant as an audible indicator
+    /// of being transferred.
+    pub play_dialtone: Option<bool>,
+    /// Max time for the transfer destination to answer the call.
+    pub ringing_timeout: Option<Duration>,
+    /// SIP headers added to the REFER SIP request.
+    pub headers: Option<HashMap<String, String>>,
+    /// Per-request timeout override. A transfer always dials (REFER) and blocks
+    /// until the destination answers, so this is raised, if needed, to stay above
+    /// `ringing_timeout`.
+    pub timeout: Option<Duration>,
+}
+
 impl SIPClient {
     pub fn with_api_key(host: &str, api_key: &str, api_secret: &str) -> Self {
         Self {
             base: ServiceBase::with_api_key(api_key, api_secret),
             client: TwirpClient::new(host, LIVEKIT_PACKAGE, None),
         }
+    }
+
+    pub fn with_token(host: &str, token: &str) -> Self {
+        Self {
+            base: ServiceBase::with_token(token),
+            client: TwirpClient::new(host, LIVEKIT_PACKAGE, None),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_default_headers(mut self, headers: http::HeaderMap) -> Self {
+        self.client = self.client.with_default_headers(headers);
+        self
     }
 
     pub fn new(host: &str) -> ServiceResult<Self> {
@@ -291,6 +322,105 @@ impl SIPClient {
             .map_err(Into::into)
     }
 
+    /// Updates specific fields of an existing SIP inbound trunk. Only the fields
+    /// set on `update` are changed; everything else is left as-is. Mirrors the
+    /// Python SDK's `update_inbound_trunk_fields` / server-sdk-go's
+    /// `SipInboundTrunkUpdate` action.
+    pub async fn update_sip_inbound_trunk(
+        &self,
+        trunk_id: String,
+        update: proto::SipInboundTrunkUpdate,
+    ) -> ServiceResult<proto::SipInboundTrunkInfo> {
+        self.client
+            .request(
+                SVC,
+                "UpdateSIPInboundTrunk",
+                proto::UpdateSipInboundTrunkRequest {
+                    sip_trunk_id: trunk_id,
+                    action: Some(proto::update_sip_inbound_trunk_request::Action::Update(update)),
+                },
+                self.base.auth_header(
+                    Default::default(),
+                    Some(SIPGrants { admin: true, ..Default::default() }),
+                )?,
+            )
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Updates an existing SIP inbound trunk by replacing it entirely with
+    /// `trunk`. Mirrors the Python SDK's `update_inbound_trunk` / server-sdk-go's
+    /// `SipInboundTrunkInfo` (Replace) action.
+    pub async fn update_sip_inbound_trunk_replace(
+        &self,
+        trunk_id: String,
+        trunk: proto::SipInboundTrunkInfo,
+    ) -> ServiceResult<proto::SipInboundTrunkInfo> {
+        self.client
+            .request(
+                SVC,
+                "UpdateSIPInboundTrunk",
+                proto::UpdateSipInboundTrunkRequest {
+                    sip_trunk_id: trunk_id,
+                    action: Some(proto::update_sip_inbound_trunk_request::Action::Replace(trunk)),
+                },
+                self.base.auth_header(
+                    Default::default(),
+                    Some(SIPGrants { admin: true, ..Default::default() }),
+                )?,
+            )
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Updates specific fields of an existing SIP outbound trunk. Only the fields
+    /// set on `update` are changed; everything else is left as-is.
+    pub async fn update_sip_outbound_trunk(
+        &self,
+        trunk_id: String,
+        update: proto::SipOutboundTrunkUpdate,
+    ) -> ServiceResult<proto::SipOutboundTrunkInfo> {
+        self.client
+            .request(
+                SVC,
+                "UpdateSIPOutboundTrunk",
+                proto::UpdateSipOutboundTrunkRequest {
+                    sip_trunk_id: trunk_id,
+                    action: Some(proto::update_sip_outbound_trunk_request::Action::Update(update)),
+                },
+                self.base.auth_header(
+                    Default::default(),
+                    Some(SIPGrants { admin: true, ..Default::default() }),
+                )?,
+            )
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Updates an existing SIP outbound trunk by replacing it entirely with
+    /// `trunk`.
+    pub async fn update_sip_outbound_trunk_replace(
+        &self,
+        trunk_id: String,
+        trunk: proto::SipOutboundTrunkInfo,
+    ) -> ServiceResult<proto::SipOutboundTrunkInfo> {
+        self.client
+            .request(
+                SVC,
+                "UpdateSIPOutboundTrunk",
+                proto::UpdateSipOutboundTrunkRequest {
+                    sip_trunk_id: trunk_id,
+                    action: Some(proto::update_sip_outbound_trunk_request::Action::Replace(trunk)),
+                },
+                self.base.auth_header(
+                    Default::default(),
+                    Some(SIPGrants { admin: true, ..Default::default() }),
+                )?,
+            )
+            .await
+            .map_err(Into::into)
+    }
+
     #[deprecated]
     pub async fn list_sip_trunk(
         &self,
@@ -390,15 +520,66 @@ impl SIPClient {
                 SVC,
                 "CreateSIPDispatchRule",
                 proto::CreateSipDispatchRuleRequest {
-                    name: options.name,
-                    metadata: options.metadata,
-                    attributes: options.attributes,
-                    trunk_ids: options.trunk_ids.to_owned(),
-                    inbound_numbers: options.allowed_numbers.to_owned(),
-                    hide_phone_number: options.hide_phone_number,
-                    rule: Some(proto::SipDispatchRule { rule: Some(rule.to_owned()) }),
-
+                    dispatch_rule: Some(proto::SipDispatchRuleInfo {
+                        rule: Some(proto::SipDispatchRule { rule: Some(rule) }),
+                        name: options.name,
+                        metadata: options.metadata,
+                        attributes: options.attributes,
+                        trunk_ids: options.trunk_ids,
+                        inbound_numbers: options.allowed_numbers,
+                        hide_phone_number: options.hide_phone_number,
+                        room_config: options.room_config,
+                        ..Default::default()
+                    }),
                     ..Default::default()
+                },
+                self.base.auth_header(
+                    Default::default(),
+                    Some(SIPGrants { admin: true, ..Default::default() }),
+                )?,
+            )
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Updates specific fields of an existing SIP dispatch rule. Only the fields
+    /// set on `update` are changed; everything else is left as-is.
+    pub async fn update_sip_dispatch_rule(
+        &self,
+        dispatch_rule_id: String,
+        update: proto::SipDispatchRuleUpdate,
+    ) -> ServiceResult<proto::SipDispatchRuleInfo> {
+        self.client
+            .request(
+                SVC,
+                "UpdateSIPDispatchRule",
+                proto::UpdateSipDispatchRuleRequest {
+                    sip_dispatch_rule_id: dispatch_rule_id,
+                    action: Some(proto::update_sip_dispatch_rule_request::Action::Update(update)),
+                },
+                self.base.auth_header(
+                    Default::default(),
+                    Some(SIPGrants { admin: true, ..Default::default() }),
+                )?,
+            )
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Updates an existing SIP dispatch rule by replacing it entirely with
+    /// `rule`.
+    pub async fn update_sip_dispatch_rule_replace(
+        &self,
+        dispatch_rule_id: String,
+        rule: proto::SipDispatchRuleInfo,
+    ) -> ServiceResult<proto::SipDispatchRuleInfo> {
+        self.client
+            .request(
+                SVC,
+                "UpdateSIPDispatchRule",
+                proto::UpdateSipDispatchRuleRequest {
+                    sip_dispatch_rule_id: dispatch_rule_id,
+                    action: Some(proto::update_sip_dispatch_rule_request::Action::Replace(rule)),
                 },
                 self.base.auth_header(
                     Default::default(),
@@ -521,5 +702,43 @@ impl SIPClient {
                 .await
                 .map_err(Into::into)
         }
+    }
+
+    /// Transfers a SIP participant to another number via a SIP REFER. This always
+    /// dials the transfer destination and blocks until it answers or fails, so
+    /// the request must outlast the ring window.
+    pub async fn transfer_sip_participant(
+        &self,
+        room_name: String,
+        participant_identity: String,
+        transfer_to: String,
+        options: TransferSIPParticipantOptions,
+    ) -> ServiceResult<()> {
+        // Pin the ring window explicitly so the request timeout doesn't depend on
+        // the server's default (which could change).
+        let ringing_timeout = options.ringing_timeout.or(Some(DEFAULT_RINGING_TIMEOUT));
+        let request = proto::TransferSipParticipantRequest {
+            participant_identity,
+            room_name: room_name.to_owned(),
+            transfer_to,
+            play_dialtone: options.play_dialtone.unwrap_or(false),
+            headers: options.headers.unwrap_or_default(),
+            ringing_timeout: Self::duration_to_proto(ringing_timeout),
+        };
+        let headers = self.base.auth_header(
+            VideoGrants { room_admin: true, room: room_name, ..Default::default() },
+            Some(SIPGrants { call: true, ..Default::default() }),
+        )?;
+
+        self.client
+            .request_with_timeout(
+                SVC,
+                "TransferSIPParticipant",
+                request,
+                headers,
+                dial_timeout(options.timeout, ringing_timeout),
+            )
+            .await
+            .map_err(Into::into)
     }
 }

--- a/livekit-api/src/services/twirp_client.rs
+++ b/livekit-api/src/services/twirp_client.rs
@@ -64,7 +64,7 @@ pub enum ServerError {
     #[error("failed to execute the request: {0}")]
     Request(#[from] std::io::Error),
     #[error("server error: {0}")]
-    Twirp(TwirpErrorCode),
+    Response(ServerErrorCode),
     #[error("url error: {0}")]
     Url(#[from] url::ParseError),
     #[error("prost error: {0}")]
@@ -75,7 +75,7 @@ pub enum ServerError {
 pub type TwirpError = ServerError;
 
 #[derive(Debug, Deserialize)]
-pub struct TwirpErrorCode {
+pub struct ServerErrorCode {
     pub code: String,
     pub msg: String,
     /// Extra key/value context the server attached (e.g. SIP status). Absent on
@@ -84,7 +84,7 @@ pub struct TwirpErrorCode {
     pub meta: std::collections::HashMap<String, String>,
 }
 
-impl TwirpErrorCode {
+impl ServerErrorCode {
     pub const CANCELED: &'static str = "canceled";
     pub const UNKNOWN: &'static str = "unknown";
     pub const INVALID_ARGUMENT: &'static str = "invalid_argument";
@@ -105,13 +105,19 @@ impl TwirpErrorCode {
     pub const DATA_LOSS: &'static str = "dataloss";
 }
 
-impl Display for TwirpErrorCode {
+impl Display for ServerErrorCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}: {}", self.code, self.msg)
     }
 }
 
-pub type TwirpResult<T> = Result<T, TwirpError>;
+pub type ServerResult<T> = Result<T, ServerError>;
+
+/// Deprecated alias for [`ServerErrorCode`], kept for backwards compatibility.
+pub type TwirpErrorCode = ServerErrorCode;
+
+/// Deprecated alias for [`ServerResult`], kept for backwards compatibility.
+pub type TwirpResult<T> = ServerResult<T>;
 
 #[derive(Debug)]
 pub struct TwirpClient {
@@ -180,7 +186,7 @@ impl TwirpClient {
         method: &str,
         data: D,
         headers: HeaderMap,
-    ) -> TwirpResult<R> {
+    ) -> ServerResult<R> {
         self.request_with_timeout(service, method, data, headers, self.request_timeout).await
     }
 
@@ -193,7 +199,7 @@ impl TwirpClient {
         data: D,
         mut headers: HeaderMap,
         timeout: Duration,
-    ) -> TwirpResult<R> {
+    ) -> ServerResult<R> {
         let original = Url::parse(&self.host)?;
         let path = format!("{}/{}.{}/{}", self.prefix, self.pkg, service, method);
         headers.insert(USER_AGENT, HeaderValue::from_static(USER_AGENT_VALUE));
@@ -239,8 +245,8 @@ impl TwirpClient {
                     };
                     // No fallback: surface the server's error (needs the body).
                     let Some(next) = next else {
-                        let err: TwirpErrorCode = resp.json().await?;
-                        return Err(TwirpError::Twirp(err));
+                        let err: ServerErrorCode = resp.json().await?;
+                        return Err(ServerError::Response(err));
                     };
                     drop(resp); // release the connection before backing off
                     (next, format!("status {status}"))

--- a/livekit-api/src/services/twirp_client.rs
+++ b/livekit-api/src/services/twirp_client.rs
@@ -15,7 +15,7 @@
 use std::{fmt::Display, time::Duration};
 
 use http::{
-    header::{HeaderMap, HeaderValue, CONTENT_TYPE},
+    header::{HeaderMap, HeaderValue, CONTENT_TYPE, USER_AGENT},
     StatusCode,
 };
 use serde::Deserialize;
@@ -27,15 +27,43 @@ use crate::http_client;
 
 pub const DEFAULT_PREFIX: &str = "/twirp";
 
+/// Identifies the SDK and version to the server on every request.
+const USER_AGENT_VALUE: &str = concat!("livekit-server-sdk-rust/", env!("CARGO_PKG_VERSION"));
+
+/// LiveKit URLs are commonly `wss://` (or `ws://`); the server APIs are Twirp
+/// over HTTP, so the scheme is normalized to `https://` (or `http://`).
+fn normalize_host(host: &str) -> String {
+    if let Some(rest) = host.strip_prefix("wss://") {
+        format!("https://{rest}")
+    } else if let Some(rest) = host.strip_prefix("ws://") {
+        format!("http://{rest}")
+    } else {
+        host.to_owned()
+    }
+}
+
+#[cfg(test)]
+mod normalize_host_tests {
+    use super::normalize_host;
+
+    #[test]
+    fn normalizes_ws_schemes() {
+        assert_eq!(normalize_host("wss://my.livekit.cloud"), "https://my.livekit.cloud");
+        assert_eq!(normalize_host("ws://localhost:7880"), "http://localhost:7880");
+        assert_eq!(normalize_host("https://my.livekit.cloud"), "https://my.livekit.cloud");
+        assert_eq!(normalize_host("http://localhost:7880"), "http://localhost:7880");
+    }
+}
+
 #[derive(Debug, Error)]
-pub enum TwirpError {
+pub enum ServerError {
     #[cfg(feature = "services-tokio")]
     #[error("failed to execute the request: {0}")]
     Request(#[from] reqwest::Error),
     #[cfg(feature = "services-async")]
     #[error("failed to execute the request: {0}")]
     Request(#[from] std::io::Error),
-    #[error("twirp error: {0}")]
+    #[error("server error: {0}")]
     Twirp(TwirpErrorCode),
     #[error("url error: {0}")]
     Url(#[from] url::ParseError),
@@ -43,10 +71,17 @@ pub enum TwirpError {
     Prost(#[from] prost::DecodeError),
 }
 
+/// Deprecated alias for [`ServerError`], kept for backwards compatibility.
+pub type TwirpError = ServerError;
+
 #[derive(Debug, Deserialize)]
 pub struct TwirpErrorCode {
     pub code: String,
     pub msg: String,
+    /// Extra key/value context the server attached (e.g. SIP status). Absent on
+    /// most errors.
+    #[serde(default)]
+    pub meta: std::collections::HashMap<String, String>,
 }
 
 impl TwirpErrorCode {
@@ -86,18 +121,30 @@ pub struct TwirpClient {
     client: http_client::Client,
     failover: FailoverConfig,
     request_timeout: Duration,
+    // Headers added to every request; used by tests to inject mock directives
+    // since the public service methods don't expose per-call headers.
+    #[cfg(test)]
+    default_headers: HeaderMap,
 }
 
 impl TwirpClient {
     pub fn new(host: &str, pkg: &str, prefix: Option<&str>) -> Self {
         Self {
-            host: host.to_owned(),
+            host: normalize_host(host),
             pkg: pkg.to_owned(),
             prefix: prefix.unwrap_or(DEFAULT_PREFIX).to_owned(),
             client: http_client::Client::new(),
             failover: FailoverConfig::default(),
             request_timeout: failover::DEFAULT_REQUEST_TIMEOUT,
+            #[cfg(test)]
+            default_headers: HeaderMap::new(),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_default_headers(mut self, headers: HeaderMap) -> Self {
+        self.default_headers = headers;
+        self
     }
 
     /// Enables or disables region failover (enabled by default). Failover only
@@ -149,6 +196,11 @@ impl TwirpClient {
     ) -> TwirpResult<R> {
         let original = Url::parse(&self.host)?;
         let path = format!("{}/{}.{}/{}", self.prefix, self.pkg, service, method);
+        headers.insert(USER_AGENT, HeaderValue::from_static(USER_AGENT_VALUE));
+        #[cfg(test)]
+        for (k, v) in &self.default_headers {
+            headers.insert(k.clone(), v.clone());
+        }
         let forward = headers.clone(); // headers for the discovery fetch (no content-type yet)
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/protobuf"));
         let body = data.encode_to_vec();

--- a/livekit-api/src/services/twirp_client.rs
+++ b/livekit-api/src/services/twirp_client.rs
@@ -64,7 +64,7 @@ pub enum ServerError {
     #[error("failed to execute the request: {0}")]
     Request(#[from] std::io::Error),
     #[error("server error: {0}")]
-    Response(ServerErrorCode),
+    Twirp(ServerErrorCode),
     #[error("url error: {0}")]
     Url(#[from] url::ParseError),
     #[error("prost error: {0}")]
@@ -254,7 +254,7 @@ impl TwirpClient {
                     // No fallback: surface the server's error (needs the body).
                     let Some(next) = next else {
                         let err: ServerErrorCode = resp.json().await?;
-                        return Err(ServerError::Response(err));
+                        return Err(ServerError::Twirp(err));
                     };
                     drop(resp); // release the connection before backing off
                     (next, format!("status {status}"))

--- a/livekit-api/src/services/twirp_client.rs
+++ b/livekit-api/src/services/twirp_client.rs
@@ -153,6 +153,14 @@ impl TwirpClient {
         self
     }
 
+    /// Replaces the underlying HTTP client so several service clients can share
+    /// one connection pool (the unified [`LiveKitApi`] uses this).
+    ///
+    /// [`LiveKitApi`]: super::LiveKitApi
+    pub(crate) fn set_http_client(&mut self, client: http_client::Client) {
+        self.client = client;
+    }
+
     /// Enables or disables region failover (enabled by default). Failover only
     /// engages for LiveKit Cloud hosts.
     pub fn with_failover(mut self, enabled: bool) -> Self {

--- a/livekit-api/src/services/twirp_client.rs
+++ b/livekit-api/src/services/twirp_client.rs
@@ -135,11 +135,25 @@ pub struct TwirpClient {
 
 impl TwirpClient {
     pub fn new(host: &str, pkg: &str, prefix: Option<&str>) -> Self {
+        Self::with_client(host, pkg, prefix, http_client::Client::new())
+    }
+
+    /// Like [`new`](Self::new) but reuses an existing HTTP client (and its
+    /// connection pool) instead of creating one — the unified [`LiveKitApi`]
+    /// builds one client and shares it across all its services this way.
+    ///
+    /// [`LiveKitApi`]: super::LiveKitApi
+    pub(crate) fn with_client(
+        host: &str,
+        pkg: &str,
+        prefix: Option<&str>,
+        client: http_client::Client,
+    ) -> Self {
         Self {
             host: normalize_host(host),
             pkg: pkg.to_owned(),
             prefix: prefix.unwrap_or(DEFAULT_PREFIX).to_owned(),
-            client: http_client::Client::new(),
+            client,
             failover: FailoverConfig::default(),
             request_timeout: failover::DEFAULT_REQUEST_TIMEOUT,
             #[cfg(test)]
@@ -151,14 +165,6 @@ impl TwirpClient {
     pub(crate) fn with_default_headers(mut self, headers: HeaderMap) -> Self {
         self.default_headers = headers;
         self
-    }
-
-    /// Replaces the underlying HTTP client so several service clients can share
-    /// one connection pool (the unified [`LiveKitApi`] uses this).
-    ///
-    /// [`LiveKitApi`]: super::LiveKitApi
-    pub(crate) fn set_http_client(&mut self, client: http_client::Client) {
-        self.client = client;
     }
 
     /// Enables or disables region failover (enabled by default). Failover only

--- a/livekit-api/tests/services_async.rs
+++ b/livekit-api/tests/services_async.rs
@@ -1,0 +1,75 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Runtime smoke for the isahc-based `services-async` backend (the non-tokio
+//! server-API client). It drives the full request path — access-token auth,
+//! isahc send, header/status conversion across isahc's vendored `http`, and
+//! protobuf/JSON decode — against the mock LiveKit server (LK_TEST_SERVER_URL,
+//! default http://127.0.0.1:9999). It no-ops when the server is unreachable.
+//!
+//! The in-crate `api_test` suite is tokio-only (it uses `#[tokio::test]` and
+//! reqwest), so this integration test is the async backend's coverage; it runs
+//! on `futures::executor::block_on`, which is runtime-agnostic like isahc.
+#![cfg(all(feature = "services-async", feature = "access-token", not(feature = "services-tokio")))]
+
+use livekit_api::services::room::CreateRoomOptions;
+use livekit_api::services::LiveKitApi;
+
+fn base_url() -> String {
+    std::env::var("LK_TEST_SERVER_URL").unwrap_or_else(|_| "http://127.0.0.1:9999".to_owned())
+}
+
+/// Reachability probe kept separate from the request assertions: a TCP connect
+/// to the mock's authority tells "server offline" (skip, local dev) apart from
+/// "server up but the request failed" (a real regression — must fail the test).
+/// The tokio suite does the same with `skip_if_offline!`.
+fn server_up(base: &str) -> bool {
+    let authority = base.split("://").nth(1).unwrap_or(base).trim_end_matches('/');
+    std::net::TcpStream::connect(authority).is_ok()
+}
+
+#[test]
+fn services_async_smoke() {
+    let base = base_url();
+    if !server_up(&base) {
+        eprintln!("skipping services-async smoke: mock test server not reachable at {base}");
+        return;
+    }
+    // Server is up, so every call below must succeed — no silent skips.
+    futures::executor::block_on(async {
+        let api = LiveKitApi::with_api_key(&base, "devkey", "secret");
+
+        let room = api
+            .room()
+            .create_room(
+                "async-smoke-room",
+                CreateRoomOptions { metadata: "{}".to_owned(), ..Default::default() },
+            )
+            .await
+            .expect("create_room");
+        assert_eq!(room.name, "async-smoke-room");
+
+        api.room().list_rooms(vec!["async-smoke-room".to_owned()]).await.expect("list_rooms");
+        api.sip()
+            .create_sip_inbound_trunk(
+                "inbound".to_owned(),
+                vec!["+15105550100".to_owned()],
+                Default::default(),
+            )
+            .await
+            .expect("create_sip_inbound_trunk");
+        api.egress().list_egress(Default::default()).await.expect("list_egress");
+        api.room().delete_room("async-smoke-room").await.expect("delete_room");
+    });
+}

--- a/livekit-datatrack/Cargo.toml
+++ b/livekit-datatrack/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 
 [dependencies]
 livekit-protocol = { workspace = true }
-livekit-runtime = { workspace = true }
+livekit-runtime = { workspace = true, features = ["tokio"] }
 log = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, default-features = false, features = ["sync"] }

--- a/livekit/Cargo.toml
+++ b/livekit/Cargo.toml
@@ -11,9 +11,9 @@ readme = "README.md"
 # By default ws TLS is not enabled
 default = ["tokio"]
 
-async = ["livekit-api/signal-client-async"]
-tokio = ["livekit-api/signal-client-tokio"]
-dispatcher = ["livekit-api/signal-client-dispatcher"]
+async = ["livekit-api/signal-client-async", "livekit-runtime/async"]
+tokio = ["livekit-api/signal-client-tokio", "livekit-runtime/tokio"]
+dispatcher = ["livekit-api/signal-client-dispatcher", "livekit-runtime/dispatcher"]
 
 # On Wayland, libwebrtc uses GDBus to communicate with the XDG Desktop Portal.
 # GDBus requires a GLib event loop to be running. Enable this feature if you


### PR DESCRIPTION
- simpler constructor for interacting with various services
- ability to be used without api key/token, but with just a secret
- full smoke tests to ensure correct token permissions, request encoding
- added missing SIP APIs, achieves parity with other SDKs
