### PR TITLE
Strip DWARF from iOS FFI release archives

### DIFF
--- a/.changeset/strip-ios-ffi-dwarf.md
+++ b/.changeset/strip-ios-ffi-dwarf.md
@@ -1,0 +1,5 @@
+---
+livekit-ffi: patch
+---
+
+Strip DWARF debug information from release iOS FFI archives.

--- a/.github/workflows/ffi-builds.yml
+++ b/.github/workflows/ffi-builds.yml
@@ -203,6 +203,15 @@ jobs:
           cd livekit-ffi
           cargo rustc --crate-type staticlib --profile "$CARGO_RUST_PROFILE" --target ${{ matrix.target }} ${{ matrix.buildargs }}
 
+      - name: Strip iOS release archive
+        if: ${{ matrix.platform == 'ios' }}
+        run: |
+          if [ "$CARGO_RUST_PROFILE" = "release" ]; then
+            archive="target/${{ matrix.target }}/$CARGO_PROFILE_DIR/${{ matrix.dylib }}"
+            xcrun strip -S "$archive"
+            xcrun ranlib "$archive"
+          fi
+
       - name: Build (Windows)
         if: ${{ matrix.platform == 'windows' }}
         run: |

--- a/.github/workflows/gen-node-proto.yml
+++ b/.github/workflows/gen-node-proto.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           submodules: true
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0


### PR DESCRIPTION
## Summary

- Strip DWARF debug information from the release iOS device and simulator
  `liblivekit_ffi.a` archives before packaging.
- Rebuild each archive's symbol index with `ranlib`.
- Leave manually requested debug artifacts unstripped.
- Add a patch changeset for `livekit-ffi`.

Fixes #1087.

## Background

The iOS FFI builds produce static archives, so there is no final dynamic-link step
to discard DWARF information. Although the workspace release profile enables
symbol stripping, that does not remove debug information embedded in every
archive member, including the bundled C/C++ WebRTC objects.

Post-processing the completed archive with Apple's `strip -S` handles the whole
artifact while preserving global symbols required by downstream linkers.

## Measured impact

| Target | Raw archive | Compressed archive | Packaging time |
| --- | --- | --- | --- |
| `aarch64-apple-ios` | 462.23 → 44.92 MiB | 122.26 → 14.37 MiB | 13.59 → 1.54s |
| `aarch64-apple-ios-sim` | 463.84 → 45.07 MiB | 122.58 → 14.44 MiB | 13.76 → 1.51s |

Across both published iOS archives, this reduces raw size by 90.28% and
compressed size by 88.23%.

DWARF section size falls to zero. All defined external symbols and all 3,435
archive members are preserved, including `livekit_ffi_request`,
`livekit_ffi_initialize`, and `livekit_ffi_drop_handle`.

## Design tradeoffs

Using a Cargo profile setting alone was avoided because it does not reliably
strip debug information from all bundled C/C++ archive members.

Post-build stripping adds roughly 61 seconds to each iOS release matrix job on
my laptop. Faster packaging saves about 12 seconds per artifact, and the
smaller upload and downstream processing costs should offset additional time
outside the build itself.

## Testing

- Built release `liblivekit_ffi.a` for:
  - `aarch64-apple-ios`
  - `aarch64-apple-ios-sim`
- Applied `xcrun strip -S` and `xcrun ranlib` to both archives.
- Verified zero remaining DWARF bytes.
- Compared archive members and defined external symbols before and after.
- Verified required LiveKit FFI entry points remain exported.
- Verified Apple's linker can consume both post-strip archives.
- Built the macOS arm64 dynamic-library control and confirmed it
  already contains zero DWARF.
- Ran `cargo fmt --all -- --check`, workflow YAML parsing, changeset validation,
  and `git diff --check`.

## CI note

This PR also adds one line to `gen-node-proto.yml`: the checkout step now
sets `repository:` to the PR head repository. The job previously fetched
the head branch name from the base repository, which fails for any
fork-based PR matching the workflow's path filter — including this one,
via `.github/**`. Same-repo PRs are unaffected
(`head.repo.full_name` equals `github.repository` there).
