### PR TITLE
enable zero playout delay mode

### DIFF
--- a/.changeset/zero-playout-subscriber.md
+++ b/.changeset/zero-playout-subscriber.md
@@ -1,0 +1,7 @@
+---
+webrtc-sys: patch
+libwebrtc: patch
+livekit: patch
+---
+
+Add an opt-in zero-playout-delay mode for native video subscribers, expose it through the `local_video` subscriber's `--low-latency` flag, and isolate subscriber diagnostics from frame-driven video rendering.

--- a/examples/local_video/README.md
+++ b/examples/local_video/README.md
@@ -8,7 +8,7 @@ For smoother local rendering, especially above 720p, run the publisher/subscribe
 
 - list_devices: enumerate available cameras and their capabilities
 - publisher: capture from a selected camera and publish a video track
-- subscriber: connect to a room, subscribe to video tracks, and display in a window
+- subscriber: connect to a room, display video in a dedicated window, and show status and timing in a separate diagnostics window
 - clock: render a high-contrast wall-clock with three millisecond digits and a millisecond grid
 
 LiveKit connection can be provided via flags or environment variables:
@@ -157,11 +157,17 @@ Subscriber usage:
    --identity viewer-1 \
    --participant alice
 
- # display timestamp overlay (requires publisher to use --attach-timestamp)
+ # display detailed timing in the diagnostics window (requires publisher to use --attach-timestamp)
  cargo run -p local_video -F desktop --bin subscriber -- \
    --room-name demo \
    --identity viewer-1 \
    --display-timestamp
+
+ # minimize subscriber playout latency (trades smoothness for immediacy)
+ cargo run -p local_video -F desktop --bin subscriber -- \
+   --room-name demo \
+   --identity viewer-1 \
+   --low-latency
 
  # subscribe with end-to-end encryption (must match publisher's key)
  cargo run -p local_video -F desktop --bin subscriber -- \
@@ -172,13 +178,14 @@ Subscriber usage:
 
 Subscriber flags (in addition to the common connection flags above):
 - `--participant <identity>`: Only subscribe to video tracks from the specified participant.
-- `--display-timestamp`: Show a top-left overlay with frame ID, the publisher's timestamp, the subscriber's current time, and the computed end-to-end latency. Timestamp fields require the publisher to use `--attach-timestamp`; frame ID requires `--attach-frame-id`.
+- `--low-latency`: Force zero video playout delay so received frames render as soon as possible. This can increase visible stutter when packets arrive late or out of order.
+- `--display-timestamp`: Show detailed frame ID, publisher timestamp, subscriber timing stages, and end-to-end latency in the separate diagnostics window. Timestamp fields require the publisher to use `--attach-timestamp`; frame ID requires `--attach-frame-id`.
 - `--e2ee-key <key>`: Enable end-to-end decryption with the given shared key. Must match the key used by the publisher.
 
 Notes:
 - If the active video track is unsubscribed or unpublished, the app clears its state and will automatically attach to the next matching video track when it appears.
 - For E2EE to work, both publisher and subscriber must specify the same `--e2ee-key` value. If the keys don't match, the subscriber will not be able to decode the video.
-- The timestamp overlay updates at ~2 Hz so the latency value is readable rather than flickering every frame.
+- The subscriber's video window repaints only when a frame arrives. Its separate diagnostics window updates at 10 Hz so status, timing text, channel graphs, and controls cannot pace video rendering; closing diagnostics leaves video rendering active.
 - On Jetson, `--source argus` requires the Jetson Multimedia API headers under `/usr/src/jetson_multimedia_api`. It publishes NV12 DMA buffers through the Jetson hardware encoder; local publisher preview and burned timestamps are not supported on that path.
 - Jetson AV1 hardware encoding requires an Orin-class device (e.g. Orin NX or AGX Orin on JetPack 5+); the encoder is probed at startup and on devices without AV1 support (e.g. Xavier) `--codec av1` automatically falls back to the software libaom encoder. The Jetson AV1 encoder produces a single L1T1 stream (no SVC).
 - On Linux, preview windows use the Vulkan `wgpu` backend by default to avoid GLES/EGL conflicts on Jetson desktops. Set `WGPU_BACKEND=gl` or another supported `wgpu` backend to override this.

--- a/examples/local_video/src/subscriber.rs
+++ b/examples/local_video/src/subscriber.rs
@@ -419,6 +419,9 @@ struct Args {
 }
 
 struct SharedYuv {
+    room_name: String,
+    self_identity: String,
+    remote_identity: Option<String>,
     width: u32,
     height: u32,
     codec: String,
@@ -835,6 +838,9 @@ mod tests {
     #[test]
     fn subscriber_diagnostics_show_status_without_timing() {
         let shared = Arc::new(Mutex::new(SharedYuv {
+            room_name: "video-room".to_string(),
+            self_identity: "viewer".to_string(),
+            remote_identity: Some("publisher".to_string()),
             width: 1280,
             height: 720,
             codec: "H264".to_string(),
@@ -846,10 +852,17 @@ mod tests {
             Arc::new(Mutex::new(SimulcastState { available: true, ..Default::default() }));
         let subscriber_timing = SubscriberTimingHandle::new();
 
-        let lines = subscriber_diagnostics_lines(&shared, &simulcast, false, &subscriber_timing)
-            .expect("diagnostics should render");
+        let lines = subscriber_diagnostics_lines(&shared, &simulcast, false, &subscriber_timing);
 
-        assert_eq!(lines, vec!["1280x720 29.6fps H264 NVDEC 1.2mbps Simulcast"]);
+        assert_eq!(
+            lines,
+            vec![
+                "Room: video-room",
+                "Self Identity: viewer",
+                "Remote Identity: publisher",
+                "1280x720 29.6fps H264 NVDEC 1.2mbps Simulcast",
+            ]
+        );
     }
 }
 
@@ -915,6 +928,7 @@ async fn handle_track_subscribed(
     {
         let mut s = shared.lock();
         s.codec = codec;
+        s.remote_identity = Some(participant.identity().to_string());
     }
 
     let mut timing_events = video_track.subscribe_timing_events();
@@ -1113,6 +1127,7 @@ fn clear_hud_and_simulcast(
         s.codec_implementation.clear();
         s.bitrate_mbps = None;
         s.fps = 0.0;
+        s.remote_identity = None;
     }
     frame_slot.clear();
     channel_history.lock().clear();
@@ -1127,33 +1142,43 @@ fn subscriber_diagnostics_lines(
     simulcast: &Arc<Mutex<SimulcastState>>,
     include_timing: bool,
     subscriber_timing: &SubscriberTimingHandle,
-) -> Option<Vec<String>> {
-    let status_line = {
+) -> Vec<String> {
+    let (mut lines, status_line) = {
         let s = shared.lock();
-        if s.width == 0 || s.height == 0 {
-            return None;
-        }
-
-        let simulcast_enabled = simulcast.lock().available;
-        video_status_line(
-            s.width,
-            s.height,
-            s.fps,
-            &s.codec,
-            &s.codec_implementation,
-            s.bitrate_mbps,
-            simulcast_enabled,
-        )
+        let lines = vec![
+            format!("Room: {}", s.room_name),
+            format!("Self Identity: {}", s.self_identity),
+            format!("Remote Identity: {}", s.remote_identity.as_deref().unwrap_or("--")),
+        ];
+        let status_line = (s.width != 0 && s.height != 0).then(|| {
+            let simulcast_enabled = simulcast.lock().available;
+            video_status_line(
+                s.width,
+                s.height,
+                s.fps,
+                &s.codec,
+                &s.codec_implementation,
+                s.bitrate_mbps,
+                simulcast_enabled,
+            )
+        });
+        (lines, status_line)
     };
 
-    let mut lines = vec![status_line];
-    if include_timing {
+    let has_video = status_line.is_some();
+    if let Some(status_line) = status_line {
+        lines.push(status_line);
+    } else {
+        lines.push("Waiting for video...".to_string());
+    }
+
+    if has_video && include_timing {
         if let Some(mut timing_lines) = subscriber_timing.display_overlay_lines(Instant::now()) {
             lines.append(&mut timing_lines);
         }
     }
 
-    Some(lines)
+    lines
 }
 
 /// Render a live line graph of the six decoded channel values.
@@ -1263,26 +1288,35 @@ fn paint_subscriber_diagnostics(
     subscriber_timing: &SubscriberTimingHandle,
     channel_history: &VecDeque<[f32; user_data::NUM_CHANNELS]>,
 ) {
-    egui::ScrollArea::vertical().show(ui, |ui| {
-        ui.heading("Subscriber Diagnostics");
-        match subscriber_diagnostics_lines(shared, simulcast, include_timing, subscriber_timing) {
-            Some(lines) => {
-                ui.add(
-                    egui::Label::new(egui::RichText::new(lines.join("\n")).monospace().size(12.0))
-                        .extend(),
+    egui::Frame::NONE.inner_margin(egui::Margin::same(DIAGNOSTICS_CONTENT_PADDING)).show(
+        ui,
+        |ui| {
+            ui.visuals_mut().override_text_color = Some(egui::Color32::WHITE);
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                let lines = subscriber_diagnostics_lines(
+                    shared,
+                    simulcast,
+                    include_timing,
+                    subscriber_timing,
                 );
-            }
-            None => {
-                ui.label("Waiting for video...");
-            }
-        }
+                ui.add(
+                    egui::Label::new(
+                        egui::RichText::new(lines.join("\n"))
+                            .monospace()
+                            .size(12.0)
+                            .color(egui::Color32::WHITE),
+                    )
+                    .extend(),
+                );
 
-        if !channel_history.is_empty() {
-            ui.separator();
-            paint_channel_graph(ui, channel_history);
-        }
-        paint_simulcast_controls(ui, simulcast);
-    });
+                if !channel_history.is_empty() {
+                    ui.separator();
+                    paint_channel_graph(ui, channel_history);
+                }
+                paint_simulcast_controls(ui, simulcast);
+            });
+        },
+    );
 }
 
 fn handle_track_unsubscribed(
@@ -1341,6 +1375,9 @@ fn handle_track_unpublished(
 const CHANNEL_HISTORY_LEN: usize = 300;
 /// Diagnostics are intentionally slower than video rendering so UI work cannot pace video frames.
 const DIAGNOSTICS_REPAINT_INTERVAL: Duration = Duration::from_millis(100);
+const DIAGNOSTICS_CONTENT_PADDING: i8 = 10;
+const DIAGNOSTICS_WINDOW_SIZE: [f32; 2] = [400.0, 272.0];
+const DIAGNOSTICS_WINDOW_MIN_SIZE: [f32; 2] = [320.0, 120.0];
 
 fn diagnostics_viewport_id() -> egui::ViewportId {
     egui::ViewportId::from_hash_of("subscriber-diagnostics")
@@ -1390,8 +1427,8 @@ impl VideoApp {
             diagnostics_viewport_id(),
             egui::ViewportBuilder::default()
                 .with_title("LiveKit Subscriber Diagnostics")
-                .with_inner_size([560.0, 620.0])
-                .with_min_inner_size([360.0, 240.0]),
+                .with_inner_size(DIAGNOSTICS_WINDOW_SIZE)
+                .with_min_inner_size(DIAGNOSTICS_WINDOW_MIN_SIZE),
             move |ui, viewport_class| {
                 if !diagnostics_started.swap(true, Ordering::AcqRel) {
                     let viewport_class = match viewport_class {
@@ -1557,6 +1594,9 @@ async fn run(args: Args, ctrl_c_received: Arc<AtomicBool>) -> Result<()> {
 
     // Shared YUV buffer for UI/GPU
     let shared = Arc::new(Mutex::new(SharedYuv {
+        room_name: args.room_name.clone(),
+        self_identity: args.identity.clone(),
+        remote_identity: None,
         width: 0,
         height: 0,
         codec: String::new(),

--- a/examples/local_video/src/subscriber.rs
+++ b/examples/local_video/src/subscriber.rs
@@ -405,7 +405,11 @@ struct Args {
     #[arg(long)]
     participant: Option<String>,
 
-    /// Display frame timing and stats over the rendered video
+    /// Render received video as soon as possible, trading smoothness for lower latency
+    #[arg(long)]
+    low_latency: bool,
+
+    /// Display detailed frame timing in the separate diagnostics window
     #[arg(long)]
     display_timestamp: bool,
 
@@ -819,7 +823,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn subscriber_overlay_shows_status_without_timing() {
+    fn low_latency_flag_defaults_off_and_parses_on() {
+        let default_args = Args::try_parse_from(["subscriber"]).expect("default args should parse");
+        assert!(!default_args.low_latency);
+
+        let low_latency_args =
+            Args::try_parse_from(["subscriber", "--low-latency"]).expect("flag should parse");
+        assert!(low_latency_args.low_latency);
+    }
+
+    #[test]
+    fn subscriber_diagnostics_show_status_without_timing() {
         let shared = Arc::new(Mutex::new(SharedYuv {
             width: 1280,
             height: 720,
@@ -832,8 +846,8 @@ mod tests {
             Arc::new(Mutex::new(SimulcastState { available: true, ..Default::default() }));
         let subscriber_timing = SubscriberTimingHandle::new();
 
-        let lines = subscriber_overlay_lines(&shared, &simulcast, false, &subscriber_timing)
-            .expect("overlay should render");
+        let lines = subscriber_diagnostics_lines(&shared, &simulcast, false, &subscriber_timing)
+            .expect("diagnostics should render");
 
         assert_eq!(lines, vec!["1280x720 29.6fps H264 NVDEC 1.2mbps Simulcast"]);
     }
@@ -850,6 +864,7 @@ async fn handle_track_subscribed(
     active_sid: &Arc<Mutex<Option<TrackSid>>>,
     ctrl_c_received: &Arc<AtomicBool>,
     simulcast: &Arc<Mutex<SimulcastState>>,
+    channel_history: &Arc<Mutex<VecDeque<[f32; user_data::NUM_CHANNELS]>>>,
     repaint_ctx: &Arc<OnceLock<egui::Context>>,
     subscriber_timing: SubscriberTimingHandle,
 ) {
@@ -920,6 +935,7 @@ async fn handle_track_subscribed(
     let ctrl_c_sink = ctrl_c_received.clone();
     let repaint_ctx_sink = repaint_ctx.clone();
     let subscriber_timing_sink = subscriber_timing.clone();
+    let channel_history_sink = channel_history.clone();
     // Initialize simulcast state for this publication
     {
         let mut sc = simulcast.lock();
@@ -960,6 +976,11 @@ async fn handle_track_subscribed(
                     );
                 }
             }
+            let channel_values = frame
+                .frame_metadata
+                .as_ref()
+                .and_then(|metadata| metadata.user_data.as_deref())
+                .and_then(user_data::decode);
             let w = frame.buffer.width();
             let h = frame.buffer.height();
 
@@ -995,7 +1016,15 @@ async fn handle_track_subscribed(
             frame_slot_sink.store(frame);
 
             if let Some(ctx) = repaint_ctx_sink.get() {
-                ctx.request_repaint();
+                ctx.request_repaint_of(egui::ViewportId::ROOT);
+            }
+
+            if let Some(values) = channel_values {
+                let mut history = channel_history_sink.lock();
+                if history.len() >= CHANNEL_HISTORY_LEN {
+                    history.pop_front();
+                }
+                history.push_back(values);
             }
 
             frames += 1;
@@ -1073,6 +1102,7 @@ fn clear_hud_and_simulcast(
     frame_slot: &Arc<LatestRenderFrameSlot>,
     video_size: &Arc<AtomicVideoSize>,
     simulcast: &Arc<Mutex<SimulcastState>>,
+    channel_history: &Arc<Mutex<VecDeque<[f32; user_data::NUM_CHANNELS]>>>,
     subscriber_timing: &SubscriberTimingHandle,
 ) {
     {
@@ -1085,13 +1115,14 @@ fn clear_hud_and_simulcast(
         s.fps = 0.0;
     }
     frame_slot.clear();
+    channel_history.lock().clear();
     subscriber_timing.reset();
     video_size.clear();
     let mut sc = simulcast.lock();
     *sc = SimulcastState::default();
 }
 
-fn subscriber_overlay_lines(
+fn subscriber_diagnostics_lines(
     shared: &Arc<Mutex<SharedYuv>>,
     simulcast: &Arc<Mutex<SimulcastState>>,
     include_timing: bool,
@@ -1125,104 +1156,133 @@ fn subscriber_overlay_lines(
     Some(lines)
 }
 
-/// Render a live line graph of the six decoded channel values (top-right overlay).
+/// Render a live line graph of the six decoded channel values.
 /// Each trace is normalized so ±`VALUE_RANGE` spans the plot height.
-fn paint_channel_graph(ctx: &egui::Context, history: &VecDeque<[f32; user_data::NUM_CHANNELS]>) {
-    if history.is_empty() {
+fn paint_channel_graph(ui: &mut egui::Ui, history: &VecDeque<[f32; user_data::NUM_CHANNELS]>) {
+    let Some(latest) = history.back().copied() else {
         return;
-    }
-    let latest = *history.back().unwrap();
+    };
 
-    egui::Area::new("channel_graph".into())
-        .anchor(egui::Align2::RIGHT_TOP, egui::vec2(-10.0, 10.0))
-        .interactable(false)
-        .show(ctx, |ui| {
-            egui::Frame::NONE
-                .fill(egui::Color32::from_black_alpha(180))
-                .corner_radius(egui::CornerRadius::same(4))
-                .inner_margin(egui::Margin::same(8))
-                .show(ui, |ui| {
-                    let plot_size = egui::vec2(360.0, 160.0);
-                    // Pin the panel to the plot width so the legend wraps within it
-                    // instead of stretching the frame wider than the graph.
-                    ui.set_max_width(plot_size.x);
+    egui::Frame::NONE
+        .fill(egui::Color32::from_black_alpha(180))
+        .corner_radius(egui::CornerRadius::same(4))
+        .inner_margin(egui::Margin::same(8))
+        .show(ui, |ui| {
+            let plot_size = egui::vec2(ui.available_width().min(480.0).max(240.0), 160.0);
 
+            ui.label(
+                egui::RichText::new("user_data channels")
+                    .monospace()
+                    .size(12.0)
+                    .color(egui::Color32::WHITE),
+            );
+
+            let (rect, _) = ui.allocate_exact_size(plot_size, egui::Sense::hover());
+            let painter = ui.painter_at(rect);
+
+            painter.hline(
+                rect.x_range(),
+                rect.center().y,
+                egui::Stroke::new(1.0, egui::Color32::from_gray(90)),
+            );
+
+            let n = history.len();
+            let denom = (n.saturating_sub(1)).max(1) as f32;
+            let half_h = rect.height() / 2.0 - 2.0;
+            for j in 0..user_data::NUM_CHANNELS {
+                let points: Vec<egui::Pos2> = history
+                    .iter()
+                    .enumerate()
+                    .map(|(i, sample)| {
+                        let x = rect.left() + (i as f32 / denom) * rect.width();
+                        let norm = (sample[j] / user_data::VALUE_RANGE).clamp(-1.0, 1.0);
+                        let y = rect.center().y - norm * half_h;
+                        egui::pos2(x, y)
+                    })
+                    .collect();
+                painter.add(egui::Shape::line(points, egui::Stroke::new(1.5, CHANNEL_COLORS[j])));
+            }
+
+            ui.horizontal_wrapped(|ui| {
+                for (j, value) in latest.iter().enumerate() {
                     ui.label(
-                        egui::RichText::new("user_data channels")
+                        egui::RichText::new(format!("CH{}: {:>+6.2}", j + 1, value))
                             .monospace()
-                            .size(12.0)
-                            .color(egui::Color32::WHITE),
+                            .size(11.0)
+                            .color(CHANNEL_COLORS[j]),
                     );
-
-                    let (rect, _) = ui.allocate_exact_size(plot_size, egui::Sense::hover());
-                    let painter = ui.painter_at(rect);
-
-                    // Zero axis.
-                    painter.hline(
-                        rect.x_range(),
-                        rect.center().y,
-                        egui::Stroke::new(1.0, egui::Color32::from_gray(90)),
-                    );
-
-                    let n = history.len();
-                    let denom = (n.saturating_sub(1)).max(1) as f32;
-                    let half_h = rect.height() / 2.0 - 2.0;
-                    for j in 0..user_data::NUM_CHANNELS {
-                        let points: Vec<egui::Pos2> = history
-                            .iter()
-                            .enumerate()
-                            .map(|(i, sample)| {
-                                let x = rect.left() + (i as f32 / denom) * rect.width();
-                                let norm = (sample[j] / user_data::VALUE_RANGE).clamp(-1.0, 1.0);
-                                let y = rect.center().y - norm * half_h;
-                                egui::pos2(x, y)
-                            })
-                            .collect();
-                        painter.add(egui::Shape::line(
-                            points,
-                            egui::Stroke::new(1.5, CHANNEL_COLORS[j]),
-                        ));
-                    }
-
-                    // Legend: current value per channel.
-                    ui.horizontal_wrapped(|ui| {
-                        for (j, value) in latest.iter().enumerate() {
-                            ui.label(
-                                egui::RichText::new(format!("CH{}: {:>+6.2}", j + 1, value))
-                                    .monospace()
-                                    .size(11.0)
-                                    .color(CHANNEL_COLORS[j]),
-                            );
-                        }
-                    });
-                });
+                }
+            });
         });
 }
 
-fn paint_subscriber_overlay(ctx: &egui::Context, lines: &[String]) {
-    egui::Area::new("subscriber_overlay".into())
-        .anchor(egui::Align2::LEFT_TOP, egui::vec2(10.0, 10.0))
-        .interactable(false)
-        .show(ctx, |ui| {
-            egui::Frame::NONE
-                .fill(egui::Color32::from_black_alpha(170))
-                .corner_radius(egui::CornerRadius::same(4))
-                .inner_margin(egui::Margin::same(6))
-                .show(ui, |ui| {
-                    if lines.len() > 1 {
-                        ui.set_min_width(subscriber_timing::TIMING_LINE_WIDTH as f32 * 8.0);
-                    }
-                    ui.add(
-                        egui::Label::new(
-                            egui::RichText::new(lines.join("\n"))
-                                .monospace()
-                                .size(12.0)
-                                .color(egui::Color32::WHITE),
-                        )
+fn paint_simulcast_controls(ui: &mut egui::Ui, simulcast: &Arc<Mutex<SimulcastState>>) {
+    let (available, selected, publication) = {
+        let state = simulcast.lock();
+        (
+            state.available,
+            state.requested_quality.or(state.active_quality),
+            state.publication.clone(),
+        )
+    };
+    if !available {
+        return;
+    }
+
+    ui.separator();
+    ui.label("Simulcast layer");
+    let mut requested_quality = None;
+    ui.horizontal(|ui| {
+        let choices = [
+            (livekit::track::VideoQuality::Low, "Low"),
+            (livekit::track::VideoQuality::Medium, "Med"),
+            (livekit::track::VideoQuality::High, "High"),
+        ];
+        for (quality, label) in choices {
+            let response = ui.selectable_label(selected == Some(quality), label);
+            if response.clicked() {
+                requested_quality = Some(quality);
+            }
+        }
+    });
+
+    if let Some(quality) = requested_quality {
+        if let Some(publication) = publication {
+            info!("Requesting simulcast layer: {:?}", quality);
+            publication.set_video_quality(quality);
+            simulcast.lock().requested_quality = Some(quality);
+        }
+    }
+}
+
+fn paint_subscriber_diagnostics(
+    ui: &mut egui::Ui,
+    shared: &Arc<Mutex<SharedYuv>>,
+    simulcast: &Arc<Mutex<SimulcastState>>,
+    include_timing: bool,
+    subscriber_timing: &SubscriberTimingHandle,
+    channel_history: &VecDeque<[f32; user_data::NUM_CHANNELS]>,
+) {
+    egui::ScrollArea::vertical().show(ui, |ui| {
+        ui.heading("Subscriber Diagnostics");
+        match subscriber_diagnostics_lines(shared, simulcast, include_timing, subscriber_timing) {
+            Some(lines) => {
+                ui.add(
+                    egui::Label::new(egui::RichText::new(lines.join("\n")).monospace().size(12.0))
                         .extend(),
-                    );
-                });
-        });
+                );
+            }
+            None => {
+                ui.label("Waiting for video...");
+            }
+        }
+
+        if !channel_history.is_empty() {
+            ui.separator();
+            paint_channel_graph(ui, channel_history);
+        }
+        paint_simulcast_controls(ui, simulcast);
+    });
 }
 
 fn handle_track_unsubscribed(
@@ -1232,6 +1292,7 @@ fn handle_track_unsubscribed(
     video_size: &Arc<AtomicVideoSize>,
     active_sid: &Arc<Mutex<Option<TrackSid>>>,
     simulcast: &Arc<Mutex<SimulcastState>>,
+    channel_history: &Arc<Mutex<VecDeque<[f32; user_data::NUM_CHANNELS]>>>,
     subscriber_timing: &SubscriberTimingHandle,
 ) {
     let sid = publication.sid().clone();
@@ -1240,7 +1301,14 @@ fn handle_track_unsubscribed(
         info!("Video track unsubscribed ({}), clearing active sink", sid);
         *active = None;
     }
-    clear_hud_and_simulcast(shared, frame_slot, video_size, simulcast, subscriber_timing);
+    clear_hud_and_simulcast(
+        shared,
+        frame_slot,
+        video_size,
+        simulcast,
+        channel_history,
+        subscriber_timing,
+    );
 }
 
 fn handle_track_unpublished(
@@ -1250,6 +1318,7 @@ fn handle_track_unpublished(
     video_size: &Arc<AtomicVideoSize>,
     active_sid: &Arc<Mutex<Option<TrackSid>>>,
     simulcast: &Arc<Mutex<SimulcastState>>,
+    channel_history: &Arc<Mutex<VecDeque<[f32; user_data::NUM_CHANNELS]>>>,
     subscriber_timing: &SubscriberTimingHandle,
 ) {
     let sid = publication.sid().clone();
@@ -1258,11 +1327,24 @@ fn handle_track_unpublished(
         info!("Video track unpublished ({}), clearing active sink", sid);
         *active = None;
     }
-    clear_hud_and_simulcast(shared, frame_slot, video_size, simulcast, subscriber_timing);
+    clear_hud_and_simulcast(
+        shared,
+        frame_slot,
+        video_size,
+        simulcast,
+        channel_history,
+        subscriber_timing,
+    );
 }
 
 /// Number of channel samples retained for the live graph (~10s at 30fps).
 const CHANNEL_HISTORY_LEN: usize = 300;
+/// Diagnostics are intentionally slower than video rendering so UI work cannot pace video frames.
+const DIAGNOSTICS_REPAINT_INTERVAL: Duration = Duration::from_millis(100);
+
+fn diagnostics_viewport_id() -> egui::ViewportId {
+    egui::ViewportId::from_hash_of("subscriber-diagnostics")
+}
 
 /// Distinct colors for the six channel traces.
 const CHANNEL_COLORS: [egui::Color32; user_data::NUM_CHANNELS] = [
@@ -1285,7 +1367,65 @@ struct VideoApp {
     viewport: AspectConstrainedViewport,
     display_timestamp: bool,
     /// Rolling history of decoded channel values from the user_data trailer.
-    channel_history: VecDeque<[f32; user_data::NUM_CHANNELS]>,
+    channel_history: Arc<Mutex<VecDeque<[f32; user_data::NUM_CHANNELS]>>>,
+    diagnostics_open: Arc<AtomicBool>,
+    diagnostics_started: Arc<AtomicBool>,
+}
+
+impl VideoApp {
+    fn show_diagnostics_window(&self, ctx: &egui::Context) {
+        if !self.diagnostics_open.load(Ordering::Acquire) {
+            return;
+        }
+
+        let shared = self.shared.clone();
+        let simulcast = self.simulcast.clone();
+        let subscriber_timing = self.subscriber_timing.clone();
+        let channel_history = self.channel_history.clone();
+        let diagnostics_open = self.diagnostics_open.clone();
+        let diagnostics_started = self.diagnostics_started.clone();
+        let include_timing = self.display_timestamp;
+
+        ctx.show_viewport_deferred(
+            diagnostics_viewport_id(),
+            egui::ViewportBuilder::default()
+                .with_title("LiveKit Subscriber Diagnostics")
+                .with_inner_size([560.0, 620.0])
+                .with_min_inner_size([360.0, 240.0]),
+            move |ui, viewport_class| {
+                if !diagnostics_started.swap(true, Ordering::AcqRel) {
+                    let viewport_class = match viewport_class {
+                        egui::ViewportClass::Root => "root",
+                        egui::ViewportClass::Deferred => "deferred",
+                        egui::ViewportClass::Immediate => "immediate",
+                        egui::ViewportClass::EmbeddedWindow => "embedded",
+                    };
+                    info!(
+                        "Subscriber diagnostics window active: {}, refresh={}ms",
+                        viewport_class,
+                        DIAGNOSTICS_REPAINT_INTERVAL.as_millis()
+                    );
+                }
+                if ui.input(|input| input.viewport().close_requested()) {
+                    diagnostics_open.store(false, Ordering::Release);
+                    info!("Subscriber diagnostics window closed; video rendering remains active");
+                    ui.ctx().request_repaint_of(egui::ViewportId::ROOT);
+                    return;
+                }
+
+                let channel_history = channel_history.lock().clone();
+                paint_subscriber_diagnostics(
+                    ui,
+                    &shared,
+                    &simulcast,
+                    include_timing,
+                    &subscriber_timing,
+                    &channel_history,
+                );
+                ui.ctx().request_repaint_after(DIAGNOSTICS_REPAINT_INTERVAL);
+            },
+        );
+    }
 }
 
 impl eframe::App for VideoApp {
@@ -1311,26 +1451,10 @@ impl eframe::App for VideoApp {
                         current_timestamp_us(),
                     );
                 }
-                // Decode the 6 user_data channel values for the live graph.
-                if let Some(values) = metadata.user_data.as_deref().and_then(user_data::decode) {
-                    if self.channel_history.len() >= CHANNEL_HISTORY_LEN {
-                        self.channel_history.pop_front();
-                    }
-                    self.channel_history.push_back(values);
-                }
             }
         }
 
-        let overlay_lines = subscriber_overlay_lines(
-            &self.shared,
-            &self.simulcast,
-            self.display_timestamp,
-            &self.subscriber_timing,
-        );
-
         egui::CentralPanel::default().frame(egui::Frame::NONE).show(root_ui, |ui| {
-            ui.ctx().request_repaint();
-
             // Let the native window follow live resize, and letterbox the video instead of
             // programmatically resizing the window while the user is dragging it.
             let size =
@@ -1352,44 +1476,7 @@ impl eframe::App for VideoApp {
                 },
             );
         });
-
-        if let Some(lines) = overlay_lines.as_ref() {
-            paint_subscriber_overlay(&ctx, lines);
-        }
-
-        paint_channel_graph(&ctx, &self.channel_history);
-
-        // Simulcast layer controls: bottom-left overlay
-        egui::Area::new("simulcast_controls".into())
-            .anchor(egui::Align2::LEFT_BOTTOM, egui::vec2(10.0, -10.0))
-            .interactable(true)
-            .show(&ctx, |ui| {
-                let mut sc = self.simulcast.lock();
-                if !sc.available {
-                    return;
-                }
-                let selected = sc.requested_quality.or(sc.active_quality);
-                ui.horizontal(|ui| {
-                    let choices = [
-                        (livekit::track::VideoQuality::Low, "Low"),
-                        (livekit::track::VideoQuality::Medium, "Med"),
-                        (livekit::track::VideoQuality::High, "High"),
-                    ];
-                    for (q, label) in choices {
-                        let is_selected = selected.is_some_and(|s| s == q);
-                        let resp = ui.selectable_label(is_selected, label);
-                        if resp.clicked() {
-                            if let Some(ref pub_remote) = sc.publication {
-                                info!("Requesting layer: {:?}", q);
-                                pub_remote.set_video_quality(q);
-                                sc.requested_quality = Some(q);
-                            }
-                        }
-                    }
-                });
-            });
-
-        ctx.request_repaint_after(viewport_aspect::VIDEO_REPAINT_INTERVAL);
+        self.show_diagnostics_window(&ctx);
     }
 }
 
@@ -1412,6 +1499,11 @@ async fn main() -> Result<()> {
 }
 
 async fn run(args: Args, ctrl_c_received: Arc<AtomicBool>) -> Result<()> {
+    if args.low_latency {
+        livekit::webrtc::enable_zero_playout_delay()?;
+        info!("Low-latency mode enabled: WebRTC-ForcePlayoutDelay/min_ms:0,max_ms:0/");
+    }
+
     // LiveKit connection details (prefer CLI args, fallback to env vars)
     let url = args.url.or_else(|| env::var("LIVEKIT_URL").ok()).expect(
         "LiveKit URL must be provided via --url argument or LIVEKIT_URL environment variable",
@@ -1475,6 +1567,7 @@ async fn run(args: Args, ctrl_c_received: Arc<AtomicBool>) -> Result<()> {
     let frame_slot = Arc::new(LatestRenderFrameSlot::new());
     let video_size = Arc::new(AtomicVideoSize::default());
     let subscriber_timing = SubscriberTimingHandle::new();
+    let channel_history = Arc::new(Mutex::new(VecDeque::with_capacity(CHANNEL_HISTORY_LEN)));
 
     // Subscribe to room events: on first video track, start sink task
     let allowed_identity = args.participant.clone();
@@ -1487,6 +1580,7 @@ async fn run(args: Args, ctrl_c_received: Arc<AtomicBool>) -> Result<()> {
     let simulcast = Arc::new(Mutex::new(SimulcastState::default()));
     let repaint_ctx = Arc::new(OnceLock::new());
     let simulcast_events = simulcast.clone();
+    let channel_history_events = channel_history.clone();
     let repaint_ctx_events = repaint_ctx.clone();
     let ctrl_c_events = ctrl_c_received.clone();
     let subscriber_timing_events = subscriber_timing.clone();
@@ -1510,6 +1604,7 @@ async fn run(args: Args, ctrl_c_received: Arc<AtomicBool>) -> Result<()> {
                         &active_sid,
                         &ctrl_c_events,
                         &simulcast,
+                        &channel_history_events,
                         &repaint_ctx_events,
                         subscriber_timing_events.clone(),
                     )
@@ -1523,6 +1618,7 @@ async fn run(args: Args, ctrl_c_received: Arc<AtomicBool>) -> Result<()> {
                         &video_size_events,
                         &active_sid,
                         &simulcast,
+                        &channel_history_events,
                         &subscriber_timing_events,
                     );
                 }
@@ -1534,6 +1630,7 @@ async fn run(args: Args, ctrl_c_received: Arc<AtomicBool>) -> Result<()> {
                         &video_size_events,
                         &active_sid,
                         &simulcast,
+                        &channel_history_events,
                         &subscriber_timing_events,
                     );
                 }
@@ -1554,7 +1651,9 @@ async fn run(args: Args, ctrl_c_received: Arc<AtomicBool>) -> Result<()> {
         ctrl_c_received: ctrl_c_received.clone(),
         viewport,
         display_timestamp: args.display_timestamp,
-        channel_history: VecDeque::with_capacity(CHANNEL_HISTORY_LEN),
+        channel_history,
+        diagnostics_open: Arc::new(AtomicBool::new(true)),
+        diagnostics_started: Arc::new(AtomicBool::new(false)),
     };
     let native_options = viewport_aspect::native_options(None);
     eframe::run_native(

--- a/examples/local_video/src/subscriber_timing.rs
+++ b/examples/local_video/src/subscriber_timing.rs
@@ -10,13 +10,13 @@ use parking_lot::Mutex;
 
 const MAX_SUBSCRIBER_TIMING_SAMPLES: usize = 300;
 const DISPLAY_UPDATE_INTERVAL: Duration = Duration::from_millis(100);
-pub(crate) const TIMING_LINE_WIDTH: usize =
-    TIMING_LABEL_WIDTH + 1 + TIMING_TIMESTAMP_WIDTH + 1 + TIMING_DELTA_WIDTH;
-
 const TIMING_LABEL_WIDTH: usize = 22;
 const TIMING_TIMESTAMP_WIDTH: usize = 12;
 const TIMING_DELTA_WIDTH: usize = 10;
 const TIMING_VALUE_WIDTH: usize = TIMING_TIMESTAMP_WIDTH + 1 + TIMING_DELTA_WIDTH;
+#[cfg(test)]
+const TIMING_LINE_WIDTH: usize =
+    TIMING_LABEL_WIDTH + 1 + TIMING_TIMESTAMP_WIDTH + 1 + TIMING_DELTA_WIDTH;
 
 #[derive(Clone, Default)]
 pub(crate) struct SubscriberTimingHandle {

--- a/examples/local_video/src/viewport_aspect.rs
+++ b/examples/local_video/src/viewport_aspect.rs
@@ -6,6 +6,7 @@ const DEFAULT_ASPECT: f32 = 16.0 / 9.0;
 const DEFAULT_INITIAL_LONG_EDGE: f32 = 960.0;
 const MIN_LONG_EDGE: f32 = 320.0;
 /// Repaint cadence used while a local video window is visible.
+#[allow(dead_code)] // This shared module is compiled separately by binaries with different pacing.
 pub(crate) const VIDEO_REPAINT_INTERVAL: Duration = Duration::from_millis(8);
 const ASPECT_EPSILON: f32 = 0.001;
 

--- a/libwebrtc/src/native/peer_connection_factory.rs
+++ b/libwebrtc/src/native/peer_connection_factory.rs
@@ -59,6 +59,7 @@ impl Default for PeerConnectionFactory {
 }
 
 impl PeerConnectionFactory {
+    /// Creates a [`PeerConnectionFactory`] with the WebRTC-ForcePlayoutDelay field trial enabled.
     pub fn with_zero_playout_delay() -> Self {
         ensure_log_sink();
         let sys_handle = sys_pcf::ffi::create_peer_connection_factory_with_zero_playout_delay();

--- a/libwebrtc/src/native/peer_connection_factory.rs
+++ b/libwebrtc/src/native/peer_connection_factory.rs
@@ -35,6 +35,16 @@ lazy_static! {
     static ref LOG_SINK: Mutex<Option<UniquePtr<sys_rtc::ffi::LogSink>>> = Default::default();
 }
 
+fn ensure_log_sink() {
+    let mut log_sink = LOG_SINK.lock();
+    if log_sink.is_none() {
+        *log_sink = Some(sys_rtc::ffi::new_log_sink(|msg, _| {
+            let msg = msg.strip_suffix("\r\n").or(msg.strip_suffix('\n')).unwrap_or(&msg);
+            log::debug!(target: "libwebrtc", "{}", msg);
+        }));
+    }
+}
+
 #[derive(Clone)]
 pub struct PeerConnectionFactory {
     pub(crate) sys_handle: SharedPtr<sys_pcf::ffi::PeerConnectionFactory>,
@@ -42,20 +52,24 @@ pub struct PeerConnectionFactory {
 
 impl Default for PeerConnectionFactory {
     fn default() -> Self {
-        let mut log_sink = LOG_SINK.lock();
-        if log_sink.is_none() {
-            *log_sink = Some(sys_rtc::ffi::new_log_sink(|msg, _| {
-                let msg = msg.strip_suffix("\r\n").or(msg.strip_suffix('\n')).unwrap_or(&msg);
-                log::debug!(target: "libwebrtc", "{}", msg);
-            }));
-        }
-
+        ensure_log_sink();
         let sys_handle = sys_pcf::ffi::create_peer_connection_factory();
         Self { sys_handle }
     }
 }
 
 impl PeerConnectionFactory {
+    pub fn with_zero_playout_delay() -> Self {
+        ensure_log_sink();
+        let sys_handle = sys_pcf::ffi::create_peer_connection_factory_with_zero_playout_delay();
+        Self { sys_handle }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn zero_playout_delay_enabled(&self) -> bool {
+        self.sys_handle.zero_playout_delay_enabled()
+    }
+
     pub fn create_peer_connection(
         &self,
         config: RtcConfiguration,

--- a/libwebrtc/src/peer_connection_factory.rs
+++ b/libwebrtc/src/peer_connection_factory.rs
@@ -68,6 +68,12 @@ impl Debug for PeerConnectionFactory {
 }
 
 impl PeerConnectionFactory {
+    /// Creates a native peer connection factory that renders received video as soon as possible.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn with_zero_playout_delay() -> Self {
+        Self { handle: imp_pcf::PeerConnectionFactory::with_zero_playout_delay() }
+    }
+
     pub fn create_peer_connection(
         &self,
         config: RtcConfiguration,
@@ -81,6 +87,21 @@ impl PeerConnectionFactory {
 
     pub fn get_rtp_receiver_capabilities(&self, media_type: MediaType) -> RtpCapabilities {
         self.handle.get_rtp_receiver_capabilities(media_type)
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::PeerConnectionFactory;
+
+    #[test]
+    fn zero_playout_delay_factory_uses_force_playout_delay_field_trial() {
+        let default_factory = PeerConnectionFactory::default();
+        assert!(!default_factory.handle.zero_playout_delay_enabled());
+        drop(default_factory);
+
+        let low_latency_factory = PeerConnectionFactory::with_zero_playout_delay();
+        assert!(low_latency_factory.handle.zero_playout_delay_enabled());
     }
 }
 

--- a/livekit/src/lib.rs
+++ b/livekit/src/lib.rs
@@ -21,6 +21,19 @@ pub mod rtc_engine;
 
 pub mod webrtc {
     pub use libwebrtc::*;
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub use crate::rtc_engine::lk_runtime::WebRtcRuntimeInitializedError;
+
+    /// Enables zero playout delay for native video receivers created by the shared WebRTC runtime.
+    ///
+    /// Call this before [`crate::Room::connect`]. Repeated calls are allowed, but enabling the
+    /// mode after the default WebRTC runtime is active returns
+    /// [`WebRtcRuntimeInitializedError`].
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn enable_zero_playout_delay() -> Result<(), WebRtcRuntimeInitializedError> {
+        crate::rtc_engine::lk_runtime::LkRuntime::enable_zero_playout_delay()
+    }
 }
 
 pub use room::*;

--- a/livekit/src/rtc_engine/lk_runtime.rs
+++ b/livekit/src/rtc_engine/lk_runtime.rs
@@ -20,16 +20,43 @@ use std::{
 use lazy_static::lazy_static;
 use libwebrtc::prelude::*;
 use parking_lot::Mutex;
+use thiserror::Error;
 
 #[cfg(not(target_arch = "wasm32"))]
 use libwebrtc::peer_connection_factory::native::PeerConnectionFactoryExt;
 
 lazy_static! {
-    static ref LK_RUNTIME: Mutex<Weak<LkRuntime>> = Mutex::new(Weak::new());
+    static ref LK_RUNTIME: Mutex<LkRuntimeState> = Mutex::new(LkRuntimeState::default());
 }
+
+#[derive(Default)]
+struct LkRuntimeState {
+    runtime: Weak<LkRuntime>,
+    zero_playout_delay: bool,
+}
+
+impl LkRuntimeState {
+    fn enable_zero_playout_delay(
+        &mut self,
+        active_runtime_zero_playout_delay: Option<bool>,
+    ) -> Result<(), WebRtcRuntimeInitializedError> {
+        if active_runtime_zero_playout_delay == Some(false) {
+            return Err(WebRtcRuntimeInitializedError);
+        }
+
+        self.zero_playout_delay = true;
+        Ok(())
+    }
+}
+
+/// Returned when zero playout delay is requested after the default WebRTC runtime is active.
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+#[error("the WebRTC runtime is already initialized without zero playout delay")]
+pub struct WebRtcRuntimeInitializedError;
 
 pub struct LkRuntime {
     pc_factory: PeerConnectionFactory,
+    zero_playout_delay: bool,
 }
 
 impl Debug for LkRuntime {
@@ -39,14 +66,30 @@ impl Debug for LkRuntime {
 }
 
 impl LkRuntime {
+    pub(crate) fn enable_zero_playout_delay() -> Result<(), WebRtcRuntimeInitializedError> {
+        let mut state = LK_RUNTIME.lock();
+        let active_runtime_zero_playout_delay =
+            state.runtime.upgrade().map(|runtime| runtime.zero_playout_delay);
+        state.enable_zero_playout_delay(active_runtime_zero_playout_delay)
+    }
+
     pub fn instance() -> Arc<LkRuntime> {
-        let mut lk_runtime_ref = LK_RUNTIME.lock();
-        if let Some(lk_runtime) = lk_runtime_ref.upgrade() {
+        let mut state = LK_RUNTIME.lock();
+        if let Some(lk_runtime) = state.runtime.upgrade() {
             lk_runtime
         } else {
             log::debug!("LkRuntime::new()");
-            let new_runtime = Arc::new(Self { pc_factory: PeerConnectionFactory::default() });
-            *lk_runtime_ref = Arc::downgrade(&new_runtime);
+            let zero_playout_delay = state.zero_playout_delay;
+            #[cfg(not(target_arch = "wasm32"))]
+            let pc_factory = if zero_playout_delay {
+                PeerConnectionFactory::with_zero_playout_delay()
+            } else {
+                PeerConnectionFactory::default()
+            };
+            #[cfg(target_arch = "wasm32")]
+            let pc_factory = PeerConnectionFactory::default();
+            let new_runtime = Arc::new(Self { pc_factory, zero_playout_delay });
+            state.runtime = Arc::downgrade(&new_runtime);
             new_runtime
         }
     }
@@ -274,6 +317,31 @@ impl LkRuntime {
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn is_platform_adm_active(&self) -> bool {
         self.pc_factory.is_platform_adm_active()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LkRuntimeState, WebRtcRuntimeInitializedError};
+
+    #[test]
+    fn zero_playout_delay_can_be_enabled_early_and_repeated() {
+        let mut state = LkRuntimeState::default();
+
+        assert_eq!(state.enable_zero_playout_delay(None), Ok(()));
+        assert!(state.zero_playout_delay);
+        assert_eq!(state.enable_zero_playout_delay(Some(true)), Ok(()));
+    }
+
+    #[test]
+    fn zero_playout_delay_rejects_late_enable_on_default_runtime() {
+        let mut state = LkRuntimeState::default();
+
+        assert_eq!(
+            state.enable_zero_playout_delay(Some(false)),
+            Err(WebRtcRuntimeInitializedError)
+        );
+        assert!(!state.zero_playout_delay);
     }
 }
 

--- a/webrtc-sys/include/livekit/peer_connection_factory.h
+++ b/webrtc-sys/include/livekit/peer_connection_factory.h
@@ -45,6 +45,8 @@ webrtc::PeerConnectionInterface::RTCConfiguration to_native_rtc_configuration(
 class PeerConnectionFactory {
  public:
   explicit PeerConnectionFactory(std::shared_ptr<RtcRuntime> rtc_runtime);
+  PeerConnectionFactory(std::shared_ptr<RtcRuntime> rtc_runtime,
+                        bool zero_playout_delay);
   ~PeerConnectionFactory();
 
   std::shared_ptr<PeerConnection> create_peer_connection(
@@ -70,6 +72,7 @@ class PeerConnectionFactory {
 
   std::shared_ptr<RtcRuntime> rtc_runtime() const { return rtc_runtime_; }
   std::shared_ptr<AudioDeviceController> audio_device() const;
+  bool zero_playout_delay_enabled() const;
 
  private:
   std::shared_ptr<RtcRuntime> rtc_runtime_;
@@ -80,4 +83,6 @@ class PeerConnectionFactory {
 };
 
 std::shared_ptr<PeerConnectionFactory> create_peer_connection_factory();
+std::shared_ptr<PeerConnectionFactory>
+create_peer_connection_factory_with_zero_playout_delay();
 }  // namespace livekit_ffi

--- a/webrtc-sys/src/peer_connection_factory.cpp
+++ b/webrtc-sys/src/peer_connection_factory.cpp
@@ -24,7 +24,7 @@
 #include "api/audio/builtin_audio_processing_builder.h"
 #include "api/create_modular_peer_connection_factory.h"
 #include "api/environment/environment_factory.h"
-#include "api/field_trials.h"
+#include "api/field_trials_view.h"
 #include "api/peer_connection_interface.h"
 #include "api/rtc_error.h"
 #include "api/enable_media.h"
@@ -53,10 +53,21 @@ constexpr char kForcePlayoutDelayFieldTrial[] =
     "WebRTC-ForcePlayoutDelay/min_ms:0,max_ms:0/";
 constexpr char kForcePlayoutDelayValue[] = "min_ms:0,max_ms:0";
 
+class ZeroPlayoutDelayFieldTrials final : public webrtc::FieldTrialsView {
+ public:
+  std::string Lookup(absl::string_view key) const override {
+    return key == "WebRTC-ForcePlayoutDelay" ? kForcePlayoutDelayValue : "";
+  }
+
+  std::unique_ptr<webrtc::FieldTrialsView> CreateCopy() const override {
+    return std::make_unique<ZeroPlayoutDelayFieldTrials>();
+  }
+};
+
 webrtc::Environment CreateEnvironment(bool zero_playout_delay) {
   if (zero_playout_delay) {
     return webrtc::CreateEnvironment(
-        std::make_unique<webrtc::FieldTrials>(kForcePlayoutDelayFieldTrial));
+        std::make_unique<ZeroPlayoutDelayFieldTrials>());
   }
   return webrtc::CreateEnvironment();
 }

--- a/webrtc-sys/src/peer_connection_factory.cpp
+++ b/webrtc-sys/src/peer_connection_factory.cpp
@@ -24,6 +24,7 @@
 #include "api/audio/builtin_audio_processing_builder.h"
 #include "api/create_modular_peer_connection_factory.h"
 #include "api/environment/environment_factory.h"
+#include "api/field_trials.h"
 #include "api/peer_connection_interface.h"
 #include "api/rtc_error.h"
 #include "api/enable_media.h"
@@ -46,19 +47,45 @@
 #include "webrtc-sys/src/peer_connection_factory.rs.h"
 
 namespace livekit_ffi {
+namespace {
+
+constexpr char kForcePlayoutDelayFieldTrial[] =
+    "WebRTC-ForcePlayoutDelay/min_ms:0,max_ms:0/";
+constexpr char kForcePlayoutDelayValue[] = "min_ms:0,max_ms:0";
+
+webrtc::Environment CreateEnvironment(bool zero_playout_delay) {
+  if (zero_playout_delay) {
+    return webrtc::CreateEnvironment(
+        std::make_unique<webrtc::FieldTrials>(kForcePlayoutDelayFieldTrial));
+  }
+  return webrtc::CreateEnvironment();
+}
+
+}  // namespace
 
 class PeerConnectionObserver;
 
 PeerConnectionFactory::PeerConnectionFactory(
     std::shared_ptr<RtcRuntime> rtc_runtime)
+    : PeerConnectionFactory(std::move(rtc_runtime), false) {}
+
+PeerConnectionFactory::PeerConnectionFactory(
+    std::shared_ptr<RtcRuntime> rtc_runtime,
+    bool zero_playout_delay)
     : rtc_runtime_(rtc_runtime),
-    env_(webrtc::EnvironmentFactory().Create()) {
+      env_(CreateEnvironment(zero_playout_delay)) {
   webrtc::PeerConnectionFactoryDependencies dependencies;
   dependencies.network_thread = rtc_runtime_->network_thread();
   dependencies.worker_thread = rtc_runtime_->worker_thread();
   dependencies.signaling_thread = rtc_runtime_->signaling_thread();
   dependencies.socket_factory = rtc_runtime_->network_thread()->socketserver();
   dependencies.event_log_factory = std::make_unique<webrtc::RtcEventLogFactory>();
+  dependencies.env = env_;
+
+  if (zero_playout_delay) {
+    RTC_LOG(LS_INFO) << "WebRTC zero playout delay enabled with field trial: "
+                     << kForcePlayoutDelayFieldTrial;
+  }
 
   // Create AdmProxy - it creates and initializes Platform ADM internally
   adm_proxy_ = rtc_runtime_->worker_thread()->BlockingCall([&] {
@@ -163,8 +190,18 @@ std::shared_ptr<AudioDeviceController> PeerConnectionFactory::audio_device() con
   return audio_device_;
 }
 
+bool PeerConnectionFactory::zero_playout_delay_enabled() const {
+  return env_.field_trials().Lookup("WebRTC-ForcePlayoutDelay") ==
+         kForcePlayoutDelayValue;
+}
+
 std::shared_ptr<PeerConnectionFactory> create_peer_connection_factory() {
   return std::make_shared<PeerConnectionFactory>(RtcRuntime::create());
+}
+
+std::shared_ptr<PeerConnectionFactory>
+create_peer_connection_factory_with_zero_playout_delay() {
+  return std::make_shared<PeerConnectionFactory>(RtcRuntime::create(), true);
 }
 
 }  // namespace livekit_ffi

--- a/webrtc-sys/src/peer_connection_factory.rs
+++ b/webrtc-sys/src/peer_connection_factory.rs
@@ -88,6 +88,10 @@ pub mod ffi {
         type PeerConnectionFactory;
 
         fn create_peer_connection_factory() -> SharedPtr<PeerConnectionFactory>;
+        fn create_peer_connection_factory_with_zero_playout_delay(
+        ) -> SharedPtr<PeerConnectionFactory>;
+
+        fn zero_playout_delay_enabled(self: &PeerConnectionFactory) -> bool;
 
         fn create_peer_connection(
             self: &PeerConnectionFactory,


### PR DESCRIPTION
- Add option to enable `WebRTC-ForcePlayoutDelay` trial in subscriber peerconnection
- Add --low-latency flag to local_video subscriber example to demonstrate low latency mode