### PR TITLE
Fix publisher transport self-deadlock during renegotiation

### DIFF
--- a/.changeset/fix-publisher-renegotiation-deadlock.md
+++ b/.changeset/fix-publisher-renegotiation-deadlock.md
@@ -1,0 +1,6 @@
+---
+livekit: patch
+livekit-ffi: patch
+---
+
+Fix a publisher-transport deadlock during renegotiation. When another negotiation was requested while an offer was awaiting its answer, `set_remote_description` re-entered `create_and_send_offer` while holding the transport's non-reentrant inner mutex, permanently wedging publishing.

--- a/livekit/Cargo.toml
+++ b/livekit/Cargo.toml
@@ -59,6 +59,9 @@ base64 = "0.22"
 [dev-dependencies]
 # Enable data-stream test constructors (e.g. TextStreamReader::new_for_test) for our test suites.
 livekit-data-stream = { workspace = true, features = ["test-utils"] }
+# Async test runtime + timers, needed by the peer_transport deadlock reproducer.
+# (rt/time are already built elsewhere in the workspace, so no new crates enter the lockfile.)
+tokio = { version = "1", features = ["rt", "macros", "time"] }
 anyhow = "1.0.99"
 test-log = "0.2.18"
 test-case = "3.3"

--- a/livekit/src/rtc_engine/peer_transport.rs
+++ b/livekit/src/rtc_engine/peer_transport.rs
@@ -127,6 +127,10 @@ impl PeerTransport {
 
         if inner.renegotiate {
             inner.renegotiate = false;
+            // Release the lock before re-entering `create_and_send_offer`, which re-acquires
+            // `self.inner`. `tokio::sync::Mutex` is not reentrant, so holding the guard across
+            // this call would deadlock the task.
+            drop(inner);
             self.create_and_send_offer(OfferOptions::default()).await?;
         }
 
@@ -549,6 +553,104 @@ impl PeerTransport {
 #[cfg(test)]
 mod tests {
     use super::PeerTransport;
+
+    /// Reproduces the publisher-transport self-deadlock.
+    ///
+    /// `PeerTransport::set_remote_description` locks `self.inner` and then, when
+    /// `inner.renegotiate` is set, calls `create_and_send_offer` *while still holding that
+    /// guard*. `create_and_send_offer`'s first statement re-locks the same
+    /// `tokio::sync::Mutex`, which is not reentrant, so the task waits forever for a lock it
+    /// already holds.
+    ///
+    /// This test drives the production-reachable `HaveLocalOffer` sequence that sets
+    /// `renegotiate = true`:
+    ///
+    ///  1. The publisher creates and sends an ordinary offer, entering `HaveLocalOffer`.
+    ///  2. Before the answer is applied, another publish/unpublish negotiation is requested.
+    ///     `create_and_send_offer` sees `HaveLocalOffer` and sets `renegotiate = true`.
+    ///  3. The answer reaches the transport. Because `renegotiate == true`,
+    ///     `set_remote_description` re-enters `create_and_send_offer`; holding the inner lock
+    ///     across that call would deadlock.
+    ///
+    /// The `timeout` distinguishes a deadlock (the future never resolves) from success. On the
+    /// buggy code this test fails via the timeout assertion; with the lock released before the
+    /// nested call it passes.
+    #[tokio::test]
+    async fn renegotiation_does_not_deadlock() {
+        use std::{
+            sync::{Arc, Mutex},
+            time::Duration,
+        };
+
+        use libwebrtc::prelude::*;
+        use livekit_protocol as proto;
+
+        let factory = PeerConnectionFactory::default();
+        let config = RtcConfiguration {
+            ice_servers: vec![],
+            continual_gathering_policy: ContinualGatheringPolicy::GatherOnce,
+            ice_transport_type: IceTransportsType::All,
+        };
+
+        let alice_pc = factory.create_peer_connection(config.clone()).unwrap();
+        let bob_pc = factory.create_peer_connection(config).unwrap();
+
+        // Give the publisher an m-line so the offer/answer exchange is non-trivial.
+        let _dc = alice_pc.create_data_channel("repro", DataChannelInit::default()).unwrap();
+
+        let transport = PeerTransport::new(
+            alice_pc,
+            proto::SignalTarget::Publisher,
+            /* single_pc_mode= */ true,
+        );
+
+        let offers = Arc::new(Mutex::new(Vec::new()));
+        let emitted_offers = offers.clone();
+        transport.on_offer(Some(Box::new(move |offer| {
+            emitted_offers.lock().expect("offers lock poisoned").push(offer);
+        })));
+
+        // 1. Send an ordinary publisher offer, putting Alice in `HaveLocalOffer`.
+        transport.create_and_send_offer(OfferOptions::default()).await.unwrap();
+        assert_eq!(transport.peer_connection().signaling_state(), SignalingState::HaveLocalOffer);
+
+        let offer = offers
+            .lock()
+            .expect("offers lock poisoned")
+            .first()
+            .cloned()
+            .expect("first offer was not emitted");
+
+        // Bob prepares the answer, but it has not reached Alice yet.
+        bob_pc.set_remote_description(offer).await.unwrap();
+        let answer = bob_pc.create_answer(AnswerOptions::default()).await.unwrap();
+        bob_pc.set_local_description(answer.clone()).await.unwrap();
+
+        // 2. Model another publish/unpublish negotiation during the offer/answer RTT. Because
+        //    Alice is still in `HaveLocalOffer`, this only sets `renegotiate = true`.
+        transport.create_and_send_offer(OfferOptions::default()).await.unwrap();
+        assert_eq!(offers.lock().expect("offers lock poisoned").len(), 1);
+
+        // 3. Applying the answer must complete and emit the deferred follow-up offer.
+        let res =
+            tokio::time::timeout(Duration::from_secs(10), transport.set_remote_description(answer))
+                .await;
+
+        assert!(
+            res.is_ok(),
+            "DEADLOCK: set_remote_description re-locked the transport's `inner` AsyncMutex while \
+             renegotiating (peer_transport.rs: lock at set_remote_description, re-lock at \
+             create_and_send_offer)"
+        );
+        res.unwrap().expect("set_remote_description returned an error");
+
+        assert_eq!(
+            offers.lock().expect("offers lock poisoned").len(),
+            2,
+            "the deferred renegotiation should emit a follow-up offer"
+        );
+        assert_eq!(transport.peer_connection().signaling_state(), SignalingState::HaveLocalOffer);
+    }
 
     #[test]
     fn no_video_codec_is_noop() {


### PR DESCRIPTION
Summary

- Release the publisher transport's inner mutex before starting a deferred renegotiation.
- Add a loopback regression test for a second negotiation requested while an offer is awaiting its answer.
- Verify that applying the answer completes and emits the deferred follow-up offer.

## Problem

`PeerTransport::set_remote_description` held `self.inner`, a `tokio::sync::Mutex`, while processing an answer. If another publisher negotiation had been requested while the previous offer was in flight, `create_and_send_offer` recorded that request by setting `inner.renegotiate = true`.

After applying the answer, `set_remote_description` saw that flag and called `create_and_send_offer` without releasing the mutex guard. `create_and_send_offer` immediately tried to lock `self.inner` again. Because Tokio's mutex is not reentrant, the task waited forever for the lock it already held.

This leaves the room reporting `Connected` while publisher operations that need the transport mutex remain blocked. Further track negotiation and ICE restart cannot proceed without tearing down the connection.

## Production reachability

The deadlock is reachable through the ordinary `HaveLocalOffer` path when
`fast_publish` is disabled and publisher changes use the 150 ms debouncer:

1. A publish or unpublish operation creates an offer and the publisher enters `HaveLocalOffer`.
2. After that debounced negotiation completes, but before the server's answer is applied, another
   publish or unpublish change schedules a second debounced negotiation.
3. `create_and_send_offer` sees the offer in flight and sets `renegotiate = true`.
4. The answer arrives and `set_remote_description` attempts the deferred renegotiation.

This can occur when track changes are separated by the debounce window and signaling latency keeps the first offer in flight long enough for the second negotiation to run. When `fast_publish` is
enabled, subsequent publisher negotiations are queued outside `PeerTransport`, generally avoiding
this exact overlap.

## Fix

Clear the deferred-renegotiation flag and drop the `inner` guard before calling `create_and_send_offer`. The nested call can then acquire the mutex normally.

## Testing

The new `renegotiation_does_not_deadlock` test uses two in-process peer connections:

1. Alice creates an ordinary publisher offer and enters `HaveLocalOffer`.
2. Bob prepares an answer, but Alice does not apply it yet.
3. A second offer request sets the deferred-renegotiation flag.
4. Alice applies Bob's answer under a timeout.
5. The test verifies that the call completes and that a second offer is emitted.

- `cargo fmt --all -- --check`
- `cargo test -p livekit --lib`