### PR TITLE
Fixes issue #1154 by forward-declaring PeerContext as struct

### DIFF
--- a/.changeset/fix-peercontext-forward-declaration.md
+++ b/.changeset/fix-peercontext-forward-declaration.md
@@ -1,0 +1,5 @@
+---
+webrtc-sys: patch
+---
+
+Fix `PeerContext` forward-declaration in `jsep.h` from `class` to `struct` to match the cxx bridge definition, resolving LNK2019 linker errors on windows-msvc - #1154

--- a/webrtc-sys/include/livekit/jsep.h
+++ b/webrtc-sys/include/livekit/jsep.h
@@ -35,7 +35,7 @@ class SessionDescription;
 
 namespace livekit_ffi {
 
-class PeerContext;
+struct PeerContext;
 
 class IceCandidate {
  public:


### PR DESCRIPTION
### Description
This PR changes the forward declaration of `PeerContext` from a `class` to a `struct` in `jsep.h` to match how the type is generated by the `cxx` crate on the Rust side. 

This resolves the name-mangling mismatch that causes 4x `LNK2019` unresolved external symbol errors on stricter MSVC toolchains on Windows.

Fixes #1154 

### Notes
Re-submitting this clean fix as the previous PR (#1167) was abandoned last month without a CLA signature. Verified locally that this compiles and passes all unit tests for `webrtc-sys`.

