### PR TITLE
fix: don't log expected publisher data channel close as unexpected

### DIFF
--- a/.changeset/fix_publisher_dc_closed_unexpectedly.md
+++ b/.changeset/fix_publisher_dc_closed_unexpectedly.md
@@ -1,0 +1,6 @@
+---
+livekit: patch
+livekit-ffi: patch
+---
+
+Don't log an expected publisher data channel close as unexpected - #1224 (@longcw)

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -413,6 +413,9 @@ struct SessionInner {
     dt_packet_tx: DataTrackSendQueue,
 
     closed: AtomicBool,
+    // Set on a terminal disconnect (server `Leave{Disconnect}`) so the publisher
+    // data-channel close it triggers isn't logged as unexpected
+    disconnecting: AtomicBool,
     emitter: SessionEmitter,
 
     options: EngineOptions,
@@ -617,6 +620,7 @@ impl RtcSession {
             sub_data_track_dc: Mutex::new(None),
             dt_packet_tx,
             closed: Default::default(),
+            disconnecting: Default::default(),
             emitter,
             options,
             negotiation_debouncer: Default::default(),
@@ -642,7 +646,10 @@ impl RtcSession {
                 let Some(inner) = weak_inner.upgrade() else {
                     return;
                 };
-                if !inner.closed.load(Ordering::Acquire) && inner.publisher_pc.is_connected() {
+                if !inner.closed.load(Ordering::Acquire)
+                    && !inner.disconnecting.load(Ordering::Acquire)
+                    && inner.publisher_pc.is_connected()
+                {
                     log::error!("publisher data channel '{}' closed unexpectedly", label);
                 }
             })));
@@ -1876,6 +1883,11 @@ impl SessionInner {
         action: proto::leave_request::Action,
         retry_now: bool,
     ) {
+        // A terminal disconnect (e.g. room deleted) closes the publisher data channels
+        // from the remote side; flag it so that close isn't logged as unexpected
+        if action == proto::leave_request::Action::Disconnect {
+            self.disconnecting.store(true, Ordering::Release);
+        }
         let _ = self.emitter.send(SessionEvent::Close {
             source: source.to_owned(),
             reason,


### PR DESCRIPTION
Fixes the spurious ERROR logs reported in livekit/agents#6250.

When the server tears a session down (e.g. the room is deleted) it closes the publisher data channels from the remote side before the engine sets its `closed` flag, so the close was logged at ERROR as "publisher data channel closed unexpectedly" even though it was expected.

This records the terminal disconnect (server `Leave{Disconnect}`) so the close it triggers isn't logged as unexpected. Genuine unexpected closes (e.g. an oversized message silently killing the channel) still log, and Resume/Reconnect are unaffected.