### PR TITLE
Generate Go package for UniFFI

### DIFF
--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -20,6 +20,7 @@ TARGET_DIR = "${CARGO_MAKE_CRATE_TARGET_DIRECTORY}"
 SPM_NAME = "LiveKitUniFFI"
 NPM_NAME = "@livekit/uniffi"
 DART_PACKAGE_NAME = "livekit_uniffi"
+GO_MODULE = "github.com/livekit/livekit-uniffi-go"
 
 # Per-release directory holding the cdylib archives published by
 # .github/workflows/uniffi-cdylib.yml. Downloaders append
@@ -173,6 +174,7 @@ dependencies = [
     "bindgen-kotlin",
     "bindgen-python",
     "bindgen-dart",
+    "bindgen-go",
 ]
 
 # MARK: - Kotlin
@@ -743,3 +745,59 @@ description = "Build a consumable Dart package with bindings, hook, and (dev) na
 # See bindgen-dart: keep symbols so library-mode bindgen can read metadata.
 env = { LANG = "dart", CARGO_PROFILE_RELEASE_STRIP = "false" }
 run_task = "dart-package-flow"
+
+# MARK: - Go
+
+[tasks.bindgen-go]
+description = "Generate Go bindings"
+env = { LANG = "go", CARGO_PROFILE_RELEASE_STRIP = "false" }
+run_task = "bindgen-go-flow"
+
+[tasks.bindgen-go-flow]
+private = true
+dependencies = ["build", "locate-lib"]
+install_crate = { crate_name = "uniffi-bindgen-go", binary = "uniffi-bindgen-go", test_arg = "--help" }
+install_crate_args = ["--git", "https://github.com/NordSecurity/uniffi-bindgen-go", "--tag", "v0.7.1+v0.31.0", "uniffi-bindgen-go"]
+command = "uniffi-bindgen-go"
+args = ["--library", "${LIB_PATH}", "--out-dir", "${PACKAGES_DIR}/${LANG}"]
+
+[tasks.go-generate-manifest]
+private = true
+extend = "tera"
+args = ["--env-only", "-t", "${SUPPORT_DIR}/${LANG}/go.mod.tera", "-o", "${PACKAGES_DIR}/${LANG}/go.mod"]
+
+[tasks.go-copy-link-file]
+private = true
+script_runner = "@shell"
+script = """
+cp ${SUPPORT_DIR}/${LANG}/link.go ${PACKAGES_DIR}/${LANG}/livekit_uniffi/link.go
+"""
+
+[tasks.go-copy-tests]
+private = true
+script_runner = "@shell"
+script = """
+cp ${SUPPORT_DIR}/${LANG}/test/*_test.go ${PACKAGES_DIR}/${LANG}/livekit_uniffi/
+"""
+
+[tasks.go-copy-lib]
+private = true
+script_runner = "@shell"
+script = """
+cp ${LIB_PATH} ${PACKAGES_DIR}/${LANG}/
+"""
+
+[tasks.go-package-flow]
+private = true
+dependencies = [
+    "bindgen-go",
+    "go-generate-manifest",
+    "go-copy-link-file",
+    "go-copy-tests",
+    "go-copy-lib",
+]
+
+[tasks.go-package]
+description = "Build a consumable Go module with bindings, link flags, and (dev) native lib"
+env = { LANG = "go", CARGO_PROFILE_RELEASE_STRIP = "false" }
+run_task = "go-package-flow"

--- a/livekit-uniffi/support/go/README.md
+++ b/livekit-uniffi/support/go/README.md
@@ -1,0 +1,100 @@
+# LiveKit UniFFI — Go module
+
+Support files for assembling a consumable Go module from the
+[uniffi-bindgen-go](https://github.com/NordSecurity/uniffi-bindgen-go)
+bindings. The bindgen is versioned in lockstep with uniffi-rs (the `+vX.Y.Z`
+tag suffix); the tag pinned in `Makefile.toml` must target the same uniffi-rs
+release as the workspace `uniffi` dependency.
+
+## Prerequisites
+
+- Go ≥ 1.19 on `PATH` (the bindgen runs `go fmt` on its output; cgo builds
+  need a C toolchain)
+
+## Full package build
+
+From the crate root:
+
+```bash
+cargo make go-package                        # debug native lib
+cargo make --profile release go-package      # release native lib
+```
+
+Output module at `packages/go`:
+
+```
+packages/go/
+  go.mod                    (from go.mod.tera; module path = GO_MODULE)
+  livekit_uniffi/           (generated bindings + C header per uniffi component)
+  livekit_datatrack/
+  livekit_uniffi/link.go    (from link.go here; cgo LDFLAGS)
+  livekit_uniffi/*_test.go  (from test/)
+  liblivekit_uniffi.<ext>   (dev: locally built dynamic library)
+```
+
+Consumers import the `livekit_uniffi` package; `livekit_datatrack` is
+imported directly only for encryption providers and typed data-track errors:
+
+```go
+import uniffi "github.com/livekit/livekit-uniffi-go/livekit_uniffi"
+```
+
+## Linking
+
+The generated bindings carry no cgo linker flags; `link.go` supplies
+`-L${SRCDIR}/.. -llivekit_uniffi`, resolving the dynamic library from the
+module root (where `go-copy-lib` placed the local build). On Linux an rpath
+entry makes it resolve at runtime too; on macOS the dev dylib's install name
+is the absolute path into `target/`, so it resolves as long as the local
+Rust build exists. Windows consumers must arrange an import library and
+`PATH` themselves. To link a library from a different location, set
+`CGO_LDFLAGS` instead.
+
+## Build notes
+
+Context for the non-obvious parts of the `Makefile.toml` Go tasks:
+
+- `bindgen-go` and `go-package` set `CARGO_PROFILE_RELEASE_STRIP=false`
+  because library-mode bindgen reads `UNIFFI_META_*` symbols from the
+  compiled cdylib, and the release profile's `strip = "symbols"` removes
+  them on Linux (same workaround as `bindgen-dart`).
+- The pinned bindgen tag's `+vX.Y.Z` suffix is the uniffi-rs release it
+  targets and must match the workspace `uniffi` dependency, or the bindgen
+  cannot read this crate's compiled metadata and the generated
+  contract-version/checksum guards would panic at runtime.
+- The `cargo install` args end with an explicit `uniffi-bindgen-go` package
+  name: the bindgen repo is a workspace with several binary packages
+  (fixtures), and cargo-make does not pass `crate_name` itself when
+  `install_crate_args` is set.
+- Library mode generates one Go package per uniffi component in the cdylib
+  (`livekit_uniffi`, `livekit_datatrack`); the cross-package import in
+  `livekit_uniffi` is built from the `go_mod` path in `uniffi.toml`.
+- Copying the locally built library into the module root (`go-copy-lib`) is
+  the dev delivery mechanism; see Distribution below for how a release flow
+  would deliver the library.
+
+## Verify
+
+```bash
+cd packages/go && go test ./...
+```
+
+## App integration (local development)
+
+Point your app's module at the assembled package with a `replace` directive:
+
+```bash
+go mod edit -replace github.com/livekit/livekit-uniffi-go=<path to packages/go>
+go mod tidy
+```
+
+or add both to a `go.work` workspace. Re-run `cargo make go-package` to
+rebuild after Rust-side changes.
+
+The module path is declared in two places that must stay in sync: `GO_MODULE`
+in `Makefile.toml` (baked into `go.mod`) and `go_mod` in `uniffi.toml`
+(baked into generated import paths).
+
+## Distribution (not yet implemented)
+
+TODO

--- a/livekit-uniffi/support/go/go.mod.tera
+++ b/livekit-uniffi/support/go/go.mod.tera
@@ -1,0 +1,4 @@
+
+module {{ GO_MODULE }}
+
+go 1.19

--- a/livekit-uniffi/support/go/link.go
+++ b/livekit-uniffi/support/go/link.go
@@ -1,0 +1,21 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package livekit_uniffi
+
+/*
+#cgo LDFLAGS: -L${SRCDIR}/.. -llivekit_uniffi
+#cgo linux LDFLAGS: -Wl,-rpath,${SRCDIR}/..
+*/
+import "C"

--- a/livekit-uniffi/support/go/test/build_version_test.go
+++ b/livekit-uniffi/support/go/test/build_version_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package livekit_uniffi
+
+import "testing"
+
+// Smoke test for the whole FFI path: cgo links the native library, Go calls a
+// Rust function, and the result crosses back.
+func TestBuildVersionIsNonEmpty(t *testing.T) {
+	if BuildVersion() == "" {
+		t.Fatal("BuildVersion() returned an empty string")
+	}
+}

--- a/livekit-uniffi/uniffi.toml
+++ b/livekit-uniffi/uniffi.toml
@@ -11,3 +11,10 @@ cdylib_name = "livekit_uniffi" # the name of the so file to be loaded
 # asset id resolves to `package:livekit_uniffi/uniffi:livekit_uniffi`.
 package_name = "livekit_uniffi"
 cdylib_name = "livekit_uniffi"
+
+[bindings.go]
+# Go module path of the assembled package (must match GO_MODULE in
+# Makefile.toml). Used as the import source for cross-crate references: the
+# generated livekit_uniffi package imports the livekit_datatrack package
+# generated into the same module.
+go_mod = "github.com/livekit/livekit-uniffi-go"


### PR DESCRIPTION
Experimental Go package support for _livekit-uniffi_. Outstanding tasks:
- [ ] Investigate package name-spacing (currently has same issues as other languages)
- [ ] Setup distribution path