### PR TITLE
Sxian/clt 3110/add compression to the url for single pc

### DIFF
--- a/.changeset/compress-initial-offer-in-url.md
+++ b/.changeset/compress-initial-offer-in-url.md
@@ -1,0 +1,7 @@
+---
+"livekit-api": patch
+---
+
+Compress initial offer in URL for single PC mode
+
+Apply compression to the initial offer when sending it in the JoinRequest URL, reducing URL size and improving connection performance on slow networks.

--- a/livekit-api/src/signal_client/mod.rs
+++ b/livekit-api/src/signal_client/mod.rs
@@ -796,20 +796,23 @@ fn create_join_request_param(
     // Serialize JoinRequest to bytes
     let join_request_bytes = join_request.encode_to_vec();
 
-    // Use gzip compression when publisher offer is included (SDP makes payload large)
-    let (compressed_bytes, compression) = if publisher_offer.is_some() {
+    // Always use gzip compression to reduce URL size on poor networks
+    let (compressed_bytes, compression) = {
         let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
         if encoder.write_all(&join_request_bytes).is_ok() {
             if let Ok(compressed) = encoder.finish() {
-                (compressed, proto::wrapped_join_request::Compression::Gzip as i32)
+                // Only use compressed version if it's actually smaller
+                if compressed.len() < join_request_bytes.len() {
+                    (compressed, proto::wrapped_join_request::Compression::Gzip as i32)
+                } else {
+                    (join_request_bytes, proto::wrapped_join_request::Compression::None as i32)
+                }
             } else {
                 (join_request_bytes, proto::wrapped_join_request::Compression::None as i32)
             }
         } else {
             (join_request_bytes, proto::wrapped_join_request::Compression::None as i32)
         }
-    } else {
-        (join_request_bytes, proto::wrapped_join_request::Compression::None as i32)
     };
 
     let wrapped_join_request =


### PR DESCRIPTION
Summary

  - Always attempt gzip compression for JoinRequest URL parameter, not just when publisher offer is present
  - Only use compressed version if it's actually smaller than the original

  Details

  Previously, gzip compression was only applied to the JoinRequest when a publisher offer was included (since SDP makes the payload large). This change attempts compression for all JoinRequests, which can reduce URL size on poor networks even without a publisher offer.

  The change also adds a size check to ensure we only use the compressed version if it actually results in a smaller payload, avoiding the edge case where compression overhead exceeds the savings on small payloads.

  Test plan

  - Verify connection works with and without publisher offer
  - Verify compressed URL is used when beneficial
  - Test on poor network conditions
