### PR TITLE
Add livekit-capture core crate

### DIFF
--- a/.changeset/livekit-capture-preencoded.md
+++ b/.changeset/livekit-capture-preencoded.md
@@ -1,0 +1,5 @@
+---
+"livekit-capture": minor
+---
+
+Add a `livekit-capture` crate with shared decoded, native, DMA-BUF, and pre-encoded capture types, publishing helpers, and codec-neutral ingress primitives.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3988,6 +3988,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "livekit-capture"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "livekit",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "livekit-common"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "livekit-uniffi",
     "livekit-datatrack",
     "livekit-ffi-node-bindings",
+    "livekit-capture",
     "livekit-runtime",
     "livekit-wakeword",
     "libwebrtc",
@@ -49,6 +50,7 @@ device-info = { version = "0.1.1", path = "device-info" }
 imgproc = { version = "0.3.19", path = "imgproc" }
 libwebrtc = { version = "0.3.41", path = "libwebrtc" }
 livekit = { version = "0.7.52", path = "livekit" }
+livekit-capture = { version = "0.1.0", path = "livekit-capture" }
 livekit-api = { version = "0.5.5", path = "livekit-api" }
 livekit-ffi = { version = "0.12.70", path = "livekit-ffi" }
 livekit-datatrack = { version = "0.1.11", path = "livekit-datatrack" }

--- a/livekit-capture/Cargo.toml
+++ b/livekit-capture/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "livekit-capture"
+description = "Capture sources and pre-encoded video publishing helpers for LiveKit"
+version = "0.1.0"
+readme = "README.md"
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
+
+[dependencies]
+bytes = { workspace = true }
+livekit = { workspace = true }
+thiserror = { workspace = true }
+
+[features]
+default = []

--- a/livekit-capture/README.md
+++ b/livekit-capture/README.md
@@ -1,0 +1,20 @@
+# livekit-capture
+
+`livekit-capture` provides shared capture types and publishing helpers for the
+LiveKit Rust SDK. It supports decoded frames, native buffers, Linux DMA-BUF
+frames, and pre-encoded video access units.
+
+Concrete capture sources are optional and are introduced behind crate features.
+
+## Core entry points
+
+- `VideoCaptureTrack` creates a publishable LiveKit video track and accepts
+  decoded, DMA-BUF, or pre-encoded frames.
+- `CaptureFrameSource` is the common interface implemented by capture sources.
+- `CaptureFrame` represents native, raw, DMA-BUF, or encoded output.
+- `EncodedIngress` drives an encoded source while forwarding keyframe and
+  rate-control requests upstream.
+
+The encoded path accepts H.264, H.265, VP8, VP9, and AV1 access units. The
+shared helpers include Annex-B and AVC parsing plus RTP depacketization used by
+network capture sources.

--- a/livekit-capture/README.md
+++ b/livekit-capture/README.md
@@ -1,10 +1,22 @@
 # livekit-capture
 
 `livekit-capture` provides shared capture types and publishing helpers for the
-LiveKit Rust SDK. It supports decoded frames, native buffers, Linux DMA-BUF
-frames, and pre-encoded video access units.
+LiveKit Rust SDK.
 
-Concrete capture sources are optional and are introduced behind crate features.
+## Supported capture sources
+
+Concrete capture sources are optional and are introduced behind crate features:
+
+- [ ] `avfoundation`
+- [ ] `gstreamer`
+- [ ] `libargus`
+- [ ] `rtsp`
+- [ ] `tcpsink`
+- [ ] `v41`
+
+<!-- TODO: check-off as each is implemented -->
+
+Enable the feature(s) required for your application. None are enabled by default.
 
 ## Core entry points
 

--- a/livekit-capture/src/device.rs
+++ b/livekit-capture/src/device.rs
@@ -1,0 +1,307 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use livekit::webrtc::video_source::VideoResolution;
+use thiserror::Error;
+
+/// Capture backend used by a source implementation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum CaptureBackend {
+    /// Let `livekit-capture` choose the platform default backend.
+    Auto,
+    /// macOS AVFoundation camera capture.
+    AvFoundation,
+    /// Linux Video4Linux2 camera capture.
+    V4l2,
+    /// NVIDIA Jetson libargus camera capture.
+    LibArgus,
+    /// RTSP encoded ingress.
+    Rtsp,
+    /// TCP byte-stream encoded ingress.
+    Tcp,
+    /// GStreamer appsink encoded ingress.
+    Gstreamer,
+}
+
+impl CaptureBackend {
+    /// Returns a stable backend name.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::AvFoundation => "avfoundation",
+            Self::V4l2 => "v4l2",
+            Self::LibArgus => "libargus",
+            Self::Rtsp => "rtsp",
+            Self::Tcp => "tcp",
+            Self::Gstreamer => "gstreamer",
+        }
+    }
+}
+
+impl fmt::Display for CaptureBackend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Capture path used by a source implementation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum CapturePath {
+    /// Platform-native uncompressed frame buffers.
+    Native,
+    /// Uncompressed CPU-accessible frame buffers.
+    Raw,
+    /// Linux DMA-BUF backed frames.
+    DmaBuf,
+    /// Compressed encoded access units.
+    Encoded,
+}
+
+/// Error returned while querying capture devices.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum CaptureDeviceQueryError {
+    /// The backend does not support device enumeration on this target or build.
+    #[error("capture backend {0} does not support device enumeration")]
+    UnsupportedBackend(CaptureBackend),
+    /// The backend failed while querying devices.
+    #[error("capture backend {backend} device query failed: {message}")]
+    Backend {
+        /// Backend that failed.
+        backend: CaptureBackend,
+        /// Backend error message.
+        message: String,
+    },
+}
+
+/// Capture device discovered by a platform backend.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CaptureDeviceInfo {
+    /// Backend that reported this device.
+    pub backend: CaptureBackend,
+    /// Backend-stable device identifier.
+    pub id: String,
+    /// Preferred selector that reopens this exact device.
+    pub selector: CaptureDeviceSelector,
+    /// Human-readable device name.
+    pub name: String,
+    /// Device model identifier, when available.
+    pub model_id: Option<String>,
+    /// Device manufacturer, when available.
+    pub manufacturer: Option<String>,
+    /// Capture paths supported by this device.
+    pub paths: Vec<CapturePath>,
+    /// Capture formats reported by the backend.
+    pub formats: Vec<CaptureFormat>,
+    /// Whether [`CaptureDeviceInfo::formats`] is a complete backend-reported list.
+    pub formats_complete: bool,
+}
+
+/// Device selector used by capture backends.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CaptureDeviceSelector {
+    /// Use the backend default video device.
+    Default,
+    /// Use the device at the backend enumeration index.
+    Index(usize),
+    /// Use a backend-stable device identifier.
+    Id(String),
+}
+
+/// Frame format used by a raw-frame capture backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CaptureFrameFormat {
+    /// Planar I420/YUV420P.
+    I420,
+    /// Biplanar NV12.
+    Nv12,
+    /// Packed BGRA.
+    Bgra,
+    /// Packed RGB24.
+    Rgb24,
+    /// Packed BGR24.
+    Bgr24,
+    /// Packed YUYV/YUY2.
+    Yuyv,
+    /// Packed UYVY.
+    Uyvy,
+    /// Single-plane 8-bit luma.
+    Grey,
+    /// Encoded MJPEG frames.
+    Mjpeg,
+}
+
+impl CaptureFrameFormat {
+    /// Returns a stable lower-case frame-format name.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::I420 => "i420",
+            Self::Nv12 => "nv12",
+            Self::Bgra => "bgra",
+            Self::Rgb24 => "rgb24",
+            Self::Bgr24 => "bgr24",
+            Self::Yuyv => "yuyv",
+            Self::Uyvy => "uyvy",
+            Self::Grey => "grey",
+            Self::Mjpeg => "mjpeg",
+        }
+    }
+}
+
+impl fmt::Display for CaptureFrameFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for CaptureFrameFormat {
+    type Err = CaptureFrameFormatParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_ascii_lowercase().as_str() {
+            "i420" | "yuv420p" => Ok(Self::I420),
+            "nv12" => Ok(Self::Nv12),
+            "bgra" => Ok(Self::Bgra),
+            "rgb24" | "rgb" => Ok(Self::Rgb24),
+            "bgr24" | "bgr" => Ok(Self::Bgr24),
+            "yuyv" | "yuy2" => Ok(Self::Yuyv),
+            "uyvy" => Ok(Self::Uyvy),
+            "grey" | "greyscale" => Ok(Self::Grey),
+            "mjpeg" | "mjpg" => Ok(Self::Mjpeg),
+            _ => Err(CaptureFrameFormatParseError),
+        }
+    }
+}
+
+/// Error returned when parsing a [`CaptureFrameFormat`] from a string.
+#[derive(Debug, Clone, Copy, Error, PartialEq, Eq)]
+#[error("unknown capture frame format")]
+pub struct CaptureFrameFormatParseError;
+
+/// Pixel dimensions for a capture format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CaptureResolution {
+    /// Frame width in pixels.
+    pub width: u32,
+    /// Frame height in pixels.
+    pub height: u32,
+}
+
+impl CaptureResolution {
+    /// Creates a capture resolution.
+    pub const fn new(width: u32, height: u32) -> Self {
+        Self { width, height }
+    }
+}
+
+impl From<CaptureResolution> for VideoResolution {
+    fn from(value: CaptureResolution) -> Self {
+        Self { width: value.width, height: value.height }
+    }
+}
+
+/// Raw-frame capture format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CaptureFormat {
+    /// Frame dimensions.
+    pub resolution: CaptureResolution,
+    /// Frame rate in frames per second.
+    pub frame_rate: u32,
+    /// Frame format.
+    pub frame_format: CaptureFrameFormat,
+}
+
+impl CaptureFormat {
+    /// Creates a raw-frame capture format.
+    pub const fn new(
+        resolution: CaptureResolution,
+        frame_rate: u32,
+        frame_format: CaptureFrameFormat,
+    ) -> Self {
+        Self { resolution, frame_rate, frame_format }
+    }
+}
+
+/// Format selection requested from a capture backend.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CaptureFormatRequest {
+    /// Let the backend choose its default format.
+    Default,
+    /// Require an exact format match.
+    Exact(CaptureFormat),
+    /// Use the backend's closest supported format.
+    Closest(CaptureFormat),
+    /// Prefer the highest frame rate, optionally constrained by resolution and frame format.
+    HighestFrameRate {
+        /// Optional resolution constraint.
+        resolution: Option<CaptureResolution>,
+        /// Optional frame format constraint.
+        frame_format: Option<CaptureFrameFormat>,
+    },
+    /// Prefer the highest resolution, optionally constrained by frame rate and frame format.
+    HighestResolution {
+        /// Optional frame-rate constraint.
+        frame_rate: Option<u32>,
+        /// Optional frame format constraint.
+        frame_format: Option<CaptureFrameFormat>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn capture_frame_format_parses_common_names() {
+        assert_eq!(CaptureFrameFormat::from_str("MJPEG"), Ok(CaptureFrameFormat::Mjpeg));
+        assert_eq!(CaptureFrameFormat::from_str("mjpg"), Ok(CaptureFrameFormat::Mjpeg));
+        assert_eq!(CaptureFrameFormat::from_str("grey"), Ok(CaptureFrameFormat::Grey));
+        assert_eq!(CaptureFrameFormat::from_str("GREY"), Ok(CaptureFrameFormat::Grey));
+        assert_eq!(CaptureFrameFormat::from_str("yuy2"), Ok(CaptureFrameFormat::Yuyv));
+    }
+
+    #[test]
+    fn capture_frame_format_displays_canonical_names() {
+        assert_eq!(CaptureFrameFormat::Mjpeg.to_string(), "mjpeg");
+        assert_eq!(CaptureFrameFormat::Grey.to_string(), "grey");
+    }
+
+    #[test]
+    fn device_info_can_report_incomplete_format_lists() {
+        let info = CaptureDeviceInfo {
+            backend: CaptureBackend::AvFoundation,
+            id: "camera-0".to_string(),
+            selector: CaptureDeviceSelector::Id("camera-0".to_string()),
+            name: "Camera".to_string(),
+            model_id: None,
+            manufacturer: None,
+            paths: vec![CapturePath::Native, CapturePath::Raw],
+            formats: Vec::new(),
+            formats_complete: false,
+        };
+
+        assert_eq!(info.backend, CaptureBackend::AvFoundation);
+        assert_eq!(info.selector, CaptureDeviceSelector::Id("camera-0".to_string()));
+        assert_eq!(info.paths, vec![CapturePath::Native, CapturePath::Raw]);
+        assert!(!info.formats_complete);
+    }
+}

--- a/livekit-capture/src/device.rs
+++ b/livekit-capture/src/device.rs
@@ -14,8 +14,9 @@
 
 use std::fmt;
 
-use livekit::webrtc::video_source::VideoResolution;
 use thiserror::Error;
+
+use crate::primitives::VideoResolution;
 
 /// Capture backend used by a source implementation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -195,33 +196,11 @@ impl std::str::FromStr for CaptureFrameFormat {
 #[error("unknown capture frame format")]
 pub struct CaptureFrameFormatParseError;
 
-/// Pixel dimensions for a capture format.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct CaptureResolution {
-    /// Frame width in pixels.
-    pub width: u32,
-    /// Frame height in pixels.
-    pub height: u32,
-}
-
-impl CaptureResolution {
-    /// Creates a capture resolution.
-    pub const fn new(width: u32, height: u32) -> Self {
-        Self { width, height }
-    }
-}
-
-impl From<CaptureResolution> for VideoResolution {
-    fn from(value: CaptureResolution) -> Self {
-        Self { width: value.width, height: value.height }
-    }
-}
-
 /// Raw-frame capture format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CaptureFormat {
     /// Frame dimensions.
-    pub resolution: CaptureResolution,
+    pub resolution: VideoResolution,
     /// Frame rate in frames per second.
     pub frame_rate: u32,
     /// Frame format.
@@ -231,7 +210,7 @@ pub struct CaptureFormat {
 impl CaptureFormat {
     /// Creates a raw-frame capture format.
     pub const fn new(
-        resolution: CaptureResolution,
+        resolution: VideoResolution,
         frame_rate: u32,
         frame_format: CaptureFrameFormat,
     ) -> Self {
@@ -252,7 +231,7 @@ pub enum CaptureFormatRequest {
     /// Prefer the highest frame rate, optionally constrained by resolution and frame format.
     HighestFrameRate {
         /// Optional resolution constraint.
-        resolution: Option<CaptureResolution>,
+        resolution: Option<VideoResolution>,
         /// Optional frame format constraint.
         frame_format: Option<CaptureFrameFormat>,
     },

--- a/livekit-capture/src/dmabuf.rs
+++ b/livekit-capture/src/dmabuf.rs
@@ -1,0 +1,62 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// DMA-BUF pixel format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DmaBufPixelFormat {
+    /// NV12 biplanar format.
+    Nv12,
+    /// YUV420M multiplanar format.
+    Yuv420M,
+}
+
+impl DmaBufPixelFormat {
+    #[cfg(target_os = "linux")]
+    pub(crate) fn as_native(self) -> i32 {
+        match self {
+            Self::Nv12 => 0,
+            Self::Yuv420M => 1,
+        }
+    }
+}
+
+/// One DMA-BUF plane descriptor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DmaBufPlane {
+    /// DMA-BUF file descriptor.
+    pub fd: i32,
+    /// Plane byte offset.
+    pub offset: u32,
+    /// Plane byte stride.
+    pub stride: u32,
+}
+
+/// One DMA-BUF backed captured frame.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DmaBufFrame {
+    /// Frame width in pixels.
+    pub width: u32,
+    /// Frame height in pixels.
+    pub height: u32,
+    /// Pixel format.
+    pub pixel_format: DmaBufPixelFormat,
+    /// DMA-BUF planes.
+    pub planes: Vec<DmaBufPlane>,
+    /// Optional DRM format modifier.
+    pub modifier: Option<u64>,
+    /// Capture timestamp in microseconds.
+    pub timestamp_us: i64,
+    /// Sensor timestamp translated to UNIX-epoch microseconds, when available.
+    pub sensor_timestamp_us: Option<u64>,
+}

--- a/livekit-capture/src/encoded.rs
+++ b/livekit-capture/src/encoded.rs
@@ -1,0 +1,536 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod h26x;
+pub mod ingress;
+pub mod rtp;
+
+use bytes::Bytes;
+use livekit::{
+    options::VideoCodec,
+    webrtc::video_frame::{
+        EncodedFrameType as RtcEncodedFrameType, EncodedVideoCodec as RtcEncodedVideoCodec,
+    },
+};
+
+use crate::error::CaptureError;
+
+const ANNEX_B_START_CODE: [u8; 4] = [0, 0, 0, 1];
+
+/// Encoder rate-control target requested by WebRTC for an encoded source.
+pub use livekit::webrtc::video_source::EncodedRateControl;
+
+/// Encoded byte-stream framing used by encoded source backends.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum EncodedWireFormat {
+    /// H.264 Annex-B byte stream.
+    H264AnnexB,
+    /// H.264/AVC byte stream with length-prefixed NAL units.
+    ///
+    /// `nal_length_size` is the number of big-endian length bytes before each NAL unit. Values
+    /// from 1 through 4 are accepted; 4 is the common AVC configuration.
+    H264Avc {
+        /// Length-prefix size in bytes.
+        nal_length_size: u8,
+    },
+    /// H.265 Annex-B byte stream.
+    H265AnnexB,
+    /// RTP packets for the supplied codec and RTP clock rate.
+    Rtp {
+        /// RTP payload codec.
+        codec: EncodedVideoCodec,
+        /// RTP timestamp clock rate.
+        clock_rate: u32,
+    },
+    /// MPEG transport stream carrying encoded video.
+    MpegTs,
+}
+
+/// Encoded video codec carried by an [`EncodedAccessUnit`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum EncodedVideoCodec {
+    /// H.264/AVC video.
+    H264,
+    /// H.265/HEVC video.
+    H265,
+    /// VP8 video.
+    VP8,
+    /// VP9 video.
+    VP9,
+    /// AV1 video.
+    AV1,
+}
+
+/// Encoded video frame type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EncodedFrameType {
+    /// A key frame.
+    Key,
+    /// A delta frame.
+    Delta,
+}
+
+/// Layer identifiers associated with an encoded frame.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct EncodedLayerInfo {
+    /// Spatial layer index, when present.
+    pub spatial_id: Option<u8>,
+    /// Temporal layer index, when present.
+    pub temporal_id: Option<u8>,
+}
+
+/// H.264 packetization mode for passthrough metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum H264PacketizationMode {
+    /// Non-interleaved packetization mode.
+    NonInterleaved,
+}
+
+/// Codec-specific metadata for encoded passthrough.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CodecSpecific {
+    /// No codec-specific metadata.
+    None,
+    /// H.264-specific metadata.
+    H264 {
+        /// H.264 RTP packetization mode.
+        packetization_mode: H264PacketizationMode,
+    },
+    /// H.265-specific metadata.
+    H265,
+    /// VP8-specific metadata.
+    VP8 {
+        /// Temporal layer index, when present.
+        temporal_id: Option<u8>,
+        /// Whether this frame synchronizes a temporal layer.
+        layer_sync: bool,
+    },
+    /// VP9-specific metadata.
+    VP9 {
+        /// Temporal layer index, when present.
+        temporal_id: Option<u8>,
+        /// Spatial layer index, when present.
+        spatial_id: Option<u8>,
+        /// Whether this frame depends on an inter-layer reference.
+        inter_layer_predicted: Option<bool>,
+    },
+    /// AV1-specific metadata.
+    AV1 {
+        /// RTP scalability mode, such as `L1T1`.
+        scalability_mode: Option<String>,
+        /// Encoded dependency descriptor bytes, when supplied by the caller.
+        dependency_descriptor: Option<Vec<u8>>,
+    },
+}
+
+impl Default for CodecSpecific {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+impl CodecSpecific {
+    /// Returns the single-layer default metadata for a codec, matching what
+    /// the passthrough encoder synthesizes on the wire.
+    pub fn default_for(codec: EncodedVideoCodec) -> Self {
+        match codec {
+            EncodedVideoCodec::H264 => {
+                Self::H264 { packetization_mode: H264PacketizationMode::NonInterleaved }
+            }
+            EncodedVideoCodec::H265 => Self::H265,
+            EncodedVideoCodec::VP8 => Self::VP8 { temporal_id: None, layer_sync: false },
+            EncodedVideoCodec::VP9 => {
+                Self::VP9 { temporal_id: None, spatial_id: None, inter_layer_predicted: None }
+            }
+            EncodedVideoCodec::AV1 => {
+                Self::AV1 { scalability_mode: Some("L1T1".to_owned()), dependency_descriptor: None }
+            }
+        }
+    }
+}
+
+/// Borrowed encoded payload fragment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EncodedFragment<'a> {
+    /// Encoded fragment bytes.
+    pub bytes: &'a [u8],
+}
+
+/// Encoded access-unit payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EncodedPayload<'a> {
+    /// One contiguous payload buffer.
+    Contiguous(&'a [u8]),
+    /// Multiple payload fragments.
+    Fragments(&'a [EncodedFragment<'a>]),
+    /// Owned payload bytes.
+    Owned(Vec<u8>),
+}
+
+impl EncodedPayload<'_> {
+    pub(crate) fn is_empty(&self) -> bool {
+        match self {
+            Self::Contiguous(bytes) => bytes.is_empty(),
+            Self::Fragments(fragments) => {
+                fragments.is_empty() || fragments.iter().any(|fragment| fragment.bytes.is_empty())
+            }
+            Self::Owned(bytes) => bytes.is_empty(),
+        }
+    }
+
+    pub(crate) fn to_vec(&self) -> Vec<u8> {
+        match self {
+            Self::Contiguous(bytes) => bytes.to_vec(),
+            Self::Fragments(fragments) => {
+                let len = fragments.iter().map(|fragment| fragment.bytes.len()).sum();
+                let mut payload = Vec::with_capacity(len);
+                for fragment in *fragments {
+                    payload.extend_from_slice(fragment.bytes);
+                }
+                payload
+            }
+            Self::Owned(bytes) => bytes.clone(),
+        }
+    }
+}
+
+/// One encoded video access unit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncodedAccessUnit<'a> {
+    /// Encoded codec.
+    pub codec: EncodedVideoCodec,
+    /// Encoded payload.
+    pub payload: EncodedPayload<'a>,
+    /// Capture timestamp in microseconds.
+    pub timestamp_us: i64,
+    /// Encoded frame type.
+    pub frame_type: EncodedFrameType,
+    /// Encoded frame width in pixels.
+    pub width: u32,
+    /// Encoded frame height in pixels.
+    pub height: u32,
+    /// Optional layer identifiers.
+    pub layers: EncodedLayerInfo,
+    /// Optional codec-specific metadata.
+    pub codec_specific: CodecSpecific,
+}
+
+/// Owned encoded video access unit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OwnedEncodedAccessUnit {
+    /// Encoded codec.
+    pub codec: EncodedVideoCodec,
+    /// Encoded payload bytes.
+    pub payload: Bytes,
+    /// Capture timestamp in microseconds.
+    pub timestamp_us: i64,
+    /// Encoded frame type.
+    pub frame_type: EncodedFrameType,
+    /// Encoded frame width in pixels.
+    pub width: u32,
+    /// Encoded frame height in pixels.
+    pub height: u32,
+    /// Optional layer identifiers.
+    pub layers: EncodedLayerInfo,
+    /// Optional codec-specific metadata.
+    pub codec_specific: CodecSpecific,
+}
+
+impl OwnedEncodedAccessUnit {
+    /// Creates an owned encoded access unit from contiguous bytes.
+    pub fn new(
+        codec: EncodedVideoCodec,
+        payload: impl Into<Bytes>,
+        timestamp_us: i64,
+        frame_type: EncodedFrameType,
+        width: u32,
+        height: u32,
+    ) -> Self {
+        Self {
+            codec,
+            payload: payload.into(),
+            timestamp_us,
+            frame_type,
+            width,
+            height,
+            layers: EncodedLayerInfo::default(),
+            codec_specific: CodecSpecific::None,
+        }
+    }
+
+    /// Borrows this owned access unit as an [`EncodedAccessUnit`].
+    pub fn as_access_unit(&self) -> EncodedAccessUnit<'_> {
+        EncodedAccessUnit {
+            codec: self.codec,
+            payload: EncodedPayload::Contiguous(&self.payload),
+            timestamp_us: self.timestamp_us,
+            frame_type: self.frame_type,
+            width: self.width,
+            height: self.height,
+            layers: self.layers,
+            codec_specific: self.codec_specific.clone(),
+        }
+    }
+
+    /// Creates an owned access unit by copying a borrowed access unit.
+    pub fn copy_from(access_unit: &EncodedAccessUnit<'_>) -> Self {
+        Self {
+            codec: access_unit.codec,
+            payload: Bytes::from(access_unit.payload.to_vec()),
+            timestamp_us: access_unit.timestamp_us,
+            frame_type: access_unit.frame_type,
+            width: access_unit.width,
+            height: access_unit.height,
+            layers: access_unit.layers,
+            codec_specific: access_unit.codec_specific.clone(),
+        }
+    }
+}
+
+impl<'a> EncodedAccessUnit<'a> {
+    /// Creates an access unit from one contiguous payload.
+    pub fn contiguous(
+        codec: EncodedVideoCodec,
+        payload: &'a [u8],
+        timestamp_us: i64,
+        frame_type: EncodedFrameType,
+        width: u32,
+        height: u32,
+    ) -> Self {
+        Self {
+            codec,
+            payload: EncodedPayload::Contiguous(payload),
+            timestamp_us,
+            frame_type,
+            width,
+            height,
+            layers: EncodedLayerInfo::default(),
+            codec_specific: CodecSpecific::None,
+        }
+    }
+
+    /// Creates an H.264 access unit from raw NAL-unit payloads.
+    pub fn from_h264_nalus(
+        nal_units: &[&[u8]],
+        timestamp_us: i64,
+        width: u32,
+        height: u32,
+    ) -> Result<EncodedAccessUnit<'static>, CaptureError> {
+        Self::from_nalus(EncodedVideoCodec::H264, nal_units, timestamp_us, width, height)
+    }
+
+    /// Creates an H.265 access unit from raw NAL-unit payloads.
+    pub fn from_h265_nalus(
+        nal_units: &[&[u8]],
+        timestamp_us: i64,
+        width: u32,
+        height: u32,
+    ) -> Result<EncodedAccessUnit<'static>, CaptureError> {
+        Self::from_nalus(EncodedVideoCodec::H265, nal_units, timestamp_us, width, height)
+    }
+
+    fn from_nalus(
+        codec: EncodedVideoCodec,
+        nal_units: &[&[u8]],
+        timestamp_us: i64,
+        width: u32,
+        height: u32,
+    ) -> Result<EncodedAccessUnit<'static>, CaptureError> {
+        let is_key = is_keyframe_nalus(codec, nal_units)?;
+        Ok(EncodedAccessUnit {
+            codec,
+            payload: EncodedPayload::Owned(annex_b_payload(nal_units)?),
+            timestamp_us,
+            frame_type: if is_key { EncodedFrameType::Key } else { EncodedFrameType::Delta },
+            width,
+            height,
+            layers: EncodedLayerInfo::default(),
+            codec_specific: CodecSpecific::default_for(codec),
+        })
+    }
+}
+
+/// Returns true when the NAL units form a WebRTC-usable key frame.
+pub(crate) fn is_keyframe_nalus(
+    codec: EncodedVideoCodec,
+    nal_units: &[&[u8]],
+) -> Result<bool, CaptureError> {
+    match codec {
+        EncodedVideoCodec::H264 => {
+            nal_units.iter().try_fold(false, |is_key, nal| Ok(is_key || h264_nal_type(nal)? == 5))
+        }
+        EncodedVideoCodec::H265 => {
+            let mut has_vps = false;
+            let mut has_sps = false;
+            let mut has_pps = false;
+            let mut has_idr = false;
+
+            for nal in nal_units {
+                match h265_nal_type(nal)? {
+                    32 => has_vps = true,
+                    33 => has_sps = true,
+                    34 => has_pps = true,
+                    19 | 20 => has_idr = true,
+                    _ => {}
+                }
+            }
+
+            Ok(has_vps && has_sps && has_pps && has_idr)
+        }
+        EncodedVideoCodec::VP8 | EncodedVideoCodec::VP9 | EncodedVideoCodec::AV1 => {
+            Err(CaptureError::UnsupportedCodec(codec))
+        }
+    }
+}
+
+impl From<EncodedVideoCodec> for VideoCodec {
+    fn from(value: EncodedVideoCodec) -> Self {
+        match value {
+            EncodedVideoCodec::H264 => Self::H264,
+            EncodedVideoCodec::H265 => Self::H265,
+            EncodedVideoCodec::VP8 => Self::VP8,
+            EncodedVideoCodec::VP9 => Self::VP9,
+            EncodedVideoCodec::AV1 => Self::AV1,
+        }
+    }
+}
+
+impl From<EncodedVideoCodec> for RtcEncodedVideoCodec {
+    fn from(value: EncodedVideoCodec) -> Self {
+        match value {
+            EncodedVideoCodec::H264 => Self::H264,
+            EncodedVideoCodec::H265 => Self::H265,
+            EncodedVideoCodec::VP8 => Self::VP8,
+            EncodedVideoCodec::VP9 => Self::VP9,
+            EncodedVideoCodec::AV1 => Self::AV1,
+        }
+    }
+}
+
+impl From<EncodedFrameType> for RtcEncodedFrameType {
+    fn from(value: EncodedFrameType) -> Self {
+        match value {
+            EncodedFrameType::Key => Self::Key,
+            EncodedFrameType::Delta => Self::Delta,
+        }
+    }
+}
+
+pub(crate) fn h264_nal_type(nal: &[u8]) -> Result<u8, CaptureError> {
+    let header = nal.first().ok_or(CaptureError::EmptyPayload)?;
+    Ok(header & 0x1f)
+}
+
+pub(crate) fn h265_nal_type(nal: &[u8]) -> Result<u8, CaptureError> {
+    if nal.is_empty() {
+        return Err(CaptureError::EmptyPayload);
+    }
+    if nal.len() < 2 {
+        return Err(CaptureError::H265NalTooShort);
+    }
+    Ok((nal[0] >> 1) & 0x3f)
+}
+
+pub(crate) fn annex_b_payload(nal_units: &[&[u8]]) -> Result<Vec<u8>, CaptureError> {
+    if nal_units.is_empty() {
+        return Err(CaptureError::EmptyPayload);
+    }
+    let len = nal_units.iter().try_fold(0usize, |len, nal| {
+        if nal.is_empty() {
+            Err(CaptureError::EmptyPayload)
+        } else {
+            Ok(len + ANNEX_B_START_CODE.len() + nal.len())
+        }
+    })?;
+
+    let mut payload = Vec::with_capacity(len);
+    for nal in nal_units {
+        payload.extend_from_slice(&ANNEX_B_START_CODE);
+        payload.extend_from_slice(nal);
+    }
+    Ok(payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn h264_nal_helper_assembles_annex_b_and_detects_keyframe() {
+        let sps = [0x67, 1, 2, 3];
+        let idr = [0x65, 4, 5, 6];
+        let au = EncodedAccessUnit::from_h264_nalus(&[&sps, &idr], 10, 640, 480).unwrap();
+
+        assert_eq!(au.codec, EncodedVideoCodec::H264);
+        assert_eq!(au.frame_type, EncodedFrameType::Key);
+        assert_eq!(
+            au.payload,
+            EncodedPayload::Owned(vec![0, 0, 0, 1, 0x67, 1, 2, 3, 0, 0, 0, 1, 0x65, 4, 5, 6])
+        );
+    }
+
+    #[test]
+    fn h265_nal_helper_requires_parameter_sets_and_idr_keyframe() {
+        let vps = [0x40, 1, 2];
+        let sps = [0x42, 1, 2];
+        let pps = [0x44, 1, 2];
+        let idr_w_radl = [19 << 1, 1, 3];
+        let idr_without_headers =
+            EncodedAccessUnit::from_h265_nalus(&[&vps, &idr_w_radl], 10, 640, 480).unwrap();
+        let key =
+            EncodedAccessUnit::from_h265_nalus(&[&vps, &sps, &pps, &idr_w_radl], 10, 640, 480)
+                .unwrap();
+        let cra = [21 << 1, 1, 3];
+        let cra_with_headers =
+            EncodedAccessUnit::from_h265_nalus(&[&vps, &sps, &pps, &cra], 10, 640, 480).unwrap();
+
+        assert_eq!(idr_without_headers.codec, EncodedVideoCodec::H265);
+        assert_eq!(idr_without_headers.frame_type, EncodedFrameType::Delta);
+        assert_eq!(key.frame_type, EncodedFrameType::Key);
+        assert_eq!(cra_with_headers.frame_type, EncodedFrameType::Delta);
+    }
+
+    #[test]
+    fn h265_rejects_too_short_nal_header() {
+        let err = EncodedAccessUnit::from_h265_nalus(&[&[0x26]], 10, 640, 480).unwrap_err();
+        assert_eq!(err, CaptureError::H265NalTooShort);
+    }
+
+    #[test]
+    fn fragments_reject_empty_fragment() {
+        let fragments = [EncodedFragment { bytes: &[1] }, EncodedFragment { bytes: &[] }];
+        let payload = EncodedPayload::Fragments(&fragments);
+        assert!(payload.is_empty());
+    }
+
+    #[test]
+    fn owned_access_unit_borrows_without_copying_payload() {
+        let owned = OwnedEncodedAccessUnit::new(
+            EncodedVideoCodec::H264,
+            Bytes::from_static(&[1, 2, 3]),
+            10,
+            EncodedFrameType::Delta,
+            640,
+            480,
+        );
+
+        let borrowed = owned.as_access_unit();
+        assert_eq!(borrowed.codec, EncodedVideoCodec::H264);
+        assert_eq!(borrowed.payload, EncodedPayload::Contiguous(&[1, 2, 3]));
+        assert_eq!(borrowed.timestamp_us, 10);
+    }
+}

--- a/livekit-capture/src/encoded.rs
+++ b/livekit-capture/src/encoded.rs
@@ -24,7 +24,7 @@ use livekit::{
     },
 };
 
-use crate::error::CaptureError;
+use crate::{error::CaptureError, primitives::VideoResolution};
 
 const ANNEX_B_START_CODE: [u8; 4] = [0, 0, 0, 1];
 
@@ -219,10 +219,8 @@ pub struct EncodedAccessUnit<'a> {
     pub timestamp_us: i64,
     /// Encoded frame type.
     pub frame_type: EncodedFrameType,
-    /// Encoded frame width in pixels.
-    pub width: u32,
-    /// Encoded frame height in pixels.
-    pub height: u32,
+    /// Encoded frame dimensions in pixels.
+    pub dimensions: VideoResolution,
     /// Optional layer identifiers.
     pub layers: EncodedLayerInfo,
     /// Optional codec-specific metadata.
@@ -240,10 +238,8 @@ pub struct OwnedEncodedAccessUnit {
     pub timestamp_us: i64,
     /// Encoded frame type.
     pub frame_type: EncodedFrameType,
-    /// Encoded frame width in pixels.
-    pub width: u32,
-    /// Encoded frame height in pixels.
-    pub height: u32,
+    /// Encoded frame dimensions in pixels.
+    pub dimensions: VideoResolution,
     /// Optional layer identifiers.
     pub layers: EncodedLayerInfo,
     /// Optional codec-specific metadata.
@@ -257,16 +253,14 @@ impl OwnedEncodedAccessUnit {
         payload: impl Into<Bytes>,
         timestamp_us: i64,
         frame_type: EncodedFrameType,
-        width: u32,
-        height: u32,
+        dimensions: VideoResolution,
     ) -> Self {
         Self {
             codec,
             payload: payload.into(),
             timestamp_us,
             frame_type,
-            width,
-            height,
+            dimensions,
             layers: EncodedLayerInfo::default(),
             codec_specific: CodecSpecific::None,
         }
@@ -279,8 +273,7 @@ impl OwnedEncodedAccessUnit {
             payload: EncodedPayload::Contiguous(&self.payload),
             timestamp_us: self.timestamp_us,
             frame_type: self.frame_type,
-            width: self.width,
-            height: self.height,
+            dimensions: self.dimensions,
             layers: self.layers,
             codec_specific: self.codec_specific.clone(),
         }
@@ -293,8 +286,7 @@ impl OwnedEncodedAccessUnit {
             payload: Bytes::from(access_unit.payload.to_vec()),
             timestamp_us: access_unit.timestamp_us,
             frame_type: access_unit.frame_type,
-            width: access_unit.width,
-            height: access_unit.height,
+            dimensions: access_unit.dimensions,
             layers: access_unit.layers,
             codec_specific: access_unit.codec_specific.clone(),
         }
@@ -308,16 +300,14 @@ impl<'a> EncodedAccessUnit<'a> {
         payload: &'a [u8],
         timestamp_us: i64,
         frame_type: EncodedFrameType,
-        width: u32,
-        height: u32,
+        dimensions: VideoResolution,
     ) -> Self {
         Self {
             codec,
             payload: EncodedPayload::Contiguous(payload),
             timestamp_us,
             frame_type,
-            width,
-            height,
+            dimensions,
             layers: EncodedLayerInfo::default(),
             codec_specific: CodecSpecific::None,
         }
@@ -327,28 +317,25 @@ impl<'a> EncodedAccessUnit<'a> {
     pub fn from_h264_nalus(
         nal_units: &[&[u8]],
         timestamp_us: i64,
-        width: u32,
-        height: u32,
+        dimensions: VideoResolution,
     ) -> Result<EncodedAccessUnit<'static>, CaptureError> {
-        Self::from_nalus(EncodedVideoCodec::H264, nal_units, timestamp_us, width, height)
+        Self::from_nalus(EncodedVideoCodec::H264, nal_units, timestamp_us, dimensions)
     }
 
     /// Creates an H.265 access unit from raw NAL-unit payloads.
     pub fn from_h265_nalus(
         nal_units: &[&[u8]],
         timestamp_us: i64,
-        width: u32,
-        height: u32,
+        dimensions: VideoResolution,
     ) -> Result<EncodedAccessUnit<'static>, CaptureError> {
-        Self::from_nalus(EncodedVideoCodec::H265, nal_units, timestamp_us, width, height)
+        Self::from_nalus(EncodedVideoCodec::H265, nal_units, timestamp_us, dimensions)
     }
 
     fn from_nalus(
         codec: EncodedVideoCodec,
         nal_units: &[&[u8]],
         timestamp_us: i64,
-        width: u32,
-        height: u32,
+        dimensions: VideoResolution,
     ) -> Result<EncodedAccessUnit<'static>, CaptureError> {
         let is_key = is_keyframe_nalus(codec, nal_units)?;
         Ok(EncodedAccessUnit {
@@ -356,8 +343,7 @@ impl<'a> EncodedAccessUnit<'a> {
             payload: EncodedPayload::Owned(annex_b_payload(nal_units)?),
             timestamp_us,
             frame_type: if is_key { EncodedFrameType::Key } else { EncodedFrameType::Delta },
-            width,
-            height,
+            dimensions,
             layers: EncodedLayerInfo::default(),
             codec_specific: CodecSpecific::default_for(codec),
         })
@@ -473,7 +459,9 @@ mod tests {
     fn h264_nal_helper_assembles_annex_b_and_detects_keyframe() {
         let sps = [0x67, 1, 2, 3];
         let idr = [0x65, 4, 5, 6];
-        let au = EncodedAccessUnit::from_h264_nalus(&[&sps, &idr], 10, 640, 480).unwrap();
+        let au =
+            EncodedAccessUnit::from_h264_nalus(&[&sps, &idr], 10, VideoResolution::new(640, 480))
+                .unwrap();
 
         assert_eq!(au.codec, EncodedVideoCodec::H264);
         assert_eq!(au.frame_type, EncodedFrameType::Key);
@@ -489,14 +477,25 @@ mod tests {
         let sps = [0x42, 1, 2];
         let pps = [0x44, 1, 2];
         let idr_w_radl = [19 << 1, 1, 3];
-        let idr_without_headers =
-            EncodedAccessUnit::from_h265_nalus(&[&vps, &idr_w_radl], 10, 640, 480).unwrap();
-        let key =
-            EncodedAccessUnit::from_h265_nalus(&[&vps, &sps, &pps, &idr_w_radl], 10, 640, 480)
-                .unwrap();
+        let idr_without_headers = EncodedAccessUnit::from_h265_nalus(
+            &[&vps, &idr_w_radl],
+            10,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
+        let key = EncodedAccessUnit::from_h265_nalus(
+            &[&vps, &sps, &pps, &idr_w_radl],
+            10,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let cra = [21 << 1, 1, 3];
-        let cra_with_headers =
-            EncodedAccessUnit::from_h265_nalus(&[&vps, &sps, &pps, &cra], 10, 640, 480).unwrap();
+        let cra_with_headers = EncodedAccessUnit::from_h265_nalus(
+            &[&vps, &sps, &pps, &cra],
+            10,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
 
         assert_eq!(idr_without_headers.codec, EncodedVideoCodec::H265);
         assert_eq!(idr_without_headers.frame_type, EncodedFrameType::Delta);
@@ -506,7 +505,9 @@ mod tests {
 
     #[test]
     fn h265_rejects_too_short_nal_header() {
-        let err = EncodedAccessUnit::from_h265_nalus(&[&[0x26]], 10, 640, 480).unwrap_err();
+        let err =
+            EncodedAccessUnit::from_h265_nalus(&[&[0x26]], 10, VideoResolution::new(640, 480))
+                .unwrap_err();
         assert_eq!(err, CaptureError::H265NalTooShort);
     }
 
@@ -524,8 +525,7 @@ mod tests {
             Bytes::from_static(&[1, 2, 3]),
             10,
             EncodedFrameType::Delta,
-            640,
-            480,
+            VideoResolution::new(640, 480),
         );
 
         let borrowed = owned.as_access_unit();

--- a/livekit-capture/src/encoded/h26x.rs
+++ b/livekit-capture/src/encoded/h26x.rs
@@ -22,6 +22,7 @@ use crate::{
         EncodedFrameType, EncodedVideoCodec, OwnedEncodedAccessUnit,
     },
     error::CaptureError,
+    primitives::VideoResolution,
 };
 
 /// Upper bound on bytes buffered while waiting for an access-unit boundary.
@@ -57,8 +58,7 @@ pub struct AnnexBAccessUnitParser {
     scan_cursor: usize,
     next_timestamp_us: i64,
     frame_interval_us: i64,
-    width: u32,
-    height: u32,
+    dimensions: VideoResolution,
 }
 
 /// H.264/AVC length-prefixed parser state.
@@ -72,8 +72,7 @@ pub(crate) struct AvcAccessUnitParser {
     nal_length_size: u8,
     next_timestamp_us: i64,
     frame_interval_us: i64,
-    width: u32,
-    height: u32,
+    dimensions: VideoResolution,
 }
 
 impl AnnexBAccessUnitParser {
@@ -82,8 +81,7 @@ impl AnnexBAccessUnitParser {
         codec: EncodedVideoCodec,
         start_timestamp_us: i64,
         frame_interval_us: i64,
-        width: u32,
-        height: u32,
+        dimensions: VideoResolution,
     ) -> Result<Self, CaptureError> {
         match codec {
             EncodedVideoCodec::H264 | EncodedVideoCodec::H265 => {}
@@ -99,8 +97,7 @@ impl AnnexBAccessUnitParser {
             scan_cursor: 0,
             next_timestamp_us: start_timestamp_us,
             frame_interval_us,
-            width,
-            height,
+            dimensions,
         })
     }
 
@@ -186,8 +183,7 @@ impl AnnexBAccessUnitParser {
             self.codec,
             Bytes::from(access_unit),
             timestamp_us,
-            self.width,
-            self.height,
+            self.dimensions,
         )
         .map(Some)
     }
@@ -209,8 +205,7 @@ impl AvcAccessUnitParser {
         nal_length_size: u8,
         start_timestamp_us: i64,
         frame_interval_us: i64,
-        width: u32,
-        height: u32,
+        dimensions: VideoResolution,
     ) -> Result<Self, CaptureError> {
         validate_avc_nal_length_size(nal_length_size)?;
 
@@ -221,8 +216,7 @@ impl AvcAccessUnitParser {
             nal_length_size,
             next_timestamp_us: start_timestamp_us,
             frame_interval_us,
-            width,
-            height,
+            dimensions,
         })
     }
 
@@ -315,14 +309,8 @@ impl AvcAccessUnitParser {
         self.scan_cursor -= byte_len;
         let timestamp_us = self.next_timestamp_us;
         self.next_timestamp_us = self.next_timestamp_us.saturating_add(self.frame_interval_us);
-        access_unit_from_h264_avc(
-            &access_unit,
-            self.nal_length_size,
-            timestamp_us,
-            self.width,
-            self.height,
-        )
-        .map(Some)
+        access_unit_from_h264_avc(&access_unit, self.nal_length_size, timestamp_us, self.dimensions)
+            .map(Some)
     }
 }
 
@@ -377,11 +365,10 @@ pub(crate) fn access_unit_from_h264_avc(
     payload: &[u8],
     nal_length_size: u8,
     timestamp_us: i64,
-    width: u32,
-    height: u32,
+    dimensions: VideoResolution,
 ) -> Result<OwnedEncodedAccessUnit, CaptureError> {
     let nals = avc_nalus(payload, nal_length_size)?;
-    access_unit_from_nalus(EncodedVideoCodec::H264, &nals, timestamp_us, width, height)
+    access_unit_from_nalus(EncodedVideoCodec::H264, &nals, timestamp_us, dimensions)
 }
 
 /// Creates an access unit from an Annex-B buffer.
@@ -389,8 +376,7 @@ pub fn access_unit_from_annex_b(
     codec: EncodedVideoCodec,
     payload: Bytes,
     timestamp_us: i64,
-    width: u32,
-    height: u32,
+    dimensions: VideoResolution,
 ) -> Result<OwnedEncodedAccessUnit, CaptureError> {
     if payload.is_empty() {
         return Err(CaptureError::EmptyPayload);
@@ -402,7 +388,7 @@ pub fn access_unit_from_annex_b(
         EncodedFrameType::Delta
     };
     let mut access_unit =
-        OwnedEncodedAccessUnit::new(codec, payload, timestamp_us, frame_type, width, height);
+        OwnedEncodedAccessUnit::new(codec, payload, timestamp_us, frame_type, dimensions);
     access_unit.codec_specific = CodecSpecific::default_for(codec);
     Ok(access_unit)
 }
@@ -412,11 +398,10 @@ pub fn access_unit_from_nalus(
     codec: EncodedVideoCodec,
     nal_units: &[&[u8]],
     timestamp_us: i64,
-    width: u32,
-    height: u32,
+    dimensions: VideoResolution,
 ) -> Result<OwnedEncodedAccessUnit, CaptureError> {
     let payload = Bytes::from(annex_b_payload(nal_units)?);
-    access_unit_from_annex_b(codec, payload, timestamp_us, width, height)
+    access_unit_from_annex_b(codec, payload, timestamp_us, dimensions)
 }
 
 /// Returns true when an Annex-B access unit contains an intra/key picture.
@@ -623,7 +608,7 @@ mod tests {
     #[test]
     fn access_unit_from_avc_converts_length_prefixed_nals() {
         let bytes = [0, 0, 0, 4, 0x67, 1, 2, 3, 0, 0, 0, 3, 0x65, 4, 5];
-        let au = access_unit_from_h264_avc(&bytes, 4, 10, 640, 480).unwrap();
+        let au = access_unit_from_h264_avc(&bytes, 4, 10, VideoResolution::new(640, 480)).unwrap();
 
         assert_eq!(au.codec, EncodedVideoCodec::H264);
         assert_eq!(au.frame_type, EncodedFrameType::Key);
@@ -633,7 +618,7 @@ mod tests {
     #[test]
     fn access_unit_from_avc_supports_two_byte_lengths() {
         let bytes = [0, 2, 0x61, 1];
-        let au = access_unit_from_h264_avc(&bytes, 2, 10, 640, 480).unwrap();
+        let au = access_unit_from_h264_avc(&bytes, 2, 10, VideoResolution::new(640, 480)).unwrap();
 
         assert_eq!(au.frame_type, EncodedFrameType::Delta);
         assert_eq!(au.payload.as_ref(), &[0, 0, 0, 1, 0x61, 1]);
@@ -641,15 +626,22 @@ mod tests {
 
     #[test]
     fn access_unit_from_avc_rejects_truncated_nal() {
-        let err = access_unit_from_h264_avc(&[0, 0, 0, 3, 0x65], 4, 10, 640, 480).unwrap_err();
+        let err =
+            access_unit_from_h264_avc(&[0, 0, 0, 3, 0x65], 4, 10, VideoResolution::new(640, 480))
+                .unwrap_err();
 
         assert_eq!(err, CaptureError::InvalidEncodedData("truncated AVC NAL unit"));
     }
 
     #[test]
     fn parser_flushes_final_access_unit() {
-        let mut parser =
-            AnnexBAccessUnitParser::new(EncodedVideoCodec::H264, 100, 33_333, 640, 480).unwrap();
+        let mut parser = AnnexBAccessUnitParser::new(
+            EncodedVideoCodec::H264,
+            100,
+            33_333,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         assert!(parser.push(&[0, 0, 1, 0x65, 1, 2]).unwrap().is_none());
         let au = parser.flush().unwrap().unwrap();
         assert_eq!(au.timestamp_us, 100);
@@ -658,8 +650,13 @@ mod tests {
 
     #[test]
     fn parser_splits_at_next_access_unit_delimiter() {
-        let mut parser =
-            AnnexBAccessUnitParser::new(EncodedVideoCodec::H264, 100, 33_333, 640, 480).unwrap();
+        let mut parser = AnnexBAccessUnitParser::new(
+            EncodedVideoCodec::H264,
+            100,
+            33_333,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let stream =
             [0, 0, 1, 0x09, 0x10, 0, 0, 1, 0x65, 1, 2, 0, 0, 1, 0x09, 0x10, 0, 0, 1, 0x41, 3];
 
@@ -674,7 +671,8 @@ mod tests {
 
     #[test]
     fn avc_parser_splits_at_next_access_unit_delimiter() {
-        let mut parser = AvcAccessUnitParser::new(4, 100, 33_333, 640, 480).unwrap();
+        let mut parser =
+            AvcAccessUnitParser::new(4, 100, 33_333, VideoResolution::new(640, 480)).unwrap();
         let stream = [
             0, 0, 0, 2, 0x09, 0x10, 0, 0, 0, 3, 0x65, 1, 2, 0, 0, 0, 2, 0x09, 0x10, 0, 0, 0, 2,
             0x41, 3,
@@ -691,8 +689,13 @@ mod tests {
 
     #[test]
     fn splits_aud_less_h264_stream_per_frame() {
-        let mut parser =
-            AnnexBAccessUnitParser::new(EncodedVideoCodec::H264, 0, 33_333, 640, 480).unwrap();
+        let mut parser = AnnexBAccessUnitParser::new(
+            EncodedVideoCodec::H264,
+            0,
+            33_333,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let stream = [
             0, 0, 0, 1, 0x67, 0x42, 0x00, 0x1e, // SPS
             0, 0, 0, 1, 0x68, 0xce, // PPS
@@ -718,8 +721,13 @@ mod tests {
 
     #[test]
     fn keeps_multi_slice_h264_access_unit_together() {
-        let mut parser =
-            AnnexBAccessUnitParser::new(EncodedVideoCodec::H264, 0, 33_333, 640, 480).unwrap();
+        let mut parser = AnnexBAccessUnitParser::new(
+            EncodedVideoCodec::H264,
+            0,
+            33_333,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let stream = [
             0, 0, 1, 0x65, 0x88, 0x11, // IDR slice, first_mb_in_slice == 0
             0, 0, 1, 0x65, 0x21, 0x22, // IDR slice, first_mb_in_slice != 0
@@ -738,8 +746,13 @@ mod tests {
 
     #[test]
     fn splits_aud_less_h265_stream_per_frame() {
-        let mut parser =
-            AnnexBAccessUnitParser::new(EncodedVideoCodec::H265, 0, 33_333, 640, 480).unwrap();
+        let mut parser = AnnexBAccessUnitParser::new(
+            EncodedVideoCodec::H265,
+            0,
+            33_333,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let stream = [
             0, 0, 0, 1, 0x40, 0x01, 0x0c, // VPS
             0, 0, 0, 1, 0x42, 0x01, 0x02, // SPS
@@ -762,8 +775,13 @@ mod tests {
 
     #[test]
     fn keeps_multi_slice_h265_access_unit_together() {
-        let mut parser =
-            AnnexBAccessUnitParser::new(EncodedVideoCodec::H265, 0, 33_333, 640, 480).unwrap();
+        let mut parser = AnnexBAccessUnitParser::new(
+            EncodedVideoCodec::H265,
+            0,
+            33_333,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let stream = [
             0, 0, 1, 0x26, 0x01, 0xaf,
             0x11, // IDR slice, first_slice_segment_in_pic_flag == 1
@@ -784,8 +802,13 @@ mod tests {
 
     #[test]
     fn groups_parameter_sets_with_following_frame() {
-        let mut parser =
-            AnnexBAccessUnitParser::new(EncodedVideoCodec::H264, 0, 33_333, 640, 480).unwrap();
+        let mut parser = AnnexBAccessUnitParser::new(
+            EncodedVideoCodec::H264,
+            0,
+            33_333,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let stream = [
             0, 0, 1, 0x67, 0x42, 0x1e, // SPS
             0, 0, 1, 0x68, 0xce, // PPS
@@ -851,7 +874,15 @@ mod tests {
             0, 0, 0, 1, 0x41, 0x9a, 0x04, 0x00, // P, first_mb_in_slice == 0
         ];
         assert_chunked_matches_one_shot(
-            || AnnexBAccessUnitParser::new(EncodedVideoCodec::H264, 0, 33_333, 640, 480).unwrap(),
+            || {
+                AnnexBAccessUnitParser::new(
+                    EncodedVideoCodec::H264,
+                    0,
+                    33_333,
+                    VideoResolution::new(640, 480),
+                )
+                .unwrap()
+            },
             &h264_annex_b,
             4,
         );
@@ -866,7 +897,15 @@ mod tests {
             0, 0, 1, 0x02, 0x01, 0xd0, 0x0a, // TRAIL_R
         ];
         assert_chunked_matches_one_shot(
-            || AnnexBAccessUnitParser::new(EncodedVideoCodec::H265, 0, 33_333, 640, 480).unwrap(),
+            || {
+                AnnexBAccessUnitParser::new(
+                    EncodedVideoCodec::H265,
+                    0,
+                    33_333,
+                    VideoResolution::new(640, 480),
+                )
+                .unwrap()
+            },
             &h265_annex_b,
             3,
         );
@@ -880,7 +919,7 @@ mod tests {
             0, 0, 0, 3, 0x41, 0x9a, 0x03, // P
         ];
         assert_chunked_matches_one_shot(
-            || AvcAccessUnitParser::new(4, 0, 33_333, 640, 480).unwrap(),
+            || AvcAccessUnitParser::new(4, 0, 33_333, VideoResolution::new(640, 480)).unwrap(),
             &h264_avc,
             3,
         );
@@ -888,8 +927,13 @@ mod tests {
 
     #[test]
     fn rejects_pending_access_unit_over_size_cap() {
-        let mut parser =
-            AnnexBAccessUnitParser::new(EncodedVideoCodec::H264, 0, 33_333, 640, 480).unwrap();
+        let mut parser = AnnexBAccessUnitParser::new(
+            EncodedVideoCodec::H264,
+            0,
+            33_333,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         assert!(parser.push(&[0, 0, 1, 0x65, 0x88]).unwrap().is_none());
 
         let err = parser.push(&vec![0xff; MAX_PENDING_ACCESS_UNIT_BYTES]).unwrap_err();
@@ -901,7 +945,8 @@ mod tests {
 
     #[test]
     fn avc_rejects_pending_access_unit_over_size_cap() {
-        let mut parser = AvcAccessUnitParser::new(4, 0, 33_333, 640, 480).unwrap();
+        let mut parser =
+            AvcAccessUnitParser::new(4, 0, 33_333, VideoResolution::new(640, 480)).unwrap();
         let nal_len = (MAX_PENDING_ACCESS_UNIT_BYTES + 1) as u32;
         assert!(parser.push(&nal_len.to_be_bytes()).unwrap().is_none());
 

--- a/livekit-capture/src/encoded/h26x.rs
+++ b/livekit-capture/src/encoded/h26x.rs
@@ -1,0 +1,914 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::Range;
+
+use bytes::Bytes;
+
+use crate::{
+    encoded::{
+        annex_b_payload, h264_nal_type, h265_nal_type, is_keyframe_nalus, CodecSpecific,
+        EncodedFrameType, EncodedVideoCodec, OwnedEncodedAccessUnit,
+    },
+    error::CaptureError,
+};
+
+/// Upper bound on bytes buffered while waiting for an access-unit boundary.
+const MAX_PENDING_ACCESS_UNIT_BYTES: usize = 32 * 1024 * 1024;
+
+/// Byte-stream access-unit parser shared by the encoded ingest sources.
+///
+/// `push` appends bytes and returns at most one completed access unit; call
+/// `drain` repeatedly to pull further access units already buffered, and
+/// `flush` once at end of stream to emit the final pending access unit.
+pub(crate) trait AccessUnitParser {
+    /// Appends bytes and returns the next complete access unit, if any.
+    fn push(&mut self, bytes: &[u8]) -> Result<Option<OwnedEncodedAccessUnit>, CaptureError>;
+
+    /// Returns the next complete access unit from already-buffered bytes.
+    fn drain(&mut self) -> Result<Option<OwnedEncodedAccessUnit>, CaptureError> {
+        self.push(&[])
+    }
+
+    /// Flushes remaining buffered bytes as the final access unit.
+    fn flush(&mut self) -> Result<Option<OwnedEncodedAccessUnit>, CaptureError>;
+}
+
+/// H26x Annex-B parser state.
+#[derive(Debug, Clone)]
+pub struct AnnexBAccessUnitParser {
+    codec: EncodedVideoCodec,
+    pending: Vec<u8>,
+    /// NAL ranges found in `pending`; the last range's end is provisional
+    /// until the next start code (or flush) confirms it.
+    nal_ranges: Vec<Range<usize>>,
+    /// Offset up to which `pending` has been scanned for start codes.
+    scan_cursor: usize,
+    next_timestamp_us: i64,
+    frame_interval_us: i64,
+    width: u32,
+    height: u32,
+}
+
+/// H.264/AVC length-prefixed parser state.
+#[derive(Debug, Clone)]
+pub(crate) struct AvcAccessUnitParser {
+    pending: Vec<u8>,
+    /// Complete NAL ranges found in `pending`.
+    nal_ranges: Vec<Range<usize>>,
+    /// Offset of the first unparsed length prefix or incomplete NAL in `pending`.
+    scan_cursor: usize,
+    nal_length_size: u8,
+    next_timestamp_us: i64,
+    frame_interval_us: i64,
+    width: u32,
+    height: u32,
+}
+
+impl AnnexBAccessUnitParser {
+    /// Creates a parser for H.264 or H.265 Annex-B byte streams.
+    pub fn new(
+        codec: EncodedVideoCodec,
+        start_timestamp_us: i64,
+        frame_interval_us: i64,
+        width: u32,
+        height: u32,
+    ) -> Result<Self, CaptureError> {
+        match codec {
+            EncodedVideoCodec::H264 | EncodedVideoCodec::H265 => {}
+            EncodedVideoCodec::VP8 | EncodedVideoCodec::VP9 | EncodedVideoCodec::AV1 => {
+                return Err(CaptureError::UnsupportedCodec(codec));
+            }
+        }
+
+        Ok(Self {
+            codec,
+            pending: Vec::new(),
+            nal_ranges: Vec::new(),
+            scan_cursor: 0,
+            next_timestamp_us: start_timestamp_us,
+            frame_interval_us,
+            width,
+            height,
+        })
+    }
+
+    /// Pushes encoded bytes and returns the next complete access unit if one is found.
+    pub fn push(&mut self, bytes: &[u8]) -> Result<Option<OwnedEncodedAccessUnit>, CaptureError> {
+        self.pending.extend_from_slice(bytes);
+        self.drain_next(false)
+    }
+
+    /// Flushes the pending bytes as the final access unit.
+    pub fn flush(&mut self) -> Result<Option<OwnedEncodedAccessUnit>, CaptureError> {
+        self.drain_next(true)
+    }
+
+    fn drain_next(&mut self, at_eof: bool) -> Result<Option<OwnedEncodedAccessUnit>, CaptureError> {
+        self.scan_pending();
+
+        if let Some(split_at) =
+            access_unit_split_index(self.codec, &self.pending, &self.nal_ranges)?
+        {
+            return self.take_access_unit(split_at);
+        }
+        if at_eof && self.nal_ranges.iter().any(|range| range.start < range.end) {
+            return self.take_access_unit(self.pending.len());
+        }
+        if !at_eof && self.pending.len() > MAX_PENDING_ACCESS_UNIT_BYTES {
+            return Err(CaptureError::InvalidEncodedData(
+                "access unit exceeds maximum buffered size",
+            ));
+        }
+        Ok(None)
+    }
+
+    /// Scans bytes appended since the previous call, extending the cached NAL ranges.
+    fn scan_pending(&mut self) {
+        // Resume behind the previous scan end so a start code straddling the
+        // boundary is found, but never before the last NAL start so an
+        // already-found start code is not rediscovered.
+        let mut cursor = self.scan_cursor.saturating_sub(3);
+        if let Some(last) = self.nal_ranges.last() {
+            cursor = cursor.max(last.start);
+        }
+        while let Some((offset, prefix_len)) = find_start_code(&self.pending[cursor..]) {
+            let prefix_start = cursor + offset;
+            let nal_start = prefix_start + prefix_len;
+            if let Some(last) = self.nal_ranges.last_mut() {
+                last.end = prefix_start;
+                if last.start >= prefix_start {
+                    self.nal_ranges.pop();
+                }
+            }
+            self.nal_ranges.push(nal_start..nal_start);
+            cursor = nal_start;
+        }
+        if let Some(last) = self.nal_ranges.last_mut() {
+            last.end = self.pending.len();
+        }
+        self.scan_cursor = self.pending.len();
+    }
+
+    fn take_access_unit(
+        &mut self,
+        byte_len: usize,
+    ) -> Result<Option<OwnedEncodedAccessUnit>, CaptureError> {
+        if byte_len == 0 {
+            return Ok(None);
+        }
+
+        let access_unit = self.pending[..byte_len].to_vec();
+        self.pending.drain(..byte_len);
+        self.nal_ranges.retain_mut(|range| {
+            if range.end <= byte_len {
+                return false;
+            }
+            range.start -= byte_len;
+            range.end -= byte_len;
+            true
+        });
+        self.scan_cursor -= byte_len;
+        let timestamp_us = self.next_timestamp_us;
+        self.next_timestamp_us = self.next_timestamp_us.saturating_add(self.frame_interval_us);
+        access_unit_from_annex_b(
+            self.codec,
+            Bytes::from(access_unit),
+            timestamp_us,
+            self.width,
+            self.height,
+        )
+        .map(Some)
+    }
+}
+
+impl AccessUnitParser for AnnexBAccessUnitParser {
+    fn push(&mut self, bytes: &[u8]) -> Result<Option<OwnedEncodedAccessUnit>, CaptureError> {
+        AnnexBAccessUnitParser::push(self, bytes)
+    }
+
+    fn flush(&mut self) -> Result<Option<OwnedEncodedAccessUnit>, CaptureError> {
+        AnnexBAccessUnitParser::flush(self)
+    }
+}
+
+impl AvcAccessUnitParser {
+    /// Creates a parser for H.264/AVC length-prefixed byte streams.
+    pub(crate) fn new(
+        nal_length_size: u8,
+        start_timestamp_us: i64,
+        frame_interval_us: i64,
+        width: u32,
+        height: u32,
+    ) -> Result<Self, CaptureError> {
+        validate_avc_nal_length_size(nal_length_size)?;
+
+        Ok(Self {
+            pending: Vec::new(),
+            nal_ranges: Vec::new(),
+            scan_cursor: 0,
+            nal_length_size,
+            next_timestamp_us: start_timestamp_us,
+            frame_interval_us,
+            width,
+            height,
+        })
+    }
+
+    /// Pushes encoded bytes and returns the next complete access unit if one is found.
+    pub(crate) fn push(
+        &mut self,
+        bytes: &[u8],
+    ) -> Result<Option<OwnedEncodedAccessUnit>, CaptureError> {
+        self.pending.extend_from_slice(bytes);
+        self.drain_next(false)
+    }
+
+    /// Flushes the pending bytes as the final access unit.
+    pub(crate) fn flush(&mut self) -> Result<Option<OwnedEncodedAccessUnit>, CaptureError> {
+        self.drain_next(true)
+    }
+
+    fn drain_next(&mut self, at_eof: bool) -> Result<Option<OwnedEncodedAccessUnit>, CaptureError> {
+        self.scan_pending(at_eof)?;
+
+        if let Some(split_at) = avc_access_unit_split_index(
+            &self.pending,
+            &self.nal_ranges,
+            self.nal_length_size as usize,
+        )? {
+            return self.take_access_unit(split_at);
+        }
+        if at_eof && !self.nal_ranges.is_empty() {
+            return self.take_access_unit(self.pending.len());
+        }
+        if !at_eof && self.pending.len() > MAX_PENDING_ACCESS_UNIT_BYTES {
+            return Err(CaptureError::InvalidEncodedData(
+                "access unit exceeds maximum buffered size",
+            ));
+        }
+        Ok(None)
+    }
+
+    /// Parses length-prefixed NAL units appended since the previous call.
+    fn scan_pending(&mut self, at_eof: bool) -> Result<(), CaptureError> {
+        let nal_length_size = self.nal_length_size as usize;
+        while self.scan_cursor < self.pending.len() {
+            if self.pending.len() - self.scan_cursor < nal_length_size {
+                if at_eof {
+                    return Err(CaptureError::InvalidEncodedData("truncated AVC NAL length"));
+                }
+                break;
+            }
+
+            let nal_start = self.scan_cursor + nal_length_size;
+            let nal_len = read_avc_nal_length(&self.pending[self.scan_cursor..nal_start]);
+            if nal_len == 0 {
+                return Err(CaptureError::InvalidEncodedData("empty AVC NAL unit"));
+            }
+
+            let Some(nal_end) = nal_start.checked_add(nal_len) else {
+                return Err(CaptureError::InvalidEncodedData("AVC NAL unit length overflow"));
+            };
+            if nal_end > self.pending.len() {
+                if at_eof {
+                    return Err(CaptureError::InvalidEncodedData("truncated AVC NAL unit"));
+                }
+                break;
+            }
+
+            self.nal_ranges.push(nal_start..nal_end);
+            self.scan_cursor = nal_end;
+        }
+        Ok(())
+    }
+
+    fn take_access_unit(
+        &mut self,
+        byte_len: usize,
+    ) -> Result<Option<OwnedEncodedAccessUnit>, CaptureError> {
+        if byte_len == 0 {
+            return Ok(None);
+        }
+
+        let access_unit = self.pending[..byte_len].to_vec();
+        self.pending.drain(..byte_len);
+        self.nal_ranges.retain_mut(|range| {
+            if range.end <= byte_len {
+                return false;
+            }
+            range.start -= byte_len;
+            range.end -= byte_len;
+            true
+        });
+        self.scan_cursor -= byte_len;
+        let timestamp_us = self.next_timestamp_us;
+        self.next_timestamp_us = self.next_timestamp_us.saturating_add(self.frame_interval_us);
+        access_unit_from_h264_avc(
+            &access_unit,
+            self.nal_length_size,
+            timestamp_us,
+            self.width,
+            self.height,
+        )
+        .map(Some)
+    }
+}
+
+impl AccessUnitParser for AvcAccessUnitParser {
+    fn push(&mut self, bytes: &[u8]) -> Result<Option<OwnedEncodedAccessUnit>, CaptureError> {
+        AvcAccessUnitParser::push(self, bytes)
+    }
+
+    fn flush(&mut self) -> Result<Option<OwnedEncodedAccessUnit>, CaptureError> {
+        AvcAccessUnitParser::flush(self)
+    }
+}
+
+/// Returns NAL-unit byte ranges for an Annex-B access unit or stream chunk.
+pub fn annex_b_nal_ranges(bytes: &[u8]) -> Vec<Range<usize>> {
+    let mut ranges = Vec::new();
+    let mut cursor = 0;
+    let mut current_start = None;
+
+    while let Some((prefix_start, prefix_len)) = find_start_code(&bytes[cursor..]) {
+        let prefix_start = cursor + prefix_start;
+        let nal_start = prefix_start + prefix_len;
+        if let Some(start) = current_start.replace(nal_start) {
+            if start < prefix_start {
+                ranges.push(start..prefix_start);
+            }
+        }
+        cursor = nal_start;
+    }
+
+    if let Some(start) = current_start {
+        if start < bytes.len() {
+            ranges.push(start..bytes.len());
+        }
+    }
+
+    ranges
+}
+
+/// Returns borrowed NAL units from an Annex-B buffer.
+pub fn annex_b_nalus(bytes: &[u8]) -> Result<Vec<&[u8]>, CaptureError> {
+    let nals = annex_b_nal_ranges(bytes)
+        .into_iter()
+        .map(|range| &bytes[range])
+        .filter(|nal| !nal.is_empty())
+        .collect::<Vec<_>>();
+    Ok(nals)
+}
+
+/// Creates an Annex-B access unit from H.264/AVC length-prefixed NAL units.
+pub(crate) fn access_unit_from_h264_avc(
+    payload: &[u8],
+    nal_length_size: u8,
+    timestamp_us: i64,
+    width: u32,
+    height: u32,
+) -> Result<OwnedEncodedAccessUnit, CaptureError> {
+    let nals = avc_nalus(payload, nal_length_size)?;
+    access_unit_from_nalus(EncodedVideoCodec::H264, &nals, timestamp_us, width, height)
+}
+
+/// Creates an access unit from an Annex-B buffer.
+pub fn access_unit_from_annex_b(
+    codec: EncodedVideoCodec,
+    payload: Bytes,
+    timestamp_us: i64,
+    width: u32,
+    height: u32,
+) -> Result<OwnedEncodedAccessUnit, CaptureError> {
+    if payload.is_empty() {
+        return Err(CaptureError::EmptyPayload);
+    }
+
+    let frame_type = if is_keyframe_annex_b(codec, &payload)? {
+        EncodedFrameType::Key
+    } else {
+        EncodedFrameType::Delta
+    };
+    let mut access_unit =
+        OwnedEncodedAccessUnit::new(codec, payload, timestamp_us, frame_type, width, height);
+    access_unit.codec_specific = CodecSpecific::default_for(codec);
+    Ok(access_unit)
+}
+
+/// Creates an Annex-B access unit from raw NAL units.
+pub fn access_unit_from_nalus(
+    codec: EncodedVideoCodec,
+    nal_units: &[&[u8]],
+    timestamp_us: i64,
+    width: u32,
+    height: u32,
+) -> Result<OwnedEncodedAccessUnit, CaptureError> {
+    let payload = Bytes::from(annex_b_payload(nal_units)?);
+    access_unit_from_annex_b(codec, payload, timestamp_us, width, height)
+}
+
+/// Returns true when an Annex-B access unit contains an intra/key picture.
+pub fn is_keyframe_annex_b(codec: EncodedVideoCodec, bytes: &[u8]) -> Result<bool, CaptureError> {
+    let nals = annex_b_nalus(bytes)?;
+    is_keyframe_nalus(codec, &nals)
+}
+
+fn access_unit_split_index(
+    codec: EncodedVideoCodec,
+    bytes: &[u8],
+    ranges: &[Range<usize>],
+) -> Result<Option<usize>, CaptureError> {
+    match access_unit_boundary_nal(codec, bytes, ranges)? {
+        Some(index) => split_start_code_index(bytes, ranges[index].start).map(Some),
+        None => Ok(None),
+    }
+}
+
+fn avc_access_unit_split_index(
+    bytes: &[u8],
+    ranges: &[Range<usize>],
+    nal_length_size: usize,
+) -> Result<Option<usize>, CaptureError> {
+    match access_unit_boundary_nal(EncodedVideoCodec::H264, bytes, ranges)? {
+        Some(index) => ranges[index]
+            .start
+            .checked_sub(nal_length_size)
+            .ok_or(CaptureError::InvalidEncodedData("missing AVC NAL length"))
+            .map(Some),
+        None => Ok(None),
+    }
+}
+
+/// Returns the index of the first NAL that starts a new access unit, once at
+/// least one VCL NAL has been seen in the current one.
+fn access_unit_boundary_nal(
+    codec: EncodedVideoCodec,
+    bytes: &[u8],
+    ranges: &[Range<usize>],
+) -> Result<Option<usize>, CaptureError> {
+    let mut seen_vcl = false;
+    for (index, range) in ranges.iter().enumerate() {
+        let nal = &bytes[range.clone()];
+        // The final NAL may still be streaming in; wait for its header.
+        if index + 1 == ranges.len() && nal.len() < min_nal_header_len(codec) {
+            return Ok(None);
+        }
+        if seen_vcl && starts_new_access_unit(codec, nal)? {
+            return Ok(Some(index));
+        }
+        seen_vcl |= is_vcl_nal(codec, nal)?;
+    }
+    Ok(None)
+}
+
+fn min_nal_header_len(codec: EncodedVideoCodec) -> usize {
+    match codec {
+        EncodedVideoCodec::H265 => 2,
+        _ => 1,
+    }
+}
+
+fn starts_new_access_unit(codec: EncodedVideoCodec, nal: &[u8]) -> Result<bool, CaptureError> {
+    Ok(match codec {
+        EncodedVideoCodec::H264 => match h264_nal_type(nal)? {
+            // Prefix SEI(6), SPS(7), PPS(8), and AUD(9) open a new access unit.
+            6..=9 => true,
+            // A VCL NAL opens a new picture when first_mb_in_slice == 0:
+            // ue(v) == 0 is a lone 1 bit, so the first RBSP bit after the
+            // header is set. The header byte is nonzero, so the next byte
+            // cannot be an emulation-prevention byte.
+            1..=5 => nal.len() >= 2 && nal[1] & 0x80 != 0,
+            _ => false,
+        },
+        EncodedVideoCodec::H265 => match h265_nal_type(nal)? {
+            // VPS(32), SPS(33), PPS(34), AUD(35), and prefix SEI(39).
+            32..=35 | 39 => true,
+            // A VCL NAL opens a new picture when
+            // first_slice_segment_in_pic_flag (the bit after the 2-byte
+            // header) is set. nuh_temporal_id_plus1 makes the second header
+            // byte nonzero, so the next byte cannot be an
+            // emulation-prevention byte.
+            0..=31 => nal.len() >= 3 && nal[2] & 0x80 != 0,
+            _ => false,
+        },
+        EncodedVideoCodec::VP8 | EncodedVideoCodec::VP9 | EncodedVideoCodec::AV1 => {
+            return Err(CaptureError::UnsupportedCodec(codec));
+        }
+    })
+}
+
+fn split_start_code_index(bytes: &[u8], nal_start: usize) -> Result<usize, CaptureError> {
+    if nal_start >= 4 && bytes[nal_start - 4..nal_start] == [0, 0, 0, 1] {
+        return Ok(nal_start - 4);
+    }
+    if nal_start >= 3 && bytes[nal_start - 3..nal_start] == [0, 0, 1] {
+        return Ok(nal_start - 3);
+    }
+    Err(CaptureError::InvalidEncodedData("missing Annex-B start code"))
+}
+
+fn is_vcl_nal(codec: EncodedVideoCodec, nal: &[u8]) -> Result<bool, CaptureError> {
+    Ok(match codec {
+        EncodedVideoCodec::H264 => (1..=5).contains(&h264_nal_type(nal)?),
+        EncodedVideoCodec::H265 => h265_nal_type(nal)? <= 31,
+        EncodedVideoCodec::VP8 | EncodedVideoCodec::VP9 | EncodedVideoCodec::AV1 => {
+            return Err(CaptureError::UnsupportedCodec(codec));
+        }
+    })
+}
+
+fn find_start_code(bytes: &[u8]) -> Option<(usize, usize)> {
+    let mut idx = 0;
+    while idx + 3 <= bytes.len() {
+        if bytes[idx..].starts_with(&[0, 0, 1]) {
+            return Some((idx, 3));
+        }
+        if idx + 4 <= bytes.len() && bytes[idx..].starts_with(&[0, 0, 0, 1]) {
+            return Some((idx, 4));
+        }
+        idx += 1;
+    }
+    None
+}
+
+fn avc_nalus(payload: &[u8], nal_length_size: u8) -> Result<Vec<&[u8]>, CaptureError> {
+    let ranges = avc_nal_ranges(payload, nal_length_size, true)?;
+    if ranges.is_empty() {
+        return Err(CaptureError::EmptyPayload);
+    }
+    Ok(ranges.into_iter().map(|range| &payload[range]).collect())
+}
+
+fn avc_nal_ranges(
+    bytes: &[u8],
+    nal_length_size: u8,
+    at_eof: bool,
+) -> Result<Vec<Range<usize>>, CaptureError> {
+    validate_avc_nal_length_size(nal_length_size)?;
+
+    let nal_length_size = nal_length_size as usize;
+    let mut ranges = Vec::new();
+    let mut cursor = 0;
+    while cursor < bytes.len() {
+        if bytes.len() - cursor < nal_length_size {
+            if at_eof {
+                return Err(CaptureError::InvalidEncodedData("truncated AVC NAL length"));
+            }
+            break;
+        }
+
+        let nal_len = read_avc_nal_length(&bytes[cursor..cursor + nal_length_size]);
+        cursor += nal_length_size;
+        if nal_len == 0 {
+            return Err(CaptureError::InvalidEncodedData("empty AVC NAL unit"));
+        }
+
+        let Some(nal_end) = cursor.checked_add(nal_len) else {
+            return Err(CaptureError::InvalidEncodedData("AVC NAL unit length overflow"));
+        };
+        if nal_end > bytes.len() {
+            if at_eof {
+                return Err(CaptureError::InvalidEncodedData("truncated AVC NAL unit"));
+            }
+            break;
+        }
+
+        ranges.push(cursor..nal_end);
+        cursor = nal_end;
+    }
+
+    Ok(ranges)
+}
+
+fn read_avc_nal_length(bytes: &[u8]) -> usize {
+    bytes.iter().fold(0usize, |len, byte| (len << 8) | usize::from(*byte))
+}
+
+fn validate_avc_nal_length_size(nal_length_size: u8) -> Result<(), CaptureError> {
+    if (1..=4).contains(&nal_length_size) {
+        return Ok(());
+    }
+    Err(CaptureError::InvalidEncodedData("invalid AVC NAL length size"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_annex_b_nals_with_three_and_four_byte_prefixes() {
+        let bytes = [0, 0, 1, 0x67, 1, 0, 0, 0, 1, 0x65, 2, 3];
+        let nals = annex_b_nalus(&bytes).unwrap();
+        assert_eq!(nals, vec![&[0x67, 1][..], &[0x65, 2, 3][..]]);
+    }
+
+    #[test]
+    fn detects_h264_keyframe_from_annex_b() {
+        let bytes = [0, 0, 0, 1, 0x61, 1, 0, 0, 0, 1, 0x65, 2];
+        assert!(is_keyframe_annex_b(EncodedVideoCodec::H264, &bytes).unwrap());
+    }
+
+    #[test]
+    fn access_unit_from_avc_converts_length_prefixed_nals() {
+        let bytes = [0, 0, 0, 4, 0x67, 1, 2, 3, 0, 0, 0, 3, 0x65, 4, 5];
+        let au = access_unit_from_h264_avc(&bytes, 4, 10, 640, 480).unwrap();
+
+        assert_eq!(au.codec, EncodedVideoCodec::H264);
+        assert_eq!(au.frame_type, EncodedFrameType::Key);
+        assert_eq!(au.payload.as_ref(), &[0, 0, 0, 1, 0x67, 1, 2, 3, 0, 0, 0, 1, 0x65, 4, 5]);
+    }
+
+    #[test]
+    fn access_unit_from_avc_supports_two_byte_lengths() {
+        let bytes = [0, 2, 0x61, 1];
+        let au = access_unit_from_h264_avc(&bytes, 2, 10, 640, 480).unwrap();
+
+        assert_eq!(au.frame_type, EncodedFrameType::Delta);
+        assert_eq!(au.payload.as_ref(), &[0, 0, 0, 1, 0x61, 1]);
+    }
+
+    #[test]
+    fn access_unit_from_avc_rejects_truncated_nal() {
+        let err = access_unit_from_h264_avc(&[0, 0, 0, 3, 0x65], 4, 10, 640, 480).unwrap_err();
+
+        assert_eq!(err, CaptureError::InvalidEncodedData("truncated AVC NAL unit"));
+    }
+
+    #[test]
+    fn parser_flushes_final_access_unit() {
+        let mut parser =
+            AnnexBAccessUnitParser::new(EncodedVideoCodec::H264, 100, 33_333, 640, 480).unwrap();
+        assert!(parser.push(&[0, 0, 1, 0x65, 1, 2]).unwrap().is_none());
+        let au = parser.flush().unwrap().unwrap();
+        assert_eq!(au.timestamp_us, 100);
+        assert_eq!(au.frame_type, EncodedFrameType::Key);
+    }
+
+    #[test]
+    fn parser_splits_at_next_access_unit_delimiter() {
+        let mut parser =
+            AnnexBAccessUnitParser::new(EncodedVideoCodec::H264, 100, 33_333, 640, 480).unwrap();
+        let stream =
+            [0, 0, 1, 0x09, 0x10, 0, 0, 1, 0x65, 1, 2, 0, 0, 1, 0x09, 0x10, 0, 0, 1, 0x41, 3];
+
+        let au = parser.push(&stream).unwrap().unwrap();
+        assert_eq!(au.timestamp_us, 100);
+        assert_eq!(au.payload.as_ref(), &[0, 0, 1, 0x09, 0x10, 0, 0, 1, 0x65, 1, 2]);
+
+        let au = parser.flush().unwrap().unwrap();
+        assert_eq!(au.timestamp_us, 33_433);
+        assert_eq!(au.payload.as_ref(), &[0, 0, 1, 0x09, 0x10, 0, 0, 1, 0x41, 3]);
+    }
+
+    #[test]
+    fn avc_parser_splits_at_next_access_unit_delimiter() {
+        let mut parser = AvcAccessUnitParser::new(4, 100, 33_333, 640, 480).unwrap();
+        let stream = [
+            0, 0, 0, 2, 0x09, 0x10, 0, 0, 0, 3, 0x65, 1, 2, 0, 0, 0, 2, 0x09, 0x10, 0, 0, 0, 2,
+            0x41, 3,
+        ];
+
+        let au = parser.push(&stream).unwrap().unwrap();
+        assert_eq!(au.timestamp_us, 100);
+        assert_eq!(au.payload.as_ref(), &[0, 0, 0, 1, 0x09, 0x10, 0, 0, 0, 1, 0x65, 1, 2]);
+
+        let au = parser.flush().unwrap().unwrap();
+        assert_eq!(au.timestamp_us, 33_433);
+        assert_eq!(au.payload.as_ref(), &[0, 0, 0, 1, 0x09, 0x10, 0, 0, 0, 1, 0x41, 3]);
+    }
+
+    #[test]
+    fn splits_aud_less_h264_stream_per_frame() {
+        let mut parser =
+            AnnexBAccessUnitParser::new(EncodedVideoCodec::H264, 0, 33_333, 640, 480).unwrap();
+        let stream = [
+            0, 0, 0, 1, 0x67, 0x42, 0x00, 0x1e, // SPS
+            0, 0, 0, 1, 0x68, 0xce, // PPS
+            0, 0, 1, 0x65, 0x88, 0x84, 0x21, // IDR slice, first_mb_in_slice == 0
+            0, 0, 1, 0x41, 0x9a, 0x22, // P slice, first_mb_in_slice == 0
+            0, 0, 1, 0x41, 0x9a, 0x33, // P slice, first_mb_in_slice == 0
+        ];
+
+        let au = parser.push(&stream).unwrap().unwrap();
+        assert_eq!(au.timestamp_us, 0);
+        assert_eq!(au.frame_type, EncodedFrameType::Key);
+        assert_eq!(au.payload.as_ref(), &stream[..21]);
+
+        let au = parser.drain().unwrap().unwrap();
+        assert_eq!(au.timestamp_us, 33_333);
+        assert_eq!(au.frame_type, EncodedFrameType::Delta);
+        assert_eq!(au.payload.as_ref(), &stream[21..27]);
+
+        let au = parser.flush().unwrap().unwrap();
+        assert_eq!(au.timestamp_us, 66_666);
+        assert_eq!(au.payload.as_ref(), &stream[27..]);
+    }
+
+    #[test]
+    fn keeps_multi_slice_h264_access_unit_together() {
+        let mut parser =
+            AnnexBAccessUnitParser::new(EncodedVideoCodec::H264, 0, 33_333, 640, 480).unwrap();
+        let stream = [
+            0, 0, 1, 0x65, 0x88, 0x11, // IDR slice, first_mb_in_slice == 0
+            0, 0, 1, 0x65, 0x21, 0x22, // IDR slice, first_mb_in_slice != 0
+            0, 0, 1, 0x41, 0x9a, 0x33, // next picture
+        ];
+
+        let au = parser.push(&stream).unwrap().unwrap();
+        assert_eq!(au.timestamp_us, 0);
+        assert_eq!(au.frame_type, EncodedFrameType::Key);
+        assert_eq!(au.payload.as_ref(), &stream[..12]);
+
+        let au = parser.flush().unwrap().unwrap();
+        assert_eq!(au.timestamp_us, 33_333);
+        assert_eq!(au.payload.as_ref(), &stream[12..]);
+    }
+
+    #[test]
+    fn splits_aud_less_h265_stream_per_frame() {
+        let mut parser =
+            AnnexBAccessUnitParser::new(EncodedVideoCodec::H265, 0, 33_333, 640, 480).unwrap();
+        let stream = [
+            0, 0, 0, 1, 0x40, 0x01, 0x0c, // VPS
+            0, 0, 0, 1, 0x42, 0x01, 0x02, // SPS
+            0, 0, 0, 1, 0x44, 0x01, 0x03, // PPS
+            0, 0, 1, 0x26, 0x01, 0xaf,
+            0x04, // IDR_W_RADL, first_slice_segment_in_pic_flag == 1
+            0, 0, 1, 0x02, 0x01, 0xd0, 0x05, // TRAIL_R, first_slice_segment_in_pic_flag == 1
+        ];
+
+        let au = parser.push(&stream).unwrap().unwrap();
+        assert_eq!(au.timestamp_us, 0);
+        assert_eq!(au.frame_type, EncodedFrameType::Key);
+        assert_eq!(au.payload.as_ref(), &stream[..28]);
+
+        let au = parser.flush().unwrap().unwrap();
+        assert_eq!(au.timestamp_us, 33_333);
+        assert_eq!(au.frame_type, EncodedFrameType::Delta);
+        assert_eq!(au.payload.as_ref(), &stream[28..]);
+    }
+
+    #[test]
+    fn keeps_multi_slice_h265_access_unit_together() {
+        let mut parser =
+            AnnexBAccessUnitParser::new(EncodedVideoCodec::H265, 0, 33_333, 640, 480).unwrap();
+        let stream = [
+            0, 0, 1, 0x26, 0x01, 0xaf,
+            0x11, // IDR slice, first_slice_segment_in_pic_flag == 1
+            0, 0, 1, 0x26, 0x01, 0x40,
+            0x22, // IDR slice, first_slice_segment_in_pic_flag == 0
+            0, 0, 1, 0x02, 0x01, 0xd0, 0x33, // next picture
+        ];
+
+        let au = parser.push(&stream).unwrap().unwrap();
+        assert_eq!(au.timestamp_us, 0);
+        assert_eq!(au.frame_type, EncodedFrameType::Delta);
+        assert_eq!(au.payload.as_ref(), &stream[..14]);
+
+        let au = parser.flush().unwrap().unwrap();
+        assert_eq!(au.timestamp_us, 33_333);
+        assert_eq!(au.payload.as_ref(), &stream[14..]);
+    }
+
+    #[test]
+    fn groups_parameter_sets_with_following_frame() {
+        let mut parser =
+            AnnexBAccessUnitParser::new(EncodedVideoCodec::H264, 0, 33_333, 640, 480).unwrap();
+        let stream = [
+            0, 0, 1, 0x67, 0x42, 0x1e, // SPS
+            0, 0, 1, 0x68, 0xce, // PPS
+            0, 0, 1, 0x65, 0x88, 0x11, // IDR
+            0, 0, 1, 0x67, 0x42, 0x1e, // SPS
+            0, 0, 1, 0x68, 0xce, // PPS
+            0, 0, 1, 0x65, 0x88, 0x22, // IDR
+        ];
+
+        let au = parser.push(&stream).unwrap().unwrap();
+        assert_eq!(au.timestamp_us, 0);
+        assert_eq!(au.frame_type, EncodedFrameType::Key);
+        assert_eq!(au.payload.as_ref(), &stream[..17]);
+
+        let au = parser.flush().unwrap().unwrap();
+        assert_eq!(au.timestamp_us, 33_333);
+        assert_eq!(au.frame_type, EncodedFrameType::Key);
+        assert_eq!(au.payload.as_ref(), &stream[17..]);
+    }
+
+    fn collect_units(
+        parser: &mut impl AccessUnitParser,
+        stream: &[u8],
+        chunk_size: usize,
+    ) -> Vec<(Vec<u8>, i64, EncodedFrameType)> {
+        let mut units = Vec::new();
+        for chunk in stream.chunks(chunk_size) {
+            let mut unit = parser.push(chunk).unwrap();
+            while let Some(au) = unit {
+                units.push((au.payload.to_vec(), au.timestamp_us, au.frame_type));
+                unit = parser.drain().unwrap();
+            }
+        }
+        let mut unit = parser.flush().unwrap();
+        while let Some(au) = unit {
+            units.push((au.payload.to_vec(), au.timestamp_us, au.frame_type));
+            unit = parser.flush().unwrap();
+        }
+        units
+    }
+
+    fn assert_chunked_matches_one_shot<P: AccessUnitParser>(
+        make_parser: impl Fn() -> P,
+        stream: &[u8],
+        expected_units: usize,
+    ) {
+        let baseline = collect_units(&mut make_parser(), stream, stream.len());
+        assert_eq!(baseline.len(), expected_units);
+        for chunk_size in [1, 7] {
+            assert_eq!(collect_units(&mut make_parser(), stream, chunk_size), baseline);
+        }
+    }
+
+    #[test]
+    fn chunked_pushes_match_one_shot_parsing() {
+        let h264_annex_b = [
+            0, 0, 0, 1, 0x67, 0x64, 0x00, 0x1e, // SPS
+            0, 0, 0, 1, 0x68, 0xce, 0x3c, 0x80, // PPS
+            0, 0, 1, 0x65, 0x88, 0x84, 0x00, 0x01, // IDR, first_mb_in_slice == 0
+            0, 0, 1, 0x41, 0x9a, 0x02, // P, first_mb_in_slice == 0
+            0, 0, 1, 0x09, 0x10, // AUD
+            0, 0, 1, 0x41, 0x9a, 0x03, // P
+            0, 0, 0, 1, 0x41, 0x9a, 0x04, 0x00, // P, first_mb_in_slice == 0
+        ];
+        assert_chunked_matches_one_shot(
+            || AnnexBAccessUnitParser::new(EncodedVideoCodec::H264, 0, 33_333, 640, 480).unwrap(),
+            &h264_annex_b,
+            4,
+        );
+
+        let h265_annex_b = [
+            0, 0, 0, 1, 0x40, 0x01, 0x0c, // VPS
+            0, 0, 0, 1, 0x42, 0x01, 0x02, // SPS
+            0, 0, 0, 1, 0x44, 0x01, 0x03, // PPS
+            0, 0, 1, 0x26, 0x01, 0xaf, 0x08, // IDR_W_RADL
+            0, 0, 1, 0x02, 0x01, 0xd0, 0x09, // TRAIL_R
+            0, 0, 1, 0x46, 0x01, 0x50, // AUD
+            0, 0, 1, 0x02, 0x01, 0xd0, 0x0a, // TRAIL_R
+        ];
+        assert_chunked_matches_one_shot(
+            || AnnexBAccessUnitParser::new(EncodedVideoCodec::H265, 0, 33_333, 640, 480).unwrap(),
+            &h265_annex_b,
+            3,
+        );
+
+        let h264_avc = [
+            0, 0, 0, 4, 0x67, 0x64, 0x00, 0x1e, // SPS
+            0, 0, 0, 2, 0x68, 0xce, // PPS
+            0, 0, 0, 4, 0x65, 0x88, 0x84, 0x00, // IDR, first_mb_in_slice == 0
+            0, 0, 0, 3, 0x41, 0x9a, 0x02, // P, first_mb_in_slice == 0
+            0, 0, 0, 2, 0x09, 0x10, // AUD
+            0, 0, 0, 3, 0x41, 0x9a, 0x03, // P
+        ];
+        assert_chunked_matches_one_shot(
+            || AvcAccessUnitParser::new(4, 0, 33_333, 640, 480).unwrap(),
+            &h264_avc,
+            3,
+        );
+    }
+
+    #[test]
+    fn rejects_pending_access_unit_over_size_cap() {
+        let mut parser =
+            AnnexBAccessUnitParser::new(EncodedVideoCodec::H264, 0, 33_333, 640, 480).unwrap();
+        assert!(parser.push(&[0, 0, 1, 0x65, 0x88]).unwrap().is_none());
+
+        let err = parser.push(&vec![0xff; MAX_PENDING_ACCESS_UNIT_BYTES]).unwrap_err();
+        assert_eq!(
+            err,
+            CaptureError::InvalidEncodedData("access unit exceeds maximum buffered size")
+        );
+    }
+
+    #[test]
+    fn avc_rejects_pending_access_unit_over_size_cap() {
+        let mut parser = AvcAccessUnitParser::new(4, 0, 33_333, 640, 480).unwrap();
+        let nal_len = (MAX_PENDING_ACCESS_UNIT_BYTES + 1) as u32;
+        assert!(parser.push(&nal_len.to_be_bytes()).unwrap().is_none());
+
+        let err = parser.push(&vec![0x41; MAX_PENDING_ACCESS_UNIT_BYTES]).unwrap_err();
+        assert_eq!(
+            err,
+            CaptureError::InvalidEncodedData("access unit exceeds maximum buffered size")
+        );
+    }
+}

--- a/livekit-capture/src/encoded/ingress.rs
+++ b/livekit-capture/src/encoded/ingress.rs
@@ -21,12 +21,12 @@ use std::{
     },
 };
 
-use livekit::webrtc::video_frame::FrameMetadata;
+use livekit::webrtc::{video_frame::FrameMetadata, video_source::native::NativeVideoSource};
 
 use crate::{
     encoded::{EncodedFrameType, EncodedRateControl, OwnedEncodedAccessUnit},
     error::CaptureError,
-    track::VideoCaptureTrack,
+    track::NativeVideoSourceExt,
 };
 
 /// Source of owned encoded access units.
@@ -109,16 +109,21 @@ impl EncodedIngressStop {
 /// Pulls encoded access units from a source and forwards them into a video track.
 #[derive(Debug)]
 pub struct EncodedIngress<S> {
-    track: VideoCaptureTrack,
-    source: S,
+    rtc_source: NativeVideoSource,
+    capture_source: S,
     stop: EncodedIngressStop,
     awaiting_initial_keyframe: bool,
 }
 
 impl<S> EncodedIngress<S> {
     /// Creates an encoded ingress runner.
-    pub fn new(track: VideoCaptureTrack, source: S) -> Self {
-        Self { track, source, stop: EncodedIngressStop::new(), awaiting_initial_keyframe: true }
+    pub fn new(rtc_source: NativeVideoSource, capture_source: S) -> Self {
+        Self {
+            rtc_source,
+            capture_source,
+            stop: EncodedIngressStop::new(),
+            awaiting_initial_keyframe: true,
+        }
     }
 
     /// Returns a cancellation handle for this runner.
@@ -126,24 +131,24 @@ impl<S> EncodedIngress<S> {
         self.stop.clone()
     }
 
-    /// Returns the capture track used by this runner.
-    pub fn track(&self) -> &VideoCaptureTrack {
-        &self.track
+    /// Returns the RTC source used by this runner.
+    pub fn rtc_source(&self) -> &NativeVideoSource {
+        &self.rtc_source
     }
 
     /// Returns the underlying encoded source.
     pub fn source(&self) -> &S {
-        &self.source
+        &self.capture_source
     }
 
     /// Returns the underlying encoded source mutably.
     pub fn source_mut(&mut self) -> &mut S {
-        &mut self.source
+        &mut self.capture_source
     }
 
     /// Consumes this runner and returns its parts.
-    pub fn into_parts(self) -> (VideoCaptureTrack, S) {
-        (self.track, self.source)
+    pub fn into_parts(self) -> (NativeVideoSource, S) {
+        (self.rtc_source, self.capture_source)
     }
 }
 
@@ -182,16 +187,16 @@ where
         &mut self,
         frame_metadata: impl FnOnce(&OwnedEncodedAccessUnit) -> Option<FrameMetadata>,
     ) -> Result<Option<EncodedIngressCapture>, EncodedIngressError<S::Error>> {
-        if let Some(rate_control) = self.track.take_rate_control_request() {
-            self.source.update_rate_control(rate_control);
+        if let Some(rate_control) = self.rtc_source.take_rate_control_request() {
+            self.capture_source.update_rate_control(rate_control);
         }
-        if self.track.take_keyframe_request() {
-            self.source.request_keyframe();
+        if self.rtc_source.take_keyframe_request() {
+            self.capture_source.request_keyframe();
         }
 
         let access_unit = loop {
             let Some(access_unit) =
-                self.source.next_access_unit().map_err(EncodedIngressError::Source)?
+                self.capture_source.next_access_unit().map_err(EncodedIngressError::Source)?
             else {
                 return Ok(None);
             };
@@ -203,7 +208,7 @@ where
         };
 
         let frame_metadata = frame_metadata(&access_unit);
-        self.track
+        self.rtc_source
             .capture_encoded_with_metadata(&access_unit.as_access_unit(), frame_metadata)
             .map_err(EncodedIngressError::Capture)?;
         Ok(Some(EncodedIngressCapture {
@@ -274,8 +279,8 @@ mod tests {
         )
     }
 
-    fn encoded_track() -> VideoCaptureTrack {
-        VideoCaptureTrack::new_encoded("test", VideoResolution { width: 640, height: 480 })
+    fn rtc_source() -> NativeVideoSource {
+        NativeVideoSource::new_encoded(VideoResolution { width: 640, height: 480 })
     }
 
     #[test]
@@ -285,7 +290,7 @@ mod tests {
             access_unit(2, EncodedFrameType::Delta),
             access_unit(3, EncodedFrameType::Key),
         ]);
-        let mut ingress = EncodedIngress::new(encoded_track(), source);
+        let mut ingress = EncodedIngress::new(rtc_source(), source);
 
         let capture = ingress
             .capture_next()
@@ -302,7 +307,7 @@ mod tests {
             access_unit(1, EncodedFrameType::Key),
             access_unit(2, EncodedFrameType::Delta),
         ]);
-        let mut ingress = EncodedIngress::new(encoded_track(), source);
+        let mut ingress = EncodedIngress::new(rtc_source(), source);
 
         let first = ingress.capture_next().unwrap().unwrap();
         let second = ingress.capture_next().unwrap().unwrap();

--- a/livekit-capture/src/encoded/ingress.rs
+++ b/livekit-capture/src/encoded/ingress.rs
@@ -233,10 +233,8 @@ where
 mod tests {
     use std::{collections::VecDeque, error::Error, fmt};
 
-    use livekit::webrtc::video_source::VideoResolution;
-
     use super::*;
-    use crate::encoded::EncodedVideoCodec;
+    use crate::{encoded::EncodedVideoCodec, primitives::VideoResolution};
 
     #[derive(Debug)]
     struct FakeSourceError;
@@ -274,13 +272,12 @@ mod tests {
             vec![1, 2, 3],
             timestamp_us,
             frame_type,
-            640,
-            480,
+            VideoResolution::new(640, 480),
         )
     }
 
     fn rtc_source() -> NativeVideoSource {
-        NativeVideoSource::new_encoded(VideoResolution { width: 640, height: 480 })
+        NativeVideoSource::new_encoded(VideoResolution::new(640, 480).into())
     }
 
     #[test]

--- a/livekit-capture/src/encoded/ingress.rs
+++ b/livekit-capture/src/encoded/ingress.rs
@@ -1,0 +1,314 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    error::Error,
+    fmt,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
+
+use livekit::webrtc::video_frame::FrameMetadata;
+
+use crate::{
+    encoded::{EncodedFrameType, EncodedRateControl, OwnedEncodedAccessUnit},
+    error::CaptureError,
+    track::VideoCaptureTrack,
+};
+
+/// Source of owned encoded access units.
+pub trait EncodedAccessUnitSource {
+    /// Error returned by the source.
+    type Error: Error + Send + Sync + 'static;
+
+    /// Returns the next encoded access unit, or `Ok(None)` when the source reaches EOF.
+    fn next_access_unit(&mut self) -> Result<Option<OwnedEncodedAccessUnit>, Self::Error>;
+
+    /// Forwards a downstream keyframe request (PLI/FIR, late subscriber) to
+    /// the producer so it can emit an IDR.
+    ///
+    /// The default implementation does nothing, for transports that cannot
+    /// influence the upstream encoder.
+    fn request_keyframe(&mut self) {}
+
+    /// Forwards a downstream rate-control target to the producer.
+    ///
+    /// The default implementation does nothing, for transports that cannot
+    /// influence the upstream encoder.
+    fn update_rate_control(&mut self, _rate_control: EncodedRateControl) {}
+}
+
+/// Error returned while forwarding encoded access units into a track.
+#[derive(Debug)]
+pub enum EncodedIngressError<E> {
+    /// The encoded source failed.
+    Source(E),
+    /// The capture track rejected an access unit.
+    Capture(CaptureError),
+}
+
+impl<E: fmt::Display> fmt::Display for EncodedIngressError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Source(err) => write!(f, "encoded source failed: {err}"),
+            Self::Capture(err) => write!(f, "encoded capture failed: {err}"),
+        }
+    }
+}
+
+impl<E> Error for EncodedIngressError<E>
+where
+    E: Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Source(err) => Some(err),
+            Self::Capture(err) => Some(err),
+        }
+    }
+}
+
+/// Cancellation handle for [`EncodedIngress::run_until_end`].
+///
+/// Cheap to clone; wire it to a shutdown signal (e.g. Ctrl-C) and call
+/// [`EncodedIngressStop::stop`] from any thread to make the ingest loop
+/// return after the access unit in flight.
+#[derive(Debug, Clone, Default)]
+pub struct EncodedIngressStop(Arc<AtomicBool>);
+
+impl EncodedIngressStop {
+    /// Creates an un-stopped handle.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Signals the ingest loop to stop.
+    pub fn stop(&self) {
+        self.0.store(true, Ordering::Release);
+    }
+
+    /// Returns true once [`EncodedIngressStop::stop`] has been called.
+    pub fn is_stopped(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+}
+
+/// Pulls encoded access units from a source and forwards them into a video track.
+#[derive(Debug)]
+pub struct EncodedIngress<S> {
+    track: VideoCaptureTrack,
+    source: S,
+    stop: EncodedIngressStop,
+    awaiting_initial_keyframe: bool,
+}
+
+impl<S> EncodedIngress<S> {
+    /// Creates an encoded ingress runner.
+    pub fn new(track: VideoCaptureTrack, source: S) -> Self {
+        Self { track, source, stop: EncodedIngressStop::new(), awaiting_initial_keyframe: true }
+    }
+
+    /// Returns a cancellation handle for this runner.
+    pub fn stop_handle(&self) -> EncodedIngressStop {
+        self.stop.clone()
+    }
+
+    /// Returns the capture track used by this runner.
+    pub fn track(&self) -> &VideoCaptureTrack {
+        &self.track
+    }
+
+    /// Returns the underlying encoded source.
+    pub fn source(&self) -> &S {
+        &self.source
+    }
+
+    /// Returns the underlying encoded source mutably.
+    pub fn source_mut(&mut self) -> &mut S {
+        &mut self.source
+    }
+
+    /// Consumes this runner and returns its parts.
+    pub fn into_parts(self) -> (VideoCaptureTrack, S) {
+        (self.track, self.source)
+    }
+}
+
+/// Details of one access unit captured by [`EncodedIngress::capture_next`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EncodedIngressCapture {
+    /// Capture timestamp of the access unit in microseconds.
+    pub timestamp_us: i64,
+    /// Frame type of the access unit.
+    pub frame_type: crate::encoded::EncodedFrameType,
+    /// Payload size in bytes.
+    pub payload_len: usize,
+}
+
+impl<S> EncodedIngress<S>
+where
+    S: EncodedAccessUnitSource,
+{
+    /// Captures the next access unit, returning `None` after source EOF.
+    ///
+    /// Downstream rate-control and keyframe requests raised by the
+    /// passthrough encoder are polled on every call and forwarded to the
+    /// source via [`EncodedAccessUnitSource::update_rate_control`] and
+    /// [`EncodedAccessUnitSource::request_keyframe`].
+    pub fn capture_next(
+        &mut self,
+    ) -> Result<Option<EncodedIngressCapture>, EncodedIngressError<S::Error>> {
+        self.capture_next_with_metadata(|_| None)
+    }
+
+    /// Captures the next access unit with metadata generated after the source yields it.
+    ///
+    /// The metadata producer is not called for skipped pre-roll frames while
+    /// the ingress runner is waiting for the initial keyframe.
+    pub fn capture_next_with_metadata(
+        &mut self,
+        frame_metadata: impl FnOnce(&OwnedEncodedAccessUnit) -> Option<FrameMetadata>,
+    ) -> Result<Option<EncodedIngressCapture>, EncodedIngressError<S::Error>> {
+        if let Some(rate_control) = self.track.take_rate_control_request() {
+            self.source.update_rate_control(rate_control);
+        }
+        if self.track.take_keyframe_request() {
+            self.source.request_keyframe();
+        }
+
+        let access_unit = loop {
+            let Some(access_unit) =
+                self.source.next_access_unit().map_err(EncodedIngressError::Source)?
+            else {
+                return Ok(None);
+            };
+
+            if !self.awaiting_initial_keyframe || access_unit.frame_type == EncodedFrameType::Key {
+                self.awaiting_initial_keyframe = false;
+                break access_unit;
+            }
+        };
+
+        let frame_metadata = frame_metadata(&access_unit);
+        self.track
+            .capture_encoded_with_metadata(&access_unit.as_access_unit(), frame_metadata)
+            .map_err(EncodedIngressError::Capture)?;
+        Ok(Some(EncodedIngressCapture {
+            timestamp_us: access_unit.timestamp_us,
+            frame_type: access_unit.frame_type,
+            payload_len: access_unit.payload.len(),
+        }))
+    }
+
+    /// Captures access units until the source reaches EOF or the stop
+    /// handle fires, returning the number of captured access units.
+    pub fn run_until_end(&mut self) -> Result<u64, EncodedIngressError<S::Error>> {
+        let mut captured = 0;
+        while !self.stop.is_stopped() && self.capture_next()?.is_some() {
+            captured += 1;
+        }
+        Ok(captured)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::VecDeque, error::Error, fmt};
+
+    use livekit::webrtc::video_source::VideoResolution;
+
+    use super::*;
+    use crate::encoded::EncodedVideoCodec;
+
+    #[derive(Debug)]
+    struct FakeSourceError;
+
+    impl fmt::Display for FakeSourceError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("fake source failed")
+        }
+    }
+
+    impl Error for FakeSourceError {}
+
+    #[derive(Debug)]
+    struct FakeSource {
+        access_units: VecDeque<OwnedEncodedAccessUnit>,
+    }
+
+    impl FakeSource {
+        fn new(access_units: impl IntoIterator<Item = OwnedEncodedAccessUnit>) -> Self {
+            Self { access_units: access_units.into_iter().collect() }
+        }
+    }
+
+    impl EncodedAccessUnitSource for FakeSource {
+        type Error = FakeSourceError;
+
+        fn next_access_unit(&mut self) -> Result<Option<OwnedEncodedAccessUnit>, Self::Error> {
+            Ok(self.access_units.pop_front())
+        }
+    }
+
+    fn access_unit(timestamp_us: i64, frame_type: EncodedFrameType) -> OwnedEncodedAccessUnit {
+        OwnedEncodedAccessUnit::new(
+            EncodedVideoCodec::VP8,
+            vec![1, 2, 3],
+            timestamp_us,
+            frame_type,
+            640,
+            480,
+        )
+    }
+
+    fn encoded_track() -> VideoCaptureTrack {
+        VideoCaptureTrack::new_encoded("test", VideoResolution { width: 640, height: 480 })
+    }
+
+    #[test]
+    fn capture_next_starts_at_initial_keyframe() {
+        let source = FakeSource::new([
+            access_unit(1, EncodedFrameType::Delta),
+            access_unit(2, EncodedFrameType::Delta),
+            access_unit(3, EncodedFrameType::Key),
+        ]);
+        let mut ingress = EncodedIngress::new(encoded_track(), source);
+
+        let capture = ingress
+            .capture_next()
+            .expect("capture should succeed")
+            .expect("keyframe should be captured");
+
+        assert_eq!(capture.timestamp_us, 3);
+        assert_eq!(capture.frame_type, EncodedFrameType::Key);
+    }
+
+    #[test]
+    fn capture_next_allows_deltas_after_initial_keyframe() {
+        let source = FakeSource::new([
+            access_unit(1, EncodedFrameType::Key),
+            access_unit(2, EncodedFrameType::Delta),
+        ]);
+        let mut ingress = EncodedIngress::new(encoded_track(), source);
+
+        let first = ingress.capture_next().unwrap().unwrap();
+        let second = ingress.capture_next().unwrap().unwrap();
+
+        assert_eq!(first.frame_type, EncodedFrameType::Key);
+        assert_eq!(second.frame_type, EncodedFrameType::Delta);
+        assert_eq!(second.timestamp_us, 2);
+    }
+}

--- a/livekit-capture/src/encoded/rtp.rs
+++ b/livekit-capture/src/encoded/rtp.rs
@@ -1,0 +1,1520 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+use thiserror::Error;
+
+use crate::{
+    encoded::{
+        h26x::access_unit_from_nalus, CodecSpecific, EncodedFrameType, EncodedVideoCodec,
+        OwnedEncodedAccessUnit,
+    },
+    error::CaptureError,
+};
+
+/// Parsed RTP packet header and payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RtpPacket<'a> {
+    /// RTP marker bit.
+    pub marker: bool,
+    /// RTP payload type.
+    pub payload_type: u8,
+    /// RTP sequence number.
+    pub sequence_number: u16,
+    /// RTP timestamp.
+    pub timestamp: u32,
+    /// RTP SSRC.
+    pub ssrc: u32,
+    /// RTP payload bytes.
+    pub payload: &'a [u8],
+}
+
+impl<'a> RtpPacket<'a> {
+    /// Parses a single RTP packet.
+    pub fn parse(bytes: &'a [u8]) -> Result<Self, RtpDepacketizerError> {
+        if bytes.len() < 12 {
+            return Err(RtpDepacketizerError::PacketTooShort);
+        }
+        if bytes[0] >> 6 != 2 {
+            return Err(RtpDepacketizerError::UnsupportedVersion(bytes[0] >> 6));
+        }
+
+        let has_padding = (bytes[0] & 0x20) != 0;
+        let has_extension = (bytes[0] & 0x10) != 0;
+        let csrc_count = (bytes[0] & 0x0f) as usize;
+        let mut payload_start = 12 + csrc_count * 4;
+        if bytes.len() < payload_start {
+            return Err(RtpDepacketizerError::PacketTooShort);
+        }
+
+        if has_extension {
+            if bytes.len() < payload_start + 4 {
+                return Err(RtpDepacketizerError::PacketTooShort);
+            }
+            let extension_words =
+                u16::from_be_bytes([bytes[payload_start + 2], bytes[payload_start + 3]]) as usize;
+            payload_start += 4 + extension_words * 4;
+            if bytes.len() < payload_start {
+                return Err(RtpDepacketizerError::PacketTooShort);
+            }
+        }
+
+        let payload_end = if has_padding {
+            let Some(padding) = bytes.last().copied() else {
+                return Err(RtpDepacketizerError::PacketTooShort);
+            };
+            let padding = padding as usize;
+            if padding == 0 || bytes.len() < payload_start + padding {
+                return Err(RtpDepacketizerError::PacketTooShort);
+            }
+            bytes.len() - padding
+        } else {
+            bytes.len()
+        };
+
+        Ok(Self {
+            marker: (bytes[1] & 0x80) != 0,
+            payload_type: bytes[1] & 0x7f,
+            sequence_number: u16::from_be_bytes([bytes[2], bytes[3]]),
+            timestamp: u32::from_be_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
+            ssrc: u32::from_be_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]),
+            payload: &bytes[payload_start..payload_end],
+        })
+    }
+}
+
+/// Maps RTP timestamps to capture timestamps in microseconds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RtpTimestampMapper {
+    clock_rate: u32,
+    last_rtp_timestamp: Option<u32>,
+    extended_ticks: i64,
+    base_timestamp_us: i64,
+}
+
+impl RtpTimestampMapper {
+    /// Creates an RTP timestamp mapper.
+    pub fn new(clock_rate: u32, base_timestamp_us: i64) -> Self {
+        Self { clock_rate, last_rtp_timestamp: None, extended_ticks: 0, base_timestamp_us }
+    }
+
+    /// Maps an RTP timestamp to microseconds, unwrapping `u32` RTP timestamp
+    /// rollover so mapped timestamps stay monotonic across any number of wraps.
+    pub fn map(&mut self, rtp_timestamp: u32) -> Result<i64, RtpDepacketizerError> {
+        if self.clock_rate == 0 {
+            return Err(RtpDepacketizerError::InvalidClockRate);
+        }
+
+        let last = *self.last_rtp_timestamp.get_or_insert(rtp_timestamp);
+        self.last_rtp_timestamp = Some(rtp_timestamp);
+        // Reinterpreting the wrapped u32 delta as i32 picks the nearest extended
+        // timestamp, which unwraps rollover while tolerating small backwards
+        // jumps from reordered packets.
+        let delta_ticks = i64::from(rtp_timestamp.wrapping_sub(last) as i32);
+        self.extended_ticks = self.extended_ticks.saturating_add(delta_ticks);
+
+        let extended_us = i128::from(self.extended_ticks) * 1_000_000 / i128::from(self.clock_rate);
+        let extended_us = extended_us.clamp(i128::from(i64::MIN), i128::from(i64::MAX)) as i64;
+        Ok(self.base_timestamp_us.saturating_add(extended_us))
+    }
+}
+
+/// Error returned by RTP depayloading and access-unit assembly.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum RtpDepacketizerError {
+    /// RTP packet is shorter than its declared header.
+    #[error("RTP packet is too short")]
+    PacketTooShort,
+    /// RTP version is not supported.
+    #[error("unsupported RTP version {0}")]
+    UnsupportedVersion(u8),
+    /// RTP clock rate must be non-zero.
+    #[error("RTP clock rate must be non-zero")]
+    InvalidClockRate,
+    /// RTP payload format is unsupported or malformed.
+    #[error("unsupported or malformed RTP payload")]
+    UnsupportedPayload,
+    /// RTP fragmentation state was invalid.
+    #[error("invalid RTP fragmentation sequence")]
+    InvalidFragment,
+    /// The payload descriptor is unsupported by the single-layer depacketizer.
+    #[error("unsupported RTP payload descriptor")]
+    UnsupportedPayloadDescriptor,
+    /// Codec is not supported by this RTP assembler.
+    #[error("RTP assembler does not support {0:?}")]
+    UnsupportedCodec(EncodedVideoCodec),
+    /// Capture data could not be converted into an access unit.
+    #[error(transparent)]
+    Capture(#[from] CaptureError),
+}
+
+/// Packet-loss recovery counters for an [`RtpAccessUnitAssembler`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RtpDepacketizerStats {
+    /// Number of RTP sequence-number gaps detected.
+    pub sequence_gaps: u64,
+    /// Number of access units dropped while recovering from packet loss.
+    pub dropped_access_units: u64,
+    /// Whether output is gated until the next keyframe completes.
+    pub awaiting_keyframe: bool,
+}
+
+/// Reassembles RTP packets into encoded access units.
+#[derive(Debug, Clone)]
+pub struct RtpAccessUnitAssembler {
+    codec: EncodedVideoCodec,
+    width: u32,
+    height: u32,
+    timestamp_mapper: RtpTimestampMapper,
+    expected_sequence_number: Option<u16>,
+    current: Option<PartialAccessUnit>,
+    fragment: Option<FragmentState>,
+    current_frame: Option<PartialFrame>,
+    av1_fragment: Option<Av1FragmentState>,
+    awaiting_keyframe: bool,
+    sequence_gaps: u64,
+    dropped_access_units: u64,
+}
+
+#[derive(Debug, Clone)]
+struct PartialAccessUnit {
+    rtp_timestamp: u32,
+    timestamp_us: i64,
+    nal_units: Vec<Vec<u8>>,
+}
+
+#[derive(Debug, Clone)]
+struct FragmentState {
+    rtp_timestamp: u32,
+    nal_unit: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+struct PartialFrame {
+    rtp_timestamp: u32,
+    timestamp_us: i64,
+    payload: Vec<u8>,
+    frame_type: Option<EncodedFrameType>,
+    av1_reduced_still_picture_header: Option<bool>,
+}
+
+#[derive(Debug, Clone)]
+struct Av1FragmentState {
+    rtp_timestamp: u32,
+    obu: Vec<u8>,
+}
+
+impl RtpAccessUnitAssembler {
+    /// Creates an RTP access-unit assembler for supported video payloads.
+    pub fn new(
+        codec: EncodedVideoCodec,
+        clock_rate: u32,
+        start_timestamp_us: i64,
+        width: u32,
+        height: u32,
+    ) -> Result<Self, RtpDepacketizerError> {
+        if clock_rate == 0 {
+            return Err(RtpDepacketizerError::InvalidClockRate);
+        }
+
+        Ok(Self {
+            codec,
+            width,
+            height,
+            timestamp_mapper: RtpTimestampMapper::new(clock_rate, start_timestamp_us),
+            expected_sequence_number: None,
+            current: None,
+            fragment: None,
+            current_frame: None,
+            av1_fragment: None,
+            awaiting_keyframe: false,
+            sequence_gaps: 0,
+            dropped_access_units: 0,
+        })
+    }
+
+    /// Returns packet-loss recovery counters.
+    pub fn stats(&self) -> RtpDepacketizerStats {
+        RtpDepacketizerStats {
+            sequence_gaps: self.sequence_gaps,
+            dropped_access_units: self.dropped_access_units,
+            awaiting_keyframe: self.awaiting_keyframe,
+        }
+    }
+
+    /// Pushes one encoded RTP packet and returns an access unit when a marker closes a frame.
+    pub fn push(
+        &mut self,
+        bytes: &[u8],
+    ) -> Result<Option<OwnedEncodedAccessUnit>, RtpDepacketizerError> {
+        let packet = RtpPacket::parse(bytes)?;
+        self.push_packet(packet)
+    }
+
+    /// Pushes one parsed RTP packet and returns an access unit when a marker closes a frame.
+    ///
+    /// Packet loss is recovered internally: gaps and truncated fragments drop the
+    /// interrupted access unit and gate output on the next keyframe instead of
+    /// returning an error; see [`Self::stats`].
+    pub fn push_packet(
+        &mut self,
+        packet: RtpPacket<'_>,
+    ) -> Result<Option<OwnedEncodedAccessUnit>, RtpDepacketizerError> {
+        self.check_sequence(packet.sequence_number);
+
+        match self.codec {
+            EncodedVideoCodec::H264 => self.push_h264_payload(&packet)?,
+            EncodedVideoCodec::H265 => self.push_h265_payload(&packet)?,
+            EncodedVideoCodec::VP8 => self.push_vp8_payload(&packet)?,
+            EncodedVideoCodec::VP9 => self.push_vp9_payload(&packet)?,
+            EncodedVideoCodec::AV1 => self.push_av1_payload(&packet)?,
+        }
+
+        if packet.marker {
+            if self.fragment.is_some() || self.av1_fragment.is_some() {
+                // The marker closed the access unit before the open fragment's
+                // end arrived, so its tail packets were lost.
+                self.discard_in_progress();
+                self.dropped_access_units += 1;
+                return Ok(None);
+            }
+            if matches!(
+                self.codec,
+                EncodedVideoCodec::VP8 | EncodedVideoCodec::VP9 | EncodedVideoCodec::AV1
+            ) {
+                return self.finish_current_frame();
+            }
+            return self.finish_current();
+        }
+        Ok(None)
+    }
+
+    fn check_sequence(&mut self, sequence_number: u16) {
+        let Some(expected) = self.expected_sequence_number.replace(sequence_number.wrapping_add(1))
+        else {
+            return;
+        };
+        if sequence_number == expected {
+            return;
+        }
+
+        self.sequence_gaps += 1;
+        self.discard_in_progress();
+    }
+
+    /// Discards all partially assembled state and gates output on the next keyframe.
+    fn discard_in_progress(&mut self) {
+        self.current = None;
+        self.fragment = None;
+        self.current_frame = None;
+        self.av1_fragment = None;
+        self.awaiting_keyframe = true;
+    }
+
+    /// Drops completed access units until a keyframe ends loss recovery.
+    fn gate_on_keyframe(
+        &mut self,
+        access_unit: OwnedEncodedAccessUnit,
+    ) -> Option<OwnedEncodedAccessUnit> {
+        if self.awaiting_keyframe {
+            if access_unit.frame_type != EncodedFrameType::Key {
+                self.dropped_access_units += 1;
+                return None;
+            }
+            self.awaiting_keyframe = false;
+        }
+        Some(access_unit)
+    }
+
+    fn current_mut(
+        &mut self,
+        rtp_timestamp: u32,
+    ) -> Result<&mut PartialAccessUnit, RtpDepacketizerError> {
+        if self.current.as_ref().is_some_and(|current| current.rtp_timestamp != rtp_timestamp) {
+            self.current = None;
+            self.fragment = None;
+        }
+
+        if self.current.is_none() {
+            let timestamp_us = self.timestamp_mapper.map(rtp_timestamp)?;
+            self.current =
+                Some(PartialAccessUnit { rtp_timestamp, timestamp_us, nal_units: Vec::new() });
+        }
+
+        self.current.as_mut().ok_or(RtpDepacketizerError::InvalidFragment)
+    }
+
+    fn current_frame_mut(
+        &mut self,
+        rtp_timestamp: u32,
+    ) -> Result<&mut PartialFrame, RtpDepacketizerError> {
+        if self.current_frame.as_ref().is_some_and(|current| current.rtp_timestamp != rtp_timestamp)
+        {
+            self.current_frame = None;
+            self.av1_fragment = None;
+        }
+
+        if self.current_frame.is_none() {
+            let timestamp_us = self.timestamp_mapper.map(rtp_timestamp)?;
+            self.current_frame = Some(PartialFrame {
+                rtp_timestamp,
+                timestamp_us,
+                payload: Vec::new(),
+                frame_type: None,
+                av1_reduced_still_picture_header: None,
+            });
+        }
+
+        self.current_frame.as_mut().ok_or(RtpDepacketizerError::InvalidFragment)
+    }
+
+    fn push_h264_payload(&mut self, packet: &RtpPacket<'_>) -> Result<(), RtpDepacketizerError> {
+        let payload = packet.payload;
+        let Some(&header) = payload.first() else {
+            return Err(RtpDepacketizerError::UnsupportedPayload);
+        };
+        let nal_type = header & 0x1f;
+
+        match nal_type {
+            1..=23 => self.current_mut(packet.timestamp)?.nal_units.push(payload.to_vec()),
+            24 => self.push_h264_stap_a(packet.timestamp, &payload[1..])?,
+            28 => self.push_h264_fu_a(packet.timestamp, payload)?,
+            _ => return Err(RtpDepacketizerError::UnsupportedPayload),
+        }
+
+        Ok(())
+    }
+
+    fn push_h264_stap_a(
+        &mut self,
+        rtp_timestamp: u32,
+        payload: &[u8],
+    ) -> Result<(), RtpDepacketizerError> {
+        let mut cursor = 0;
+        while cursor < payload.len() {
+            if payload.len() < cursor + 2 {
+                return Err(RtpDepacketizerError::UnsupportedPayload);
+            }
+            let len = u16::from_be_bytes([payload[cursor], payload[cursor + 1]]) as usize;
+            cursor += 2;
+            if len == 0 || payload.len() < cursor + len {
+                return Err(RtpDepacketizerError::UnsupportedPayload);
+            }
+            self.current_mut(rtp_timestamp)?.nal_units.push(payload[cursor..cursor + len].to_vec());
+            cursor += len;
+        }
+        Ok(())
+    }
+
+    fn push_h264_fu_a(
+        &mut self,
+        rtp_timestamp: u32,
+        payload: &[u8],
+    ) -> Result<(), RtpDepacketizerError> {
+        if payload.len() < 2 {
+            return Err(RtpDepacketizerError::UnsupportedPayload);
+        }
+
+        let indicator = payload[0];
+        let header = payload[1];
+        let start = (header & 0x80) != 0;
+        let end = (header & 0x40) != 0;
+        let nal_type = header & 0x1f;
+        if nal_type == 0 || nal_type > 23 {
+            return Err(RtpDepacketizerError::UnsupportedPayload);
+        }
+
+        if start {
+            let mut nal_unit = Vec::with_capacity(1 + payload.len().saturating_sub(2));
+            nal_unit.push((indicator & 0xe0) | nal_type);
+            nal_unit.extend_from_slice(&payload[2..]);
+            self.fragment = Some(FragmentState { rtp_timestamp, nal_unit });
+            return Ok(());
+        }
+
+        let Some(fragment) =
+            self.fragment.as_mut().filter(|fragment| fragment.rtp_timestamp == rtp_timestamp)
+        else {
+            // A continuation without its start means the preceding packets were lost.
+            self.discard_in_progress();
+            return Ok(());
+        };
+        fragment.nal_unit.extend_from_slice(&payload[2..]);
+
+        if end {
+            let nal_unit =
+                self.fragment.take().ok_or(RtpDepacketizerError::InvalidFragment)?.nal_unit;
+            self.current_mut(rtp_timestamp)?.nal_units.push(nal_unit);
+        }
+        Ok(())
+    }
+
+    fn push_h265_payload(&mut self, packet: &RtpPacket<'_>) -> Result<(), RtpDepacketizerError> {
+        let payload = packet.payload;
+        if payload.len() < 2 {
+            return Err(RtpDepacketizerError::UnsupportedPayload);
+        }
+        let nal_type = (payload[0] >> 1) & 0x3f;
+
+        match nal_type {
+            0..=47 => self.current_mut(packet.timestamp)?.nal_units.push(payload.to_vec()),
+            48 => self.push_h265_aggregation(packet.timestamp, &payload[2..])?,
+            49 => self.push_h265_fragment(packet.timestamp, payload)?,
+            _ => return Err(RtpDepacketizerError::UnsupportedPayload),
+        }
+
+        Ok(())
+    }
+
+    fn push_h265_aggregation(
+        &mut self,
+        rtp_timestamp: u32,
+        payload: &[u8],
+    ) -> Result<(), RtpDepacketizerError> {
+        let mut cursor = 0;
+        while cursor < payload.len() {
+            if payload.len() < cursor + 2 {
+                return Err(RtpDepacketizerError::UnsupportedPayload);
+            }
+            let len = u16::from_be_bytes([payload[cursor], payload[cursor + 1]]) as usize;
+            cursor += 2;
+            if len == 0 || payload.len() < cursor + len {
+                return Err(RtpDepacketizerError::UnsupportedPayload);
+            }
+            self.current_mut(rtp_timestamp)?.nal_units.push(payload[cursor..cursor + len].to_vec());
+            cursor += len;
+        }
+        Ok(())
+    }
+
+    fn push_h265_fragment(
+        &mut self,
+        rtp_timestamp: u32,
+        payload: &[u8],
+    ) -> Result<(), RtpDepacketizerError> {
+        if payload.len() < 3 {
+            return Err(RtpDepacketizerError::UnsupportedPayload);
+        }
+
+        let fu_header = payload[2];
+        let start = (fu_header & 0x80) != 0;
+        let end = (fu_header & 0x40) != 0;
+        let nal_type = fu_header & 0x3f;
+        if nal_type > 47 {
+            return Err(RtpDepacketizerError::UnsupportedPayload);
+        }
+
+        if start {
+            let mut nal_unit = Vec::with_capacity(2 + payload.len().saturating_sub(3));
+            nal_unit.push((payload[0] & 0x81) | (nal_type << 1));
+            nal_unit.push(payload[1]);
+            nal_unit.extend_from_slice(&payload[3..]);
+            self.fragment = Some(FragmentState { rtp_timestamp, nal_unit });
+            return Ok(());
+        }
+
+        let Some(fragment) =
+            self.fragment.as_mut().filter(|fragment| fragment.rtp_timestamp == rtp_timestamp)
+        else {
+            // A continuation without its start means the preceding packets were lost.
+            self.discard_in_progress();
+            return Ok(());
+        };
+        fragment.nal_unit.extend_from_slice(&payload[3..]);
+
+        if end {
+            let nal_unit =
+                self.fragment.take().ok_or(RtpDepacketizerError::InvalidFragment)?.nal_unit;
+            self.current_mut(rtp_timestamp)?.nal_units.push(nal_unit);
+        }
+        Ok(())
+    }
+
+    fn push_vp8_payload(&mut self, packet: &RtpPacket<'_>) -> Result<(), RtpDepacketizerError> {
+        let descriptor = parse_vp8_payload_descriptor(packet.payload)?;
+        if descriptor.payload.is_empty() {
+            return Err(RtpDepacketizerError::UnsupportedPayload);
+        }
+
+        let frame = self.current_frame_mut(packet.timestamp)?;
+        if frame.payload.is_empty() {
+            if !descriptor.start_of_partition || descriptor.partition_id != 0 {
+                // The beginning of this frame was lost.
+                self.discard_in_progress();
+                return Ok(());
+            }
+            frame.frame_type = Some(if is_vp8_keyframe(descriptor.payload) {
+                EncodedFrameType::Key
+            } else {
+                EncodedFrameType::Delta
+            });
+        }
+        frame.payload.extend_from_slice(descriptor.payload);
+        Ok(())
+    }
+
+    fn push_vp9_payload(&mut self, packet: &RtpPacket<'_>) -> Result<(), RtpDepacketizerError> {
+        let descriptor = parse_vp9_payload_descriptor(packet.payload)?;
+        if descriptor.payload.is_empty() {
+            return Err(RtpDepacketizerError::UnsupportedPayload);
+        }
+        if descriptor.spatial_id.unwrap_or(0) != 0
+            || descriptor.inter_layer_predicted.unwrap_or(false)
+        {
+            return Err(RtpDepacketizerError::UnsupportedPayloadDescriptor);
+        }
+
+        let frame = self.current_frame_mut(packet.timestamp)?;
+        if frame.payload.is_empty() {
+            if !descriptor.beginning_of_frame {
+                // The beginning of this frame was lost.
+                self.discard_in_progress();
+                return Ok(());
+            }
+            frame.frame_type = Some(
+                if !descriptor.inter_picture_predicted || is_vp9_keyframe(descriptor.payload) {
+                    EncodedFrameType::Key
+                } else {
+                    EncodedFrameType::Delta
+                },
+            );
+        }
+        frame.payload.extend_from_slice(descriptor.payload);
+        Ok(())
+    }
+
+    fn push_av1_payload(&mut self, packet: &RtpPacket<'_>) -> Result<(), RtpDepacketizerError> {
+        let descriptor = parse_av1_payload_descriptor(packet.payload)?;
+        if descriptor.elements.is_empty() {
+            return Err(RtpDepacketizerError::UnsupportedPayload);
+        }
+
+        let last_index = descriptor.elements.len() - 1;
+        for (index, element) in descriptor.elements.iter().enumerate() {
+            if element.is_empty() {
+                return Err(RtpDepacketizerError::UnsupportedPayload);
+            }
+
+            let obu = if index == 0 && descriptor.starts_fragment {
+                let Some(fragment) = self
+                    .av1_fragment
+                    .take()
+                    .filter(|fragment| fragment.rtp_timestamp == packet.timestamp)
+                else {
+                    // A continuation without its start means the preceding packets were lost.
+                    self.discard_in_progress();
+                    return Ok(());
+                };
+                let mut obu = fragment.obu;
+                obu.extend_from_slice(element);
+                obu
+            } else {
+                if index == 0 && self.av1_fragment.is_some() {
+                    return Err(RtpDepacketizerError::InvalidFragment);
+                }
+                element.to_vec()
+            };
+
+            if index == last_index && descriptor.ends_fragment {
+                self.av1_fragment = Some(Av1FragmentState { rtp_timestamp: packet.timestamp, obu });
+                return Ok(());
+            }
+
+            let mut obu = av1_obu_from_rtp_element(&obu)?;
+            let frame = self.current_frame_mut(packet.timestamp)?;
+            if let Some(reduced_still_picture_header) = av1_reduced_still_picture_header(&obu)? {
+                frame.av1_reduced_still_picture_header = Some(reduced_still_picture_header);
+            }
+            if frame.frame_type.is_none() {
+                frame.frame_type = av1_frame_type(&obu, frame.av1_reduced_still_picture_header)?;
+            }
+            frame.payload.append(&mut obu);
+        }
+
+        Ok(())
+    }
+
+    fn finish_current(&mut self) -> Result<Option<OwnedEncodedAccessUnit>, RtpDepacketizerError> {
+        let Some(current) = self.current.take() else {
+            return Ok(None);
+        };
+        if current.nal_units.is_empty() {
+            return Ok(None);
+        }
+
+        let nal_units = current.nal_units.iter().map(Vec::as_slice).collect::<Vec<_>>();
+        let access_unit = access_unit_from_nalus(
+            self.codec,
+            &nal_units,
+            current.timestamp_us,
+            self.width,
+            self.height,
+        )?;
+        Ok(self.gate_on_keyframe(access_unit))
+    }
+
+    fn finish_current_frame(
+        &mut self,
+    ) -> Result<Option<OwnedEncodedAccessUnit>, RtpDepacketizerError> {
+        let Some(current) = self.current_frame.take() else {
+            return Ok(None);
+        };
+        if current.payload.is_empty() {
+            return Ok(None);
+        }
+
+        let mut access_unit = OwnedEncodedAccessUnit::new(
+            self.codec,
+            Bytes::from(current.payload),
+            current.timestamp_us,
+            current.frame_type.unwrap_or(EncodedFrameType::Delta),
+            self.width,
+            self.height,
+        );
+        access_unit.codec_specific = CodecSpecific::default_for(self.codec);
+        Ok(self.gate_on_keyframe(access_unit))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Vp8PayloadDescriptor<'a> {
+    start_of_partition: bool,
+    partition_id: u8,
+    payload: &'a [u8],
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Vp9PayloadDescriptor<'a> {
+    beginning_of_frame: bool,
+    inter_picture_predicted: bool,
+    spatial_id: Option<u8>,
+    inter_layer_predicted: Option<bool>,
+    payload: &'a [u8],
+}
+
+#[derive(Debug, Clone)]
+struct Av1PayloadDescriptor<'a> {
+    starts_fragment: bool,
+    ends_fragment: bool,
+    elements: Vec<&'a [u8]>,
+}
+
+fn parse_vp8_payload_descriptor(
+    payload: &[u8],
+) -> Result<Vp8PayloadDescriptor<'_>, RtpDepacketizerError> {
+    let Some(&descriptor) = payload.first() else {
+        return Err(RtpDepacketizerError::UnsupportedPayload);
+    };
+    let start_of_partition = descriptor & 0x10 != 0;
+    let partition_id = descriptor & 0x0f;
+    let mut cursor = 1;
+    if descriptor & 0x80 != 0 {
+        let Some(&extension) = payload.get(cursor) else {
+            return Err(RtpDepacketizerError::UnsupportedPayload);
+        };
+        cursor += 1;
+        if extension & 0x80 != 0 {
+            let Some(&picture_id) = payload.get(cursor) else {
+                return Err(RtpDepacketizerError::UnsupportedPayload);
+            };
+            cursor += if picture_id & 0x80 != 0 { 2 } else { 1 };
+        }
+        if extension & 0x40 != 0 {
+            cursor += 1;
+        }
+        if extension & 0x20 != 0 || extension & 0x10 != 0 {
+            cursor += 1;
+        }
+    }
+    if cursor > payload.len() {
+        return Err(RtpDepacketizerError::UnsupportedPayload);
+    }
+    Ok(Vp8PayloadDescriptor { start_of_partition, partition_id, payload: &payload[cursor..] })
+}
+
+fn parse_vp9_payload_descriptor(
+    payload: &[u8],
+) -> Result<Vp9PayloadDescriptor<'_>, RtpDepacketizerError> {
+    let Some(&descriptor) = payload.first() else {
+        return Err(RtpDepacketizerError::UnsupportedPayload);
+    };
+    if descriptor & 0x10 != 0 {
+        return Err(RtpDepacketizerError::UnsupportedPayloadDescriptor);
+    }
+
+    let beginning_of_frame = descriptor & 0x08 != 0;
+    let inter_picture_predicted = descriptor & 0x40 != 0;
+    let mut cursor = 1;
+    if descriptor & 0x80 != 0 {
+        let Some(&picture_id) = payload.get(cursor) else {
+            return Err(RtpDepacketizerError::UnsupportedPayload);
+        };
+        cursor += if picture_id & 0x80 != 0 { 2 } else { 1 };
+    }
+
+    let mut spatial_id = None;
+    let mut inter_layer_predicted = None;
+    if descriptor & 0x20 != 0 {
+        let Some(&layer_info) = payload.get(cursor) else {
+            return Err(RtpDepacketizerError::UnsupportedPayload);
+        };
+        cursor += 1;
+        spatial_id = Some((layer_info >> 1) & 0x07);
+        inter_layer_predicted = Some(layer_info & 0x01 != 0);
+        cursor += 1; // TL0PICIDX is present in non-flexible mode.
+    }
+
+    if descriptor & 0x02 != 0 {
+        skip_vp9_scalability_structure(payload, &mut cursor)?;
+    }
+
+    if cursor > payload.len() {
+        return Err(RtpDepacketizerError::UnsupportedPayload);
+    }
+    Ok(Vp9PayloadDescriptor {
+        beginning_of_frame,
+        inter_picture_predicted,
+        spatial_id,
+        inter_layer_predicted,
+        payload: &payload[cursor..],
+    })
+}
+
+fn skip_vp9_scalability_structure(
+    payload: &[u8],
+    cursor: &mut usize,
+) -> Result<(), RtpDepacketizerError> {
+    let Some(&structure) = payload.get(*cursor) else {
+        return Err(RtpDepacketizerError::UnsupportedPayload);
+    };
+    *cursor += 1;
+
+    let spatial_layers = ((structure >> 5) & 0x07) + 1;
+    if spatial_layers != 1 {
+        return Err(RtpDepacketizerError::UnsupportedPayloadDescriptor);
+    }
+
+    if structure & 0x10 != 0 {
+        let bytes = usize::from(spatial_layers) * 4;
+        skip_bytes(payload, cursor, bytes)?;
+    }
+
+    if structure & 0x08 != 0 {
+        let Some(&group_count) = payload.get(*cursor) else {
+            return Err(RtpDepacketizerError::UnsupportedPayload);
+        };
+        *cursor += 1;
+        for _ in 0..group_count {
+            let Some(&group) = payload.get(*cursor) else {
+                return Err(RtpDepacketizerError::UnsupportedPayload);
+            };
+            *cursor += 1;
+            skip_bytes(payload, cursor, usize::from((group >> 2) & 0x03))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn skip_bytes(
+    payload: &[u8],
+    cursor: &mut usize,
+    bytes: usize,
+) -> Result<(), RtpDepacketizerError> {
+    let Some(next) = cursor.checked_add(bytes) else {
+        return Err(RtpDepacketizerError::UnsupportedPayload);
+    };
+    if next > payload.len() {
+        return Err(RtpDepacketizerError::UnsupportedPayload);
+    }
+    *cursor = next;
+    Ok(())
+}
+
+fn parse_av1_payload_descriptor(
+    payload: &[u8],
+) -> Result<Av1PayloadDescriptor<'_>, RtpDepacketizerError> {
+    let Some(&header) = payload.first() else {
+        return Err(RtpDepacketizerError::UnsupportedPayload);
+    };
+    let starts_fragment = header & 0x80 != 0;
+    let ends_fragment = header & 0x40 != 0;
+    let element_count = (header >> 4) & 0x03;
+
+    let mut cursor = 1;
+    let mut elements = Vec::new();
+    if element_count == 0 {
+        while cursor < payload.len() {
+            let len = read_leb128(payload, &mut cursor)?;
+            let Some(end) = cursor.checked_add(len) else {
+                return Err(RtpDepacketizerError::UnsupportedPayload);
+            };
+            if end > payload.len() {
+                return Err(RtpDepacketizerError::UnsupportedPayload);
+            }
+            elements.push(&payload[cursor..end]);
+            cursor = end;
+        }
+    } else {
+        for index in 0..usize::from(element_count) {
+            let len = if index + 1 == usize::from(element_count) {
+                payload.len().saturating_sub(cursor)
+            } else {
+                read_leb128(payload, &mut cursor)?
+            };
+            let Some(end) = cursor.checked_add(len) else {
+                return Err(RtpDepacketizerError::UnsupportedPayload);
+            };
+            if end > payload.len() {
+                return Err(RtpDepacketizerError::UnsupportedPayload);
+            }
+            elements.push(&payload[cursor..end]);
+            cursor = end;
+        }
+    }
+
+    Ok(Av1PayloadDescriptor { starts_fragment, ends_fragment, elements })
+}
+
+fn read_leb128(bytes: &[u8], cursor: &mut usize) -> Result<usize, RtpDepacketizerError> {
+    let mut value = 0usize;
+    let mut shift = 0usize;
+    loop {
+        let Some(&byte) = bytes.get(*cursor) else {
+            return Err(RtpDepacketizerError::UnsupportedPayload);
+        };
+        *cursor += 1;
+        value |= usize::from(byte & 0x7f) << shift;
+        if byte & 0x80 == 0 {
+            return Ok(value);
+        }
+        shift += 7;
+        if shift >= usize::BITS as usize {
+            return Err(RtpDepacketizerError::UnsupportedPayload);
+        }
+    }
+}
+
+fn write_leb128(mut value: usize, out: &mut Vec<u8>) {
+    loop {
+        let mut byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value != 0 {
+            byte |= 0x80;
+        }
+        out.push(byte);
+        if value == 0 {
+            break;
+        }
+    }
+}
+
+fn av1_obu_from_rtp_element(element: &[u8]) -> Result<Vec<u8>, RtpDepacketizerError> {
+    let Some(&header) = element.first() else {
+        return Err(RtpDepacketizerError::UnsupportedPayload);
+    };
+    if header & 0x80 != 0 {
+        return Err(RtpDepacketizerError::UnsupportedPayload);
+    }
+
+    if header & 0x02 != 0 {
+        let mut cursor = if header & 0x04 != 0 { 2 } else { 1 };
+        if cursor > element.len() {
+            return Err(RtpDepacketizerError::UnsupportedPayload);
+        }
+        let payload_size = read_leb128(element, &mut cursor)?;
+        if payload_size != element.len().saturating_sub(cursor) {
+            return Err(RtpDepacketizerError::UnsupportedPayload);
+        }
+        return Ok(element.to_vec());
+    }
+
+    let payload_offset = if header & 0x04 != 0 { 2 } else { 1 };
+    if payload_offset > element.len() {
+        return Err(RtpDepacketizerError::UnsupportedPayload);
+    }
+
+    let payload_size = element.len() - payload_offset;
+    let mut obu = Vec::with_capacity(element.len() + 8);
+    obu.push(header | 0x02);
+    if header & 0x04 != 0 {
+        obu.push(element[1]);
+    }
+    write_leb128(payload_size, &mut obu);
+    obu.extend_from_slice(&element[payload_offset..]);
+    Ok(obu)
+}
+
+fn is_vp8_keyframe(payload: &[u8]) -> bool {
+    payload.first().is_some_and(|header| header & 0x01 == 0)
+}
+
+/// Parses the start of a VP9 uncompressed frame header, whose `f(n)` fields
+/// are MSB-first, and reports whether it begins a keyframe.
+fn is_vp9_keyframe(payload: &[u8]) -> bool {
+    let Some(&first_byte) = payload.first() else {
+        return false;
+    };
+    // frame_marker: f(2), must be 0b10.
+    if first_byte >> 6 != 0b10 {
+        return false;
+    }
+
+    let mut bit_offset = 2usize;
+    let profile_low = read_bit(first_byte, bit_offset);
+    bit_offset += 1;
+    let profile_high = read_bit(first_byte, bit_offset);
+    bit_offset += 1;
+    let profile = profile_low | (profile_high << 1);
+    if profile == 3 {
+        bit_offset += 1; // reserved_zero
+    }
+    // show_existing_frame: a repeated frame is never a keyframe.
+    if read_bit(first_byte, bit_offset) != 0 {
+        return false;
+    }
+    bit_offset += 1;
+    // frame_type: 0 is KEY_FRAME.
+    read_bit(first_byte, bit_offset) == 0
+}
+
+fn av1_reduced_still_picture_header(obu: &[u8]) -> Result<Option<bool>, RtpDepacketizerError> {
+    let Some((obu_type, payload)) = av1_obu_parts(obu)? else {
+        return Ok(None);
+    };
+    if obu_type != 1 {
+        return Ok(None);
+    }
+
+    let mut reader = MsbBitReader::new(payload);
+    reader.read_bits(3).ok_or(RtpDepacketizerError::UnsupportedPayload)?; // seq_profile
+    reader.read_bit().ok_or(RtpDepacketizerError::UnsupportedPayload)?; // still_picture
+    Ok(Some(reader.read_bit().ok_or(RtpDepacketizerError::UnsupportedPayload)? != 0))
+}
+
+fn av1_frame_type(
+    obu: &[u8],
+    reduced_still_picture_header: Option<bool>,
+) -> Result<Option<EncodedFrameType>, RtpDepacketizerError> {
+    let Some((obu_type, payload)) = av1_obu_parts(obu)? else {
+        return Ok(None);
+    };
+    if !matches!(obu_type, 3 | 6) {
+        return Ok(None);
+    }
+
+    if reduced_still_picture_header.unwrap_or(false) {
+        return Ok(Some(EncodedFrameType::Key));
+    }
+
+    let mut reader = MsbBitReader::new(payload);
+    let show_existing_frame = reader.read_bit().ok_or(RtpDepacketizerError::UnsupportedPayload)?;
+    if show_existing_frame != 0 {
+        return Ok(Some(EncodedFrameType::Delta));
+    }
+
+    let frame_type = reader.read_bits(2).ok_or(RtpDepacketizerError::UnsupportedPayload)?;
+    Ok(Some(if frame_type == 0 { EncodedFrameType::Key } else { EncodedFrameType::Delta }))
+}
+
+fn av1_obu_parts(obu: &[u8]) -> Result<Option<(u8, &[u8])>, RtpDepacketizerError> {
+    let Some(&header) = obu.first() else {
+        return Ok(None);
+    };
+    if header & 0x80 != 0 {
+        return Err(RtpDepacketizerError::UnsupportedPayload);
+    }
+
+    let obu_type = av1_obu_type(obu).ok_or(RtpDepacketizerError::UnsupportedPayload)?;
+    let has_extension = header & 0x04 != 0;
+    let has_size = header & 0x02 != 0;
+    let mut cursor = if has_extension { 2 } else { 1 };
+    if cursor > obu.len() {
+        return Err(RtpDepacketizerError::UnsupportedPayload);
+    }
+
+    if !has_size {
+        return Ok(Some((obu_type, &obu[cursor..])));
+    }
+
+    let payload_size = read_leb128(obu, &mut cursor)?;
+    let Some(end) = cursor.checked_add(payload_size) else {
+        return Err(RtpDepacketizerError::UnsupportedPayload);
+    };
+    if end > obu.len() {
+        return Err(RtpDepacketizerError::UnsupportedPayload);
+    }
+    Ok(Some((obu_type, &obu[cursor..end])))
+}
+
+struct MsbBitReader<'a> {
+    bytes: &'a [u8],
+    bit_offset: usize,
+}
+
+impl<'a> MsbBitReader<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, bit_offset: 0 }
+    }
+
+    fn read_bit(&mut self) -> Option<u8> {
+        let byte = *self.bytes.get(self.bit_offset / 8)?;
+        let bit = read_bit(byte, self.bit_offset % 8);
+        self.bit_offset += 1;
+        Some(bit)
+    }
+
+    fn read_bits(&mut self, bits: usize) -> Option<u8> {
+        let mut value = 0;
+        for _ in 0..bits {
+            value = (value << 1) | self.read_bit()?;
+        }
+        Some(value)
+    }
+}
+
+/// Reads bit `bit_offset` of `byte`, counting from the most significant bit.
+fn read_bit(byte: u8, bit_offset: usize) -> u8 {
+    (byte >> (7 - bit_offset)) & 0x01
+}
+
+fn av1_obu_type(obu: &[u8]) -> Option<u8> {
+    obu.first().map(|header| (header & 0x78) >> 3)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rtp_packet(sequence_number: u16, timestamp: u32, marker: bool, payload: &[u8]) -> Vec<u8> {
+        let mut packet = Vec::with_capacity(12 + payload.len());
+        packet.push(0x80);
+        packet.push(if marker { 0x80 | 96 } else { 96 });
+        packet.extend_from_slice(&sequence_number.to_be_bytes());
+        packet.extend_from_slice(&timestamp.to_be_bytes());
+        packet.extend_from_slice(&0x1122_3344_u32.to_be_bytes());
+        packet.extend_from_slice(payload);
+        packet
+    }
+
+    fn av1_sequence_and_frame_rtp_payload(frame_header: u8) -> [u8; 6] {
+        [
+            0x28, // W=2, N=1.
+            0x02, // First OBU element length.
+            0x08, // Sequence header OBU without the size field.
+            0x00, // profile=0, still_picture=false, reduced_still_picture_header=false.
+            0x30, // Frame OBU without the size field.
+            frame_header,
+        ]
+    }
+
+    #[test]
+    fn parses_rtp_packet_header() {
+        let bytes = rtp_packet(7, 90_000, true, &[0x65, 1, 2]);
+        let packet = RtpPacket::parse(&bytes).unwrap();
+        assert!(packet.marker);
+        assert_eq!(packet.payload_type, 96);
+        assert_eq!(packet.sequence_number, 7);
+        assert_eq!(packet.timestamp, 90_000);
+        assert_eq!(packet.payload, &[0x65, 1, 2]);
+    }
+
+    #[test]
+    fn maps_rtp_timestamp_rollover() {
+        let mut mapper = RtpTimestampMapper::new(90_000, 1_000);
+        assert_eq!(mapper.map(u32::MAX - 89).unwrap(), 1_000);
+        assert_eq!(mapper.map(0).unwrap(), 2_000);
+    }
+
+    #[test]
+    fn maps_rtp_timestamps_across_multiple_rollovers() {
+        let mut mapper = RtpTimestampMapper::new(90_000, 0);
+        let step = 1u32 << 30;
+        let mut rtp_timestamp = 0u32;
+        let mut last_us = mapper.map(rtp_timestamp).unwrap();
+        for _ in 0..20 {
+            rtp_timestamp = rtp_timestamp.wrapping_add(step);
+            let mapped_us = mapper.map(rtp_timestamp).unwrap();
+            assert!(mapped_us > last_us, "mapped timestamps must stay monotonic");
+            last_us = mapped_us;
+        }
+        assert_eq!(last_us, (20i64 << 30) * 1_000_000 / 90_000);
+    }
+
+    #[test]
+    fn maps_reordered_rtp_timestamps() {
+        let mut mapper = RtpTimestampMapper::new(90_000, 1_000);
+        assert_eq!(mapper.map(9_000).unwrap(), 1_000);
+        assert_eq!(mapper.map(18_000).unwrap(), 101_000);
+        // A late packet maps behind the stream without disturbing what follows.
+        assert_eq!(mapper.map(15_000).unwrap(), 67_666);
+        assert_eq!(mapper.map(27_000).unwrap(), 201_000);
+    }
+
+    #[test]
+    fn assembles_h264_fu_a() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::H264, 90_000, 0, 640, 480).unwrap();
+        let start = rtp_packet(10, 12_000, false, &[0x7c, 0x85, 1, 2]);
+        let end = rtp_packet(11, 12_000, true, &[0x7c, 0x45, 3, 4]);
+
+        assert!(assembler.push(&start).unwrap().is_none());
+        let access_unit = assembler.push(&end).unwrap().unwrap();
+        assert_eq!(access_unit.payload.as_ref(), &[0, 0, 0, 1, 0x65, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn sequence_gap_recovers_h264_at_next_keyframe() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::H264, 90_000, 0, 640, 480).unwrap();
+        let start = rtp_packet(10, 12_000, false, &[0x7c, 0x85, 1, 2]);
+        let delta = rtp_packet(12, 15_000, true, &[0x41, 1, 2]);
+        let key = rtp_packet(13, 18_000, true, &[0x65, 3, 4]);
+
+        assert!(assembler.push(&start).unwrap().is_none());
+        // The gap dropped the fragment; the delta frame after it is withheld.
+        assert!(assembler.push(&delta).unwrap().is_none());
+        let stats = assembler.stats();
+        assert_eq!(stats.sequence_gaps, 1);
+        assert_eq!(stats.dropped_access_units, 1);
+        assert!(stats.awaiting_keyframe);
+
+        let access_unit = assembler.push(&key).unwrap().unwrap();
+        assert_eq!(access_unit.frame_type, EncodedFrameType::Key);
+        assert_eq!(access_unit.payload.as_ref(), &[0, 0, 0, 1, 0x65, 3, 4]);
+        let stats = assembler.stats();
+        assert_eq!(stats.dropped_access_units, 1);
+        assert!(!stats.awaiting_keyframe);
+    }
+
+    #[test]
+    fn marker_with_open_h264_fragment_drops_access_unit() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::H264, 90_000, 0, 640, 480).unwrap();
+        let start = rtp_packet(10, 12_000, false, &[0x7c, 0x85, 1, 2]);
+        let truncated = rtp_packet(11, 12_000, true, &[0x7c, 0x05, 3, 4]);
+        let key = rtp_packet(12, 15_000, true, &[0x65, 5, 6]);
+
+        assert!(assembler.push(&start).unwrap().is_none());
+        // The marker arrived without the FU end bit: the fragment is truncated.
+        assert!(assembler.push(&truncated).unwrap().is_none());
+        let stats = assembler.stats();
+        assert_eq!(stats.sequence_gaps, 0);
+        assert_eq!(stats.dropped_access_units, 1);
+        assert!(stats.awaiting_keyframe);
+
+        let access_unit = assembler.push(&key).unwrap().unwrap();
+        assert_eq!(access_unit.frame_type, EncodedFrameType::Key);
+        assert_eq!(access_unit.payload.as_ref(), &[0, 0, 0, 1, 0x65, 5, 6]);
+        assert!(!assembler.stats().awaiting_keyframe);
+    }
+
+    #[test]
+    fn drops_h264_fu_continuation_without_start() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::H264, 90_000, 0, 640, 480).unwrap();
+        let continuation = rtp_packet(10, 12_000, false, &[0x7c, 0x05, 1, 2]);
+        let key = rtp_packet(11, 15_000, true, &[0x65, 3, 4]);
+
+        assert!(assembler.push(&continuation).unwrap().is_none());
+        assert!(assembler.stats().awaiting_keyframe);
+
+        let access_unit = assembler.push(&key).unwrap().unwrap();
+        assert_eq!(access_unit.frame_type, EncodedFrameType::Key);
+        assert_eq!(access_unit.payload.as_ref(), &[0, 0, 0, 1, 0x65, 3, 4]);
+    }
+
+    #[test]
+    fn assembles_vp8_fragments() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP8, 90_000, 0, 640, 480).unwrap();
+        let start = rtp_packet(10, 12_000, false, &[0x10, 0x00, 1, 2]);
+        let end = rtp_packet(11, 12_000, true, &[0x00, 3, 4]);
+
+        assert!(assembler.push(&start).unwrap().is_none());
+        let access_unit = assembler.push(&end).unwrap().unwrap();
+        assert_eq!(access_unit.codec, EncodedVideoCodec::VP8);
+        assert_eq!(access_unit.frame_type, EncodedFrameType::Key);
+        assert_eq!(access_unit.payload.as_ref(), &[0x00, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn drops_vp8_mid_frame_start() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP8, 90_000, 0, 640, 480).unwrap();
+        let mid_frame = rtp_packet(10, 12_000, true, &[0x00, 1, 2]);
+        let key = rtp_packet(11, 15_000, true, &[0x10, 0x00, 3, 4]);
+
+        assert!(assembler.push(&mid_frame).unwrap().is_none());
+        assert!(assembler.stats().awaiting_keyframe);
+
+        let access_unit = assembler.push(&key).unwrap().unwrap();
+        assert_eq!(access_unit.frame_type, EncodedFrameType::Key);
+        assert_eq!(access_unit.payload.as_ref(), &[0x00, 3, 4]);
+    }
+
+    #[test]
+    fn assembles_vp9_single_layer_frame() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP9, 90_000, 0, 640, 480).unwrap();
+        let packet = rtp_packet(10, 12_000, true, &[0x0c, 0x82, 1, 2]);
+
+        let access_unit = assembler.push(&packet).unwrap().unwrap();
+        assert_eq!(access_unit.codec, EncodedVideoCodec::VP9);
+        assert_eq!(access_unit.frame_type, EncodedFrameType::Key);
+        assert_eq!(access_unit.payload.as_ref(), &[0x82, 1, 2]);
+    }
+
+    #[test]
+    fn assembles_vp9_non_flexible_layer_descriptor() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP9, 90_000, 0, 640, 480).unwrap();
+        let packet = rtp_packet(10, 12_000, true, &[0x2c, 0x10, 7, 0x82, 1, 2]);
+
+        let access_unit = assembler.push(&packet).unwrap().unwrap();
+        assert_eq!(access_unit.codec, EncodedVideoCodec::VP9);
+        assert_eq!(access_unit.payload.as_ref(), &[0x82, 1, 2]);
+    }
+
+    #[test]
+    fn assembles_vp9_single_layer_scalability_structure() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP9, 90_000, 0, 640, 480).unwrap();
+        let packet = rtp_packet(
+            10,
+            12_000,
+            true,
+            &[
+                0x0e, // B, E, V
+                0x18, // one spatial layer, resolution present, picture group present
+                0x01, 0x40, 0x00, 0xb4, // 320x180
+                0x01, // one picture group
+                0x04, // one reference index
+                0x01, // P_DIFF
+                0x82, 1, 2,
+            ],
+        );
+
+        let access_unit = assembler.push(&packet).unwrap().unwrap();
+        assert_eq!(access_unit.codec, EncodedVideoCodec::VP9);
+        assert_eq!(access_unit.frame_type, EncodedFrameType::Key);
+        assert_eq!(access_unit.payload.as_ref(), &[0x82, 1, 2]);
+    }
+
+    #[test]
+    fn assembles_vp9_descriptor_keyframe_from_prediction_bit() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP9, 90_000, 0, 640, 480).unwrap();
+        let packet = rtp_packet(
+            10,
+            12_000,
+            true,
+            &[
+                0x0e, // B, E, V; P is clear, so this is not inter-picture predicted.
+                0x18, // one spatial layer, resolution present, picture group present
+                0x02, 0x80, 0x01, 0x68, // 640x360
+                0x01, // one picture group
+                0x04, // one reference index
+                0x01, // P_DIFF
+                0xb1, 1, 2,
+            ],
+        );
+
+        let access_unit = assembler.push(&packet).unwrap().unwrap();
+        assert_eq!(access_unit.frame_type, EncodedFrameType::Key);
+        assert_eq!(access_unit.payload.as_ref(), &[0xb1, 1, 2]);
+    }
+
+    #[test]
+    fn assembles_vp9_predicted_frame_as_delta() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP9, 90_000, 0, 640, 480).unwrap();
+        // P is set and the payload is an inter frame: must not classify as Key.
+        let packet = rtp_packet(10, 12_000, true, &[0x4c, 0x86, 1, 2]);
+
+        let access_unit = assembler.push(&packet).unwrap().unwrap();
+        assert_eq!(access_unit.frame_type, EncodedFrameType::Delta);
+        assert_eq!(access_unit.payload.as_ref(), &[0x86, 1, 2]);
+    }
+
+    #[test]
+    fn vp9_bitstream_keyframe_overrides_predicted_bit() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP9, 90_000, 0, 640, 480).unwrap();
+        // P is set but the uncompressed header says KEY_FRAME.
+        let packet = rtp_packet(10, 12_000, true, &[0x4c, 0x82, 1, 2]);
+
+        let access_unit = assembler.push(&packet).unwrap().unwrap();
+        assert_eq!(access_unit.frame_type, EncodedFrameType::Key);
+        assert_eq!(access_unit.payload.as_ref(), &[0x82, 1, 2]);
+    }
+
+    #[test]
+    fn classifies_vp9_uncompressed_header_frame_types() {
+        // 0b1000_0010: marker, profile 0, show_existing=0, KEY_FRAME, show_frame=1.
+        assert!(is_vp9_keyframe(&[0x82]));
+        // 0b1000_0011: keyframe with error_resilient_mode set.
+        assert!(is_vp9_keyframe(&[0x83]));
+        // 0b1011_0000: profile 3 keyframe.
+        assert!(is_vp9_keyframe(&[0xb0]));
+        // 0b1000_0110: frame_type=1, an inter frame.
+        assert!(!is_vp9_keyframe(&[0x86]));
+        // 0b1011_0010: profile 3 inter frame.
+        assert!(!is_vp9_keyframe(&[0xb2]));
+        // 0b1000_1000: show_existing_frame repeats a decoded frame.
+        assert!(!is_vp9_keyframe(&[0x88]));
+        // 0b0000_0010: invalid frame_marker.
+        assert!(!is_vp9_keyframe(&[0x02]));
+        assert!(!is_vp9_keyframe(&[]));
+    }
+
+    #[test]
+    fn rejects_vp9_multi_layer_scalability_structure() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP9, 90_000, 0, 640, 480).unwrap();
+        let packet = rtp_packet(10, 12_000, true, &[0x0e, 0x20, 0x82, 1, 2]);
+
+        let err = assembler.push(&packet).unwrap_err();
+        assert_eq!(err, RtpDepacketizerError::UnsupportedPayloadDescriptor);
+    }
+
+    #[test]
+    fn drops_vp9_mid_frame_start() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP9, 90_000, 0, 640, 480).unwrap();
+        let mid_frame = rtp_packet(10, 12_000, true, &[0x04, 0x82, 1, 2]);
+        let key = rtp_packet(11, 15_000, true, &[0x0c, 0x82, 3, 4]);
+
+        assert!(assembler.push(&mid_frame).unwrap().is_none());
+        assert!(assembler.stats().awaiting_keyframe);
+
+        let access_unit = assembler.push(&key).unwrap().unwrap();
+        assert_eq!(access_unit.frame_type, EncodedFrameType::Key);
+        assert_eq!(access_unit.payload.as_ref(), &[0x82, 3, 4]);
+    }
+
+    #[test]
+    fn rejects_vp9_flexible_mode() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP9, 90_000, 0, 640, 480).unwrap();
+        let packet = rtp_packet(10, 12_000, true, &[0x1c, 0xa2, 1, 2]);
+
+        let err = assembler.push(&packet).unwrap_err();
+        assert_eq!(err, RtpDepacketizerError::UnsupportedPayloadDescriptor);
+    }
+
+    #[test]
+    fn assembles_av1_temporal_unit() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::AV1, 90_000, 0, 640, 480).unwrap();
+        let packet = rtp_packet(10, 12_000, true, &av1_sequence_and_frame_rtp_payload(0x10));
+
+        let access_unit = assembler.push(&packet).unwrap().unwrap();
+        assert_eq!(access_unit.codec, EncodedVideoCodec::AV1);
+        assert_eq!(access_unit.frame_type, EncodedFrameType::Key);
+        assert_eq!(access_unit.payload.as_ref(), &[0x0a, 0x01, 0x00, 0x32, 0x01, 0x10]);
+    }
+
+    #[test]
+    fn av1_sequence_header_before_inter_frame_is_delta() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::AV1, 90_000, 0, 640, 480).unwrap();
+        let packet = rtp_packet(10, 12_000, true, &av1_sequence_and_frame_rtp_payload(0x38));
+
+        let access_unit = assembler.push(&packet).unwrap().unwrap();
+        assert_eq!(access_unit.frame_type, EncodedFrameType::Delta);
+        assert_eq!(access_unit.payload.as_ref(), &[0x0a, 0x01, 0x00, 0x32, 0x01, 0x38]);
+    }
+
+    #[test]
+    fn assembles_fragmented_av1_obu() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::AV1, 90_000, 0, 640, 480).unwrap();
+        let start = rtp_packet(10, 12_000, false, &[0x50, 0x30, 0x38]);
+        let end = rtp_packet(11, 12_000, true, &[0x90, 2, 3]);
+
+        assert!(assembler.push(&start).unwrap().is_none());
+        let access_unit = assembler.push(&end).unwrap().unwrap();
+        assert_eq!(access_unit.frame_type, EncodedFrameType::Delta);
+        assert_eq!(access_unit.payload.as_ref(), &[0x32, 0x03, 0x38, 2, 3]);
+    }
+
+    #[test]
+    fn assembles_av1_obu_payload_with_size_field() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::AV1, 90_000, 0, 640, 480).unwrap();
+        let packet = rtp_packet(10, 12_000, true, &[0x10, 0x30, 0x38, 2, 3]);
+
+        let access_unit = assembler.push(&packet).unwrap().unwrap();
+        assert_eq!(access_unit.frame_type, EncodedFrameType::Delta);
+        assert_eq!(access_unit.payload.as_ref(), &[0x32, 0x03, 0x38, 2, 3]);
+    }
+
+    #[test]
+    fn marker_with_open_av1_fragment_drops_frame() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::AV1, 90_000, 0, 640, 480).unwrap();
+        // Y is set, so the OBU fragment is unterminated when the marker closes it.
+        let truncated = rtp_packet(10, 12_000, true, &[0x50, 0x30, 1]);
+        let key = rtp_packet(11, 15_000, true, &av1_sequence_and_frame_rtp_payload(0x10));
+
+        assert!(assembler.push(&truncated).unwrap().is_none());
+        let stats = assembler.stats();
+        assert_eq!(stats.dropped_access_units, 1);
+        assert!(stats.awaiting_keyframe);
+
+        let access_unit = assembler.push(&key).unwrap().unwrap();
+        assert_eq!(access_unit.frame_type, EncodedFrameType::Key);
+        assert_eq!(access_unit.payload.as_ref(), &[0x0a, 0x01, 0x00, 0x32, 0x01, 0x10]);
+        assert!(!assembler.stats().awaiting_keyframe);
+    }
+
+    #[test]
+    fn drops_av1_fragment_continuation_without_start() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::AV1, 90_000, 0, 640, 480).unwrap();
+        // Z is set: this continues an OBU whose start was never received.
+        let continuation = rtp_packet(10, 12_000, true, &[0x90, 2, 3]);
+        let key = rtp_packet(11, 15_000, true, &av1_sequence_and_frame_rtp_payload(0x10));
+
+        assert!(assembler.push(&continuation).unwrap().is_none());
+        assert!(assembler.stats().awaiting_keyframe);
+
+        let access_unit = assembler.push(&key).unwrap().unwrap();
+        assert_eq!(access_unit.frame_type, EncodedFrameType::Key);
+        assert_eq!(access_unit.payload.as_ref(), &[0x0a, 0x01, 0x00, 0x32, 0x01, 0x10]);
+    }
+
+    #[test]
+    fn sequence_gap_recovers_vp8_at_next_keyframe() {
+        let mut assembler =
+            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP8, 90_000, 0, 640, 480).unwrap();
+        let start = rtp_packet(10, 12_000, false, &[0x10, 0x00, 1, 2]);
+        let delta = rtp_packet(12, 15_000, true, &[0x10, 0x01, 3, 4]);
+        let key = rtp_packet(13, 18_000, true, &[0x10, 0x00, 5, 6]);
+
+        assert!(assembler.push(&start).unwrap().is_none());
+        // The gap dropped the fragment; the delta frame after it is withheld.
+        assert!(assembler.push(&delta).unwrap().is_none());
+        let stats = assembler.stats();
+        assert_eq!(stats.sequence_gaps, 1);
+        assert_eq!(stats.dropped_access_units, 1);
+        assert!(stats.awaiting_keyframe);
+
+        let access_unit = assembler.push(&key).unwrap().unwrap();
+        assert_eq!(access_unit.frame_type, EncodedFrameType::Key);
+        assert_eq!(access_unit.payload.as_ref(), &[0x00, 5, 6]);
+        assert!(!assembler.stats().awaiting_keyframe);
+    }
+}

--- a/livekit-capture/src/encoded/rtp.rs
+++ b/livekit-capture/src/encoded/rtp.rs
@@ -21,6 +21,7 @@ use crate::{
         OwnedEncodedAccessUnit,
     },
     error::CaptureError,
+    primitives::VideoResolution,
 };
 
 /// Parsed RTP packet header and payload.
@@ -174,8 +175,7 @@ pub struct RtpDepacketizerStats {
 #[derive(Debug, Clone)]
 pub struct RtpAccessUnitAssembler {
     codec: EncodedVideoCodec,
-    width: u32,
-    height: u32,
+    dimensions: VideoResolution,
     timestamp_mapper: RtpTimestampMapper,
     expected_sequence_number: Option<u16>,
     current: Option<PartialAccessUnit>,
@@ -221,8 +221,7 @@ impl RtpAccessUnitAssembler {
         codec: EncodedVideoCodec,
         clock_rate: u32,
         start_timestamp_us: i64,
-        width: u32,
-        height: u32,
+        dimensions: VideoResolution,
     ) -> Result<Self, RtpDepacketizerError> {
         if clock_rate == 0 {
             return Err(RtpDepacketizerError::InvalidClockRate);
@@ -230,8 +229,7 @@ impl RtpAccessUnitAssembler {
 
         Ok(Self {
             codec,
-            width,
-            height,
+            dimensions,
             timestamp_mapper: RtpTimestampMapper::new(clock_rate, start_timestamp_us),
             expected_sequence_number: None,
             current: None,
@@ -654,13 +652,8 @@ impl RtpAccessUnitAssembler {
         }
 
         let nal_units = current.nal_units.iter().map(Vec::as_slice).collect::<Vec<_>>();
-        let access_unit = access_unit_from_nalus(
-            self.codec,
-            &nal_units,
-            current.timestamp_us,
-            self.width,
-            self.height,
-        )?;
+        let access_unit =
+            access_unit_from_nalus(self.codec, &nal_units, current.timestamp_us, self.dimensions)?;
         Ok(self.gate_on_keyframe(access_unit))
     }
 
@@ -679,8 +672,7 @@ impl RtpAccessUnitAssembler {
             Bytes::from(current.payload),
             current.timestamp_us,
             current.frame_type.unwrap_or(EncodedFrameType::Delta),
-            self.width,
-            self.height,
+            self.dimensions,
         );
         access_unit.codec_specific = CodecSpecific::default_for(self.codec);
         Ok(self.gate_on_keyframe(access_unit))
@@ -1164,8 +1156,13 @@ mod tests {
 
     #[test]
     fn assembles_h264_fu_a() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::H264, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::H264,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let start = rtp_packet(10, 12_000, false, &[0x7c, 0x85, 1, 2]);
         let end = rtp_packet(11, 12_000, true, &[0x7c, 0x45, 3, 4]);
 
@@ -1176,8 +1173,13 @@ mod tests {
 
     #[test]
     fn sequence_gap_recovers_h264_at_next_keyframe() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::H264, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::H264,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let start = rtp_packet(10, 12_000, false, &[0x7c, 0x85, 1, 2]);
         let delta = rtp_packet(12, 15_000, true, &[0x41, 1, 2]);
         let key = rtp_packet(13, 18_000, true, &[0x65, 3, 4]);
@@ -1200,8 +1202,13 @@ mod tests {
 
     #[test]
     fn marker_with_open_h264_fragment_drops_access_unit() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::H264, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::H264,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let start = rtp_packet(10, 12_000, false, &[0x7c, 0x85, 1, 2]);
         let truncated = rtp_packet(11, 12_000, true, &[0x7c, 0x05, 3, 4]);
         let key = rtp_packet(12, 15_000, true, &[0x65, 5, 6]);
@@ -1222,8 +1229,13 @@ mod tests {
 
     #[test]
     fn drops_h264_fu_continuation_without_start() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::H264, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::H264,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let continuation = rtp_packet(10, 12_000, false, &[0x7c, 0x05, 1, 2]);
         let key = rtp_packet(11, 15_000, true, &[0x65, 3, 4]);
 
@@ -1237,8 +1249,13 @@ mod tests {
 
     #[test]
     fn assembles_vp8_fragments() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP8, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::VP8,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let start = rtp_packet(10, 12_000, false, &[0x10, 0x00, 1, 2]);
         let end = rtp_packet(11, 12_000, true, &[0x00, 3, 4]);
 
@@ -1251,8 +1268,13 @@ mod tests {
 
     #[test]
     fn drops_vp8_mid_frame_start() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP8, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::VP8,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let mid_frame = rtp_packet(10, 12_000, true, &[0x00, 1, 2]);
         let key = rtp_packet(11, 15_000, true, &[0x10, 0x00, 3, 4]);
 
@@ -1266,8 +1288,13 @@ mod tests {
 
     #[test]
     fn assembles_vp9_single_layer_frame() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP9, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::VP9,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let packet = rtp_packet(10, 12_000, true, &[0x0c, 0x82, 1, 2]);
 
         let access_unit = assembler.push(&packet).unwrap().unwrap();
@@ -1278,8 +1305,13 @@ mod tests {
 
     #[test]
     fn assembles_vp9_non_flexible_layer_descriptor() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP9, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::VP9,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let packet = rtp_packet(10, 12_000, true, &[0x2c, 0x10, 7, 0x82, 1, 2]);
 
         let access_unit = assembler.push(&packet).unwrap().unwrap();
@@ -1289,8 +1321,13 @@ mod tests {
 
     #[test]
     fn assembles_vp9_single_layer_scalability_structure() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP9, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::VP9,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let packet = rtp_packet(
             10,
             12_000,
@@ -1314,8 +1351,13 @@ mod tests {
 
     #[test]
     fn assembles_vp9_descriptor_keyframe_from_prediction_bit() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP9, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::VP9,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let packet = rtp_packet(
             10,
             12_000,
@@ -1338,8 +1380,13 @@ mod tests {
 
     #[test]
     fn assembles_vp9_predicted_frame_as_delta() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP9, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::VP9,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         // P is set and the payload is an inter frame: must not classify as Key.
         let packet = rtp_packet(10, 12_000, true, &[0x4c, 0x86, 1, 2]);
 
@@ -1350,8 +1397,13 @@ mod tests {
 
     #[test]
     fn vp9_bitstream_keyframe_overrides_predicted_bit() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP9, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::VP9,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         // P is set but the uncompressed header says KEY_FRAME.
         let packet = rtp_packet(10, 12_000, true, &[0x4c, 0x82, 1, 2]);
 
@@ -1381,8 +1433,13 @@ mod tests {
 
     #[test]
     fn rejects_vp9_multi_layer_scalability_structure() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP9, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::VP9,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let packet = rtp_packet(10, 12_000, true, &[0x0e, 0x20, 0x82, 1, 2]);
 
         let err = assembler.push(&packet).unwrap_err();
@@ -1391,8 +1448,13 @@ mod tests {
 
     #[test]
     fn drops_vp9_mid_frame_start() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP9, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::VP9,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let mid_frame = rtp_packet(10, 12_000, true, &[0x04, 0x82, 1, 2]);
         let key = rtp_packet(11, 15_000, true, &[0x0c, 0x82, 3, 4]);
 
@@ -1406,8 +1468,13 @@ mod tests {
 
     #[test]
     fn rejects_vp9_flexible_mode() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP9, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::VP9,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let packet = rtp_packet(10, 12_000, true, &[0x1c, 0xa2, 1, 2]);
 
         let err = assembler.push(&packet).unwrap_err();
@@ -1416,8 +1483,13 @@ mod tests {
 
     #[test]
     fn assembles_av1_temporal_unit() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::AV1, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::AV1,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let packet = rtp_packet(10, 12_000, true, &av1_sequence_and_frame_rtp_payload(0x10));
 
         let access_unit = assembler.push(&packet).unwrap().unwrap();
@@ -1428,8 +1500,13 @@ mod tests {
 
     #[test]
     fn av1_sequence_header_before_inter_frame_is_delta() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::AV1, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::AV1,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let packet = rtp_packet(10, 12_000, true, &av1_sequence_and_frame_rtp_payload(0x38));
 
         let access_unit = assembler.push(&packet).unwrap().unwrap();
@@ -1439,8 +1516,13 @@ mod tests {
 
     #[test]
     fn assembles_fragmented_av1_obu() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::AV1, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::AV1,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let start = rtp_packet(10, 12_000, false, &[0x50, 0x30, 0x38]);
         let end = rtp_packet(11, 12_000, true, &[0x90, 2, 3]);
 
@@ -1452,8 +1534,13 @@ mod tests {
 
     #[test]
     fn assembles_av1_obu_payload_with_size_field() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::AV1, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::AV1,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let packet = rtp_packet(10, 12_000, true, &[0x10, 0x30, 0x38, 2, 3]);
 
         let access_unit = assembler.push(&packet).unwrap().unwrap();
@@ -1463,8 +1550,13 @@ mod tests {
 
     #[test]
     fn marker_with_open_av1_fragment_drops_frame() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::AV1, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::AV1,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         // Y is set, so the OBU fragment is unterminated when the marker closes it.
         let truncated = rtp_packet(10, 12_000, true, &[0x50, 0x30, 1]);
         let key = rtp_packet(11, 15_000, true, &av1_sequence_and_frame_rtp_payload(0x10));
@@ -1482,8 +1574,13 @@ mod tests {
 
     #[test]
     fn drops_av1_fragment_continuation_without_start() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::AV1, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::AV1,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         // Z is set: this continues an OBU whose start was never received.
         let continuation = rtp_packet(10, 12_000, true, &[0x90, 2, 3]);
         let key = rtp_packet(11, 15_000, true, &av1_sequence_and_frame_rtp_payload(0x10));
@@ -1498,8 +1595,13 @@ mod tests {
 
     #[test]
     fn sequence_gap_recovers_vp8_at_next_keyframe() {
-        let mut assembler =
-            RtpAccessUnitAssembler::new(EncodedVideoCodec::VP8, 90_000, 0, 640, 480).unwrap();
+        let mut assembler = RtpAccessUnitAssembler::new(
+            EncodedVideoCodec::VP8,
+            90_000,
+            0,
+            VideoResolution::new(640, 480),
+        )
+        .unwrap();
         let start = rtp_packet(10, 12_000, false, &[0x10, 0x00, 1, 2]);
         let delta = rtp_packet(12, 15_000, true, &[0x10, 0x01, 3, 4]);
         let key = rtp_packet(13, 18_000, true, &[0x10, 0x00, 5, 6]);

--- a/livekit-capture/src/error.rs
+++ b/livekit-capture/src/error.rs
@@ -1,0 +1,52 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use thiserror::Error;
+
+use crate::encoded::{EncodedVideoCodec, EncodedWireFormat};
+
+/// Error returned by capture helpers.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum CaptureError {
+    /// Encoded payload is empty.
+    #[error("encoded payload is empty")]
+    EmptyPayload,
+    /// H.265 NAL unit is too short to contain its header.
+    #[error("H.265 NAL unit is too short")]
+    H265NalTooShort,
+    /// DMA-BUF frame did not include any planes.
+    #[error("DMA-BUF frame did not include any planes")]
+    MissingDmaBufPlane,
+    /// DMA-BUF frame layout cannot be represented by the native capture path.
+    #[error("unsupported DMA-BUF layout: {0}")]
+    UnsupportedDmaBufLayout(&'static str),
+    /// Access unit carries layering metadata the passthrough cannot forward.
+    #[error("unsupported layered encoding: {0}")]
+    UnsupportedLayeredEncoding(&'static str),
+    /// Codec is represented by the API but not yet supported by native passthrough.
+    #[error("encoded passthrough does not support {0:?} yet")]
+    UnsupportedCodec(EncodedVideoCodec),
+    /// Encoded payload or transport data is malformed.
+    #[error("invalid encoded data: {0}")]
+    InvalidEncodedData(&'static str),
+    /// Wire format is represented by the API but not supported by this source.
+    #[error("encoded wire format is not supported by this source: {0:?}")]
+    UnsupportedWireFormat(EncodedWireFormat),
+    /// Capture backend is not available on this platform.
+    #[error("{0} is not supported on this platform")]
+    UnsupportedPlatform(&'static str),
+    /// The underlying source rejected the frame.
+    #[error("capture source rejected the frame")]
+    CaptureFailed,
+}

--- a/livekit-capture/src/lib.rs
+++ b/livekit-capture/src/lib.rs
@@ -17,29 +17,13 @@
 pub mod device;
 pub mod dmabuf;
 pub mod encoded;
-mod error;
 pub mod source;
 pub mod sources;
-pub(crate) mod time;
 pub mod track;
 
-pub use device::{
-    CaptureBackend, CaptureDeviceInfo, CaptureDeviceQueryError, CaptureDeviceSelector,
-    CaptureFormat, CaptureFormatRequest, CaptureFrameFormat, CapturePath, CaptureResolution,
-};
-pub use dmabuf::{DmaBufFrame, DmaBufPixelFormat, DmaBufPlane};
-pub use encoded::{
-    ingress::{
-        EncodedAccessUnitSource, EncodedIngress, EncodedIngressCapture, EncodedIngressError,
-        EncodedIngressStop,
-    },
-    CodecSpecific, EncodedAccessUnit, EncodedFragment, EncodedFrameType, EncodedLayerInfo,
-    EncodedPayload, EncodedRateControl, EncodedVideoCodec, EncodedWireFormat,
-    H264PacketizationMode, OwnedEncodedAccessUnit,
-};
+mod error;
+pub(crate) mod time;
+
 pub use error::CaptureError;
-pub use source::{
-    CaptureFrame, CaptureFrameSource, EncodedCaptureFrameSource, EncodedFrameSourceError,
-    NativeVideoFrame, RawVideoFrame,
-};
+pub use source::{CaptureFrame, CaptureFrameSource};
 pub use track::VideoCaptureTrack;

--- a/livekit-capture/src/lib.rs
+++ b/livekit-capture/src/lib.rs
@@ -1,0 +1,45 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Capture helpers for publishing decoded, DMA-BUF, and encoded video with LiveKit.
+
+pub mod device;
+pub mod dmabuf;
+pub mod encoded;
+mod error;
+pub mod source;
+pub mod sources;
+pub(crate) mod time;
+pub mod track;
+
+pub use device::{
+    CaptureBackend, CaptureDeviceInfo, CaptureDeviceQueryError, CaptureDeviceSelector,
+    CaptureFormat, CaptureFormatRequest, CaptureFrameFormat, CapturePath, CaptureResolution,
+};
+pub use dmabuf::{DmaBufFrame, DmaBufPixelFormat, DmaBufPlane};
+pub use encoded::{
+    ingress::{
+        EncodedAccessUnitSource, EncodedIngress, EncodedIngressCapture, EncodedIngressError,
+        EncodedIngressStop,
+    },
+    CodecSpecific, EncodedAccessUnit, EncodedFragment, EncodedFrameType, EncodedLayerInfo,
+    EncodedPayload, EncodedRateControl, EncodedVideoCodec, EncodedWireFormat,
+    H264PacketizationMode, OwnedEncodedAccessUnit,
+};
+pub use error::CaptureError;
+pub use source::{
+    CaptureFrame, CaptureFrameSource, EncodedCaptureFrameSource, EncodedFrameSourceError,
+    NativeVideoFrame, RawVideoFrame,
+};
+pub use track::VideoCaptureTrack;

--- a/livekit-capture/src/lib.rs
+++ b/livekit-capture/src/lib.rs
@@ -26,4 +26,3 @@ pub(crate) mod time;
 
 pub use error::CaptureError;
 pub use source::{CaptureFrame, CaptureFrameSource};
-pub use track::VideoCaptureTrack;

--- a/livekit-capture/src/lib.rs
+++ b/livekit-capture/src/lib.rs
@@ -17,6 +17,7 @@
 pub mod device;
 pub mod dmabuf;
 pub mod encoded;
+pub mod primitives;
 pub mod source;
 pub mod sources;
 pub mod track;

--- a/livekit-capture/src/lib.rs
+++ b/livekit-capture/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Capture helpers for publishing decoded, DMA-BUF, and encoded video with LiveKit.
+#![doc = include_str!("../README.md")]
 
 pub mod device;
 pub mod dmabuf;

--- a/livekit-capture/src/primitives.rs
+++ b/livekit-capture/src/primitives.rs
@@ -1,0 +1,69 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Domain-neutral video primitives shared across capture paths and backends.
+//!
+//! These types carry no capture- or codec-specific semantics, so they can serve
+//! as a common vocabulary for frame geometry and related quantities across
+//! crates.
+
+// TODO: in a future refactor, move these types into their own
+// crate (e.g., `livekit-video-primitives`) so all crates in this workspace can work
+// with common types without creating undesirable dependencies.
+
+/// Pixel dimensions of a video frame.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct VideoResolution {
+    /// Frame width in pixels.
+    pub width: u32,
+    /// Frame height in pixels.
+    pub height: u32,
+}
+
+impl VideoResolution {
+    /// Creates a video resolution from a width and height in pixels.
+    ///
+    /// ```
+    /// # use livekit_capture::primitives::VideoResolution;
+    /// let resolution = VideoResolution::new(1920, 1080);
+    /// assert_eq!(resolution.width, 1920);
+    /// assert_eq!(resolution.height, 1080);
+    /// ```
+    pub const fn new(width: u32, height: u32) -> Self {
+        Self { width, height }
+    }
+
+    /// Returns the ratio between the width and heigh components.
+    ///
+    /// If heigh component is zero, the result is `None`.
+    ///
+    /// ```
+    /// # use livekit_capture::primitives::VideoResolution;
+    /// assert_eq!(VideoResolution::new(1920, 960).aspect_ratio(), Some(2.0));
+    /// assert_eq!(VideoResolution::new(1920, 0).aspect_ratio(), None);
+    /// ```
+    ///
+    pub fn aspect_ratio(&self) -> Option<f64> {
+        if self.height == 0 {
+            return None;
+        }
+        Some(f64::from(self.width) / f64::from(self.height))
+    }
+}
+
+impl From<VideoResolution> for livekit::webrtc::video_source::VideoResolution {
+    fn from(value: VideoResolution) -> Self {
+        Self { width: value.width, height: value.height }
+    }
+}

--- a/livekit-capture/src/source.rs
+++ b/livekit-capture/src/source.rs
@@ -14,14 +14,17 @@
 
 use std::{error::Error, fmt};
 
-use livekit::webrtc::video_frame::{native::NativeBuffer, I420Buffer, VideoFrame};
+use livekit::webrtc::{
+    video_frame::{native::NativeBuffer, I420Buffer, VideoFrame},
+    video_source::native::NativeVideoSource,
+};
 
 use crate::{
     device::{CaptureFormat, CaptureFrameFormat, CapturePath},
     dmabuf::DmaBufFrame,
     encoded::{ingress::EncodedAccessUnitSource, OwnedEncodedAccessUnit},
     error::CaptureError,
-    track::VideoCaptureTrack,
+    track::NativeVideoSourceExt,
 };
 
 /// Uncompressed CPU-accessible video frame buffer produced by a capture source.
@@ -80,23 +83,25 @@ impl CaptureFrame {
             Self::Encoded(_) => CapturePath::Encoded,
         }
     }
+}
 
+impl CaptureFrame {
     /// Publishes this frame into a LiveKit capture track.
-    pub fn publish_to(&self, track: &VideoCaptureTrack) -> Result<(), CaptureError> {
+    pub fn capture_to(&self, source: &NativeVideoSource) -> Result<(), CaptureError> {
         match self {
             Self::Native(frame) => {
-                track.capture_frame(&frame.frame);
+                source.capture_frame(&frame.frame);
                 Ok(())
             }
             Self::Raw(frame) => {
-                track.capture_frame(&frame.frame);
+                source.capture_frame(&frame.frame);
                 Ok(())
             }
             #[cfg(target_os = "linux")]
-            Self::DmaBuf(frame) => track.capture_dmabuf(frame),
+            Self::DmaBuf(frame) => source.capture_dmabuf(frame),
             #[cfg(not(target_os = "linux"))]
             Self::DmaBuf(_) => Err(CaptureError::UnsupportedPlatform("DMA-BUF capture")),
-            Self::Encoded(access_unit) => track.capture_encoded(&access_unit.as_access_unit()),
+            Self::Encoded(access_unit) => source.capture_encoded(&access_unit.as_access_unit()),
         }
     }
 }

--- a/livekit-capture/src/source.rs
+++ b/livekit-capture/src/source.rs
@@ -1,0 +1,213 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{error::Error, fmt};
+
+use livekit::webrtc::video_frame::{native::NativeBuffer, I420Buffer, VideoFrame};
+
+use crate::{
+    device::{CaptureFormat, CaptureFrameFormat, CapturePath},
+    dmabuf::DmaBufFrame,
+    encoded::{ingress::EncodedAccessUnitSource, OwnedEncodedAccessUnit},
+    error::CaptureError,
+    track::VideoCaptureTrack,
+};
+
+/// Uncompressed CPU-accessible video frame buffer produced by a capture source.
+#[derive(Debug)]
+pub struct RawVideoFrame {
+    /// I420 video frame suitable for [`VideoCaptureTrack::capture_frame`].
+    pub frame: VideoFrame<I420Buffer>,
+    /// Source format delivered by the capture backend before conversion to I420.
+    pub source_format: CaptureFrameFormat,
+    /// Wall-clock capture timestamp in microseconds.
+    pub capture_wall_time_us: u64,
+    /// Wall-clock timestamp recorded after the frame was read, in microseconds.
+    pub read_wall_time_us: u64,
+    /// Backend capture timestamp translated to UNIX-epoch microseconds, when available.
+    pub sensor_timestamp_us: Option<u64>,
+    /// Whether the backend converted the source buffer before publishing.
+    pub used_conversion: bool,
+}
+
+impl RawVideoFrame {
+    /// Returns the decoded I420 video frame.
+    pub fn video_frame(&self) -> &VideoFrame<I420Buffer> {
+        &self.frame
+    }
+}
+
+/// Platform-native uncompressed video frame buffer produced by a capture source.
+#[derive(Debug)]
+pub struct NativeVideoFrame {
+    /// Native video frame suitable for [`VideoCaptureTrack::capture_frame`].
+    pub frame: VideoFrame<NativeBuffer>,
+    /// Source format delivered by the capture backend.
+    pub source_format: CaptureFrameFormat,
+    /// Wall-clock capture timestamp in microseconds.
+    pub capture_wall_time_us: u64,
+    /// Wall-clock timestamp recorded after the frame was read, in microseconds.
+    pub read_wall_time_us: u64,
+    /// Backend capture timestamp translated to UNIX-epoch microseconds, when available.
+    pub sensor_timestamp_us: Option<u64>,
+}
+
+impl NativeVideoFrame {
+    /// Returns the native video frame.
+    pub fn video_frame(&self) -> &VideoFrame<NativeBuffer> {
+        &self.frame
+    }
+}
+
+/// Frame produced by a capture source.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum CaptureFrame {
+    /// Platform-native uncompressed frame.
+    Native(NativeVideoFrame),
+    /// Uncompressed CPU-accessible frame.
+    Raw(RawVideoFrame),
+    /// Linux DMA-BUF backed frame.
+    DmaBuf(DmaBufFrame),
+    /// Encoded video access unit.
+    Encoded(OwnedEncodedAccessUnit),
+}
+
+impl CaptureFrame {
+    /// Returns the capture path used by this frame.
+    pub fn capture_path(&self) -> CapturePath {
+        match self {
+            Self::Native(_) => CapturePath::Native,
+            Self::Raw(_) => CapturePath::Raw,
+            Self::DmaBuf(_) => CapturePath::DmaBuf,
+            Self::Encoded(_) => CapturePath::Encoded,
+        }
+    }
+
+    /// Publishes this frame into a LiveKit capture track.
+    pub fn publish_to(&self, track: &VideoCaptureTrack) -> Result<(), CaptureError> {
+        match self {
+            Self::Native(frame) => {
+                track.capture_frame(&frame.frame);
+                Ok(())
+            }
+            Self::Raw(frame) => {
+                track.capture_frame(&frame.frame);
+                Ok(())
+            }
+            #[cfg(target_os = "linux")]
+            Self::DmaBuf(frame) => track.capture_dmabuf(frame),
+            #[cfg(not(target_os = "linux"))]
+            Self::DmaBuf(_) => Err(CaptureError::UnsupportedPlatform("DMA-BUF capture")),
+            Self::Encoded(access_unit) => track.capture_encoded(&access_unit.as_access_unit()),
+        }
+    }
+}
+
+/// Source that produces one of the common capture frame paths.
+pub trait CaptureFrameSource {
+    /// Error returned by the source.
+    type Error: Error + Send + Sync + 'static;
+
+    /// Returns the capture path produced by this source.
+    fn capture_path(&self) -> CapturePath;
+
+    /// Returns the negotiated capture format when the source has one.
+    fn format(&self) -> Option<CaptureFormat>;
+
+    /// Captures the next frame.
+    fn next_frame(&mut self) -> Result<CaptureFrame, Self::Error>;
+}
+
+/// Adapts an [`EncodedAccessUnitSource`] into the common frame-source model.
+#[derive(Debug)]
+pub struct EncodedCaptureFrameSource<S> {
+    source: S,
+}
+
+impl<S> EncodedCaptureFrameSource<S> {
+    /// Creates a frame-source adapter for an encoded access-unit source.
+    pub fn new(source: S) -> Self {
+        Self { source }
+    }
+
+    /// Returns the underlying encoded source.
+    pub fn source(&self) -> &S {
+        &self.source
+    }
+
+    /// Returns the underlying encoded source mutably.
+    pub fn source_mut(&mut self) -> &mut S {
+        &mut self.source
+    }
+
+    /// Consumes this adapter and returns the underlying encoded source.
+    pub fn into_inner(self) -> S {
+        self.source
+    }
+}
+
+impl<S> CaptureFrameSource for EncodedCaptureFrameSource<S>
+where
+    S: EncodedAccessUnitSource,
+{
+    type Error = EncodedFrameSourceError<S::Error>;
+
+    fn capture_path(&self) -> CapturePath {
+        CapturePath::Encoded
+    }
+
+    fn format(&self) -> Option<CaptureFormat> {
+        None
+    }
+
+    fn next_frame(&mut self) -> Result<CaptureFrame, Self::Error> {
+        let Some(access_unit) =
+            self.source.next_access_unit().map_err(EncodedFrameSourceError::Source)?
+        else {
+            return Err(EncodedFrameSourceError::EndOfStream);
+        };
+        Ok(CaptureFrame::Encoded(access_unit))
+    }
+}
+
+/// Error returned by [`EncodedCaptureFrameSource`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EncodedFrameSourceError<E> {
+    /// The encoded source reached EOF.
+    EndOfStream,
+    /// The encoded source failed.
+    Source(E),
+}
+
+impl<E: fmt::Display> fmt::Display for EncodedFrameSourceError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EndOfStream => f.write_str("encoded source reached end of stream"),
+            Self::Source(err) => write!(f, "encoded source failed: {err}"),
+        }
+    }
+}
+
+impl<E> Error for EncodedFrameSourceError<E>
+where
+    E: Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::EndOfStream => None,
+            Self::Source(err) => Some(err),
+        }
+    }
+}

--- a/livekit-capture/src/source.rs
+++ b/livekit-capture/src/source.rs
@@ -41,13 +41,6 @@ pub struct RawVideoFrame {
     pub used_conversion: bool,
 }
 
-impl RawVideoFrame {
-    /// Returns the decoded I420 video frame.
-    pub fn video_frame(&self) -> &VideoFrame<I420Buffer> {
-        &self.frame
-    }
-}
-
 /// Platform-native uncompressed video frame buffer produced by a capture source.
 #[derive(Debug)]
 pub struct NativeVideoFrame {
@@ -61,13 +54,6 @@ pub struct NativeVideoFrame {
     pub read_wall_time_us: u64,
     /// Backend capture timestamp translated to UNIX-epoch microseconds, when available.
     pub sensor_timestamp_us: Option<u64>,
-}
-
-impl NativeVideoFrame {
-    /// Returns the native video frame.
-    pub fn video_frame(&self) -> &VideoFrame<NativeBuffer> {
-        &self.frame
-    }
 }
 
 /// Frame produced by a capture source.

--- a/livekit-capture/src/sources/mod.rs
+++ b/livekit-capture/src/sources/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Optional capture sources that feed the shared capture paths.

--- a/livekit-capture/src/time.rs
+++ b/livekit-capture/src/time.rs
@@ -1,0 +1,65 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared capture-timestamp helpers used by the capture backends.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Maximum age a backend-reported capture timestamp may have, relative to the
+/// wall-clock read time, before it is considered stale and discarded.
+pub(crate) const MAX_CAPTURE_TIMESTAMP_AGE_US: u64 = 5_000_000;
+
+/// Returns the current UNIX wall-clock time in microseconds.
+pub(crate) fn unix_time_us_now() -> Option<u64> {
+    let elapsed = SystemTime::now().duration_since(UNIX_EPOCH).ok()?;
+    u64::try_from(elapsed.as_micros()).ok()
+}
+
+/// Converts a duration to whole microseconds, saturating at `i64::MAX`.
+pub(crate) fn elapsed_us(duration: Duration) -> i64 {
+    i64::try_from(duration.as_micros()).unwrap_or(i64::MAX)
+}
+
+/// Validates a backend-reported capture timestamp against the wall-clock read
+/// time: zero, future, and stale (older than
+/// [`MAX_CAPTURE_TIMESTAMP_AGE_US`]) timestamps are rejected.
+pub(crate) fn validate_capture_timestamp_us(
+    capture_timestamp_us: u64,
+    read_wall_time_us: u64,
+) -> Option<u64> {
+    if capture_timestamp_us == 0 || capture_timestamp_us > read_wall_time_us {
+        return None;
+    }
+    if read_wall_time_us - capture_timestamp_us > MAX_CAPTURE_TIMESTAMP_AGE_US {
+        return None;
+    }
+    Some(capture_timestamp_us)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_rejects_zero_future_and_stale_timestamps() {
+        let now = 10_000_000;
+        assert_eq!(validate_capture_timestamp_us(0, now), None);
+        assert_eq!(validate_capture_timestamp_us(now + 1, now), None);
+        assert_eq!(
+            validate_capture_timestamp_us(now - MAX_CAPTURE_TIMESTAMP_AGE_US - 1, now),
+            None
+        );
+        assert_eq!(validate_capture_timestamp_us(now - 1, now), Some(now - 1));
+    }
+}

--- a/livekit-capture/src/track.rs
+++ b/livekit-capture/src/track.rs
@@ -1,0 +1,284 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use livekit::{
+    options::{TrackPublishOptions, VideoEncoderBackend},
+    prelude::LocalVideoTrack,
+    webrtc::{
+        video_frame::{EncodedVideoFrame, FrameMetadata, VideoBuffer, VideoFrame},
+        video_source::{native::NativeVideoSource, RtcVideoSource, VideoResolution},
+    },
+};
+
+use crate::{
+    encoded::{
+        CodecSpecific, EncodedAccessUnit, EncodedLayerInfo, EncodedPayload, EncodedRateControl,
+        EncodedVideoCodec,
+    },
+    error::CaptureError,
+};
+
+pub use crate::device::CapturePath;
+#[cfg(target_os = "linux")]
+use crate::dmabuf::DmaBufFrame;
+
+/// Capture source backed by a LiveKit local video track.
+#[derive(Debug, Clone)]
+pub struct VideoCaptureTrack {
+    source: NativeVideoSource,
+    track: LocalVideoTrack,
+}
+
+impl VideoCaptureTrack {
+    /// Creates a capture track with the supplied resolution.
+    pub fn new(name: &str, resolution: VideoResolution, is_screencast: bool) -> Self {
+        let source = NativeVideoSource::new(resolution, is_screencast);
+        let track =
+            LocalVideoTrack::create_video_track(name, RtcVideoSource::Native(source.clone()));
+        Self { source, track }
+    }
+
+    /// Creates a capture track for pre-encoded access units.
+    ///
+    /// Unlike [`VideoCaptureTrack::new`], no raw keepalive frames are
+    /// injected before the first capture, so the sender starts directly on
+    /// the passthrough encoder instead of briefly encoding black frames.
+    pub fn new_encoded(name: &str, resolution: VideoResolution) -> Self {
+        let source = NativeVideoSource::new_encoded(resolution);
+        let track =
+            LocalVideoTrack::create_video_track(name, RtcVideoSource::Native(source.clone()));
+        Self { source, track }
+    }
+
+    /// Returns the publishable local video track.
+    pub fn track(&self) -> LocalVideoTrack {
+        self.track.clone()
+    }
+
+    /// Captures one decoded video frame.
+    pub fn capture_frame<T: AsRef<dyn VideoBuffer>>(&self, frame: &VideoFrame<T>) {
+        self.source.capture_frame(frame);
+    }
+
+    /// Captures one DMA-BUF backed frame.
+    ///
+    /// The native capture path hands a single file descriptor to the driver
+    /// and derives the plane layout from the underlying buffer itself
+    /// (NvBufSurface); per-plane offsets, strides, and DRM modifiers in
+    /// [`DmaBufFrame`] are informational and must describe that derived
+    /// layout. Frames whose planes span multiple file descriptors or start
+    /// at a nonzero offset are rejected rather than silently truncated.
+    #[cfg(target_os = "linux")]
+    pub fn capture_dmabuf(&self, frame: &DmaBufFrame) -> Result<(), CaptureError> {
+        let plane = frame.planes.first().ok_or(CaptureError::MissingDmaBufPlane)?;
+        if frame.planes.iter().any(|other| other.fd != plane.fd) {
+            return Err(CaptureError::UnsupportedDmaBufLayout(
+                "planes must share one DMA-BUF file descriptor",
+            ));
+        }
+        if plane.offset != 0 {
+            return Err(CaptureError::UnsupportedDmaBufLayout(
+                "first plane must start at offset 0",
+            ));
+        }
+        let ok = self.source.capture_dmabuf_frame(
+            plane.fd,
+            frame.width,
+            frame.height,
+            frame.pixel_format.as_native(),
+            frame.timestamp_us,
+        );
+        ok.then_some(()).ok_or(CaptureError::CaptureFailed)
+    }
+
+    /// Captures one encoded video access unit.
+    ///
+    /// The passthrough path forwards single-layer streams: access units
+    /// carrying temporal/spatial layer ids, an AV1 dependency descriptor, or
+    /// a non-`L1T1` scalability mode are rejected so callers are not misled
+    /// into thinking that metadata reaches the wire.
+    pub fn capture_encoded(&self, access_unit: &EncodedAccessUnit<'_>) -> Result<(), CaptureError> {
+        self.capture_encoded_with_metadata(access_unit, None)
+    }
+
+    /// Captures one encoded video access unit with optional frame metadata.
+    ///
+    /// Metadata is only propagated to subscribers when the corresponding
+    /// [`TrackPublishOptions::frame_metadata_features`] are enabled before
+    /// publishing the local track.
+    pub fn capture_encoded_with_metadata(
+        &self,
+        access_unit: &EncodedAccessUnit<'_>,
+        frame_metadata: Option<FrameMetadata>,
+    ) -> Result<(), CaptureError> {
+        validate_encoded_access_unit(access_unit)?;
+
+        let scratch;
+        let payload: &[u8] = match &access_unit.payload {
+            EncodedPayload::Contiguous(bytes) => bytes,
+            EncodedPayload::Owned(bytes) => bytes,
+            EncodedPayload::Fragments(_) => {
+                scratch = access_unit.payload.to_vec();
+                &scratch
+            }
+        };
+        let frame = EncodedVideoFrame {
+            codec: access_unit.codec.into(),
+            payload,
+            timestamp_us: access_unit.timestamp_us,
+            frame_type: access_unit.frame_type.into(),
+            resolution: VideoResolution { width: access_unit.width, height: access_unit.height },
+            frame_metadata,
+        };
+        self.source.capture_encoded_frame(&frame).then_some(()).ok_or(CaptureError::CaptureFailed)
+    }
+
+    /// Returns and clears the pending keyframe request raised by the
+    /// passthrough encoder (PLI/FIR from the SFU, late subscriber join, or
+    /// sender reconfiguration).
+    ///
+    /// Poll this from the capture loop and forward the request to the
+    /// upstream encoder so it produces an IDR; until one arrives, new
+    /// subscribers cannot render the track.
+    pub fn take_keyframe_request(&self) -> bool {
+        self.source.take_keyframe_request()
+    }
+
+    /// Returns and clears the pending rate-control target raised by the
+    /// passthrough encoder.
+    ///
+    /// Poll this from the capture loop and forward the target to the
+    /// upstream encoder so congestion control can adjust the produced
+    /// bitrate.
+    pub fn take_rate_control_request(&self) -> Option<EncodedRateControl> {
+        self.source.take_rate_control_request()
+    }
+
+    /// Returns publish options appropriate for encoded passthrough.
+    pub fn encoded_publish_options(codec: EncodedVideoCodec) -> TrackPublishOptions {
+        TrackPublishOptions {
+            video_codec: codec.into(),
+            video_encoder: VideoEncoderBackend::PreEncoded,
+            simulcast: false,
+            ..Default::default()
+        }
+    }
+}
+
+fn validate_encoded_access_unit(access_unit: &EncodedAccessUnit<'_>) -> Result<(), CaptureError> {
+    if access_unit.payload.is_empty() {
+        return Err(CaptureError::EmptyPayload);
+    }
+    if access_unit.layers != EncodedLayerInfo::default() {
+        return Err(CaptureError::UnsupportedLayeredEncoding(
+            "temporal/spatial layer ids are not forwarded by the passthrough encoder",
+        ));
+    }
+    let default_specific = CodecSpecific::default_for(access_unit.codec);
+    if access_unit.codec_specific != CodecSpecific::None
+        && access_unit.codec_specific != default_specific
+    {
+        return Err(CaptureError::UnsupportedLayeredEncoding(
+            "codec-specific layering metadata is not forwarded by the passthrough encoder",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::encoded::EncodedFrameType;
+
+    #[test]
+    fn accepts_vp8_vp9_and_av1_access_units() {
+        for codec in [EncodedVideoCodec::VP8, EncodedVideoCodec::VP9, EncodedVideoCodec::AV1] {
+            let access_unit = EncodedAccessUnit::contiguous(
+                codec,
+                &[1, 2, 3],
+                0,
+                EncodedFrameType::Key,
+                640,
+                480,
+            );
+
+            assert!(validate_encoded_access_unit(&access_unit).is_ok());
+        }
+    }
+
+    #[test]
+    fn rejects_empty_encoded_access_units() {
+        let access_unit = EncodedAccessUnit::contiguous(
+            EncodedVideoCodec::VP8,
+            &[],
+            0,
+            EncodedFrameType::Key,
+            640,
+            480,
+        );
+
+        assert_eq!(validate_encoded_access_unit(&access_unit), Err(CaptureError::EmptyPayload));
+    }
+
+    #[test]
+    fn accepts_default_codec_specific_metadata() {
+        let mut access_unit = EncodedAccessUnit::contiguous(
+            EncodedVideoCodec::AV1,
+            &[1, 2, 3],
+            0,
+            EncodedFrameType::Key,
+            640,
+            480,
+        );
+        access_unit.codec_specific = CodecSpecific::default_for(EncodedVideoCodec::AV1);
+
+        assert!(validate_encoded_access_unit(&access_unit).is_ok());
+    }
+
+    #[test]
+    fn rejects_layered_access_units() {
+        let mut access_unit = EncodedAccessUnit::contiguous(
+            EncodedVideoCodec::VP9,
+            &[1, 2, 3],
+            0,
+            EncodedFrameType::Key,
+            640,
+            480,
+        );
+        access_unit.layers = EncodedLayerInfo { spatial_id: None, temporal_id: Some(1) };
+
+        assert!(matches!(
+            validate_encoded_access_unit(&access_unit),
+            Err(CaptureError::UnsupportedLayeredEncoding(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_non_default_codec_specific_metadata() {
+        let mut access_unit = EncodedAccessUnit::contiguous(
+            EncodedVideoCodec::VP8,
+            &[1, 2, 3],
+            0,
+            EncodedFrameType::Key,
+            640,
+            480,
+        );
+        access_unit.codec_specific = CodecSpecific::VP8 { temporal_id: Some(1), layer_sync: true };
+
+        assert!(matches!(
+            validate_encoded_access_unit(&access_unit),
+            Err(CaptureError::UnsupportedLayeredEncoding(_))
+        ));
+    }
+}

--- a/livekit-capture/src/track.rs
+++ b/livekit-capture/src/track.rs
@@ -29,7 +29,6 @@ use crate::{
     error::CaptureError,
 };
 
-pub use crate::device::CapturePath;
 #[cfg(target_os = "linux")]
 use crate::dmabuf::DmaBufFrame;
 

--- a/livekit-capture/src/track.rs
+++ b/livekit-capture/src/track.rs
@@ -14,17 +14,15 @@
 
 use livekit::{
     options::{TrackPublishOptions, VideoEncoderBackend},
-    prelude::LocalVideoTrack,
     webrtc::{
-        video_frame::{EncodedVideoFrame, FrameMetadata, VideoBuffer, VideoFrame},
-        video_source::{native::NativeVideoSource, RtcVideoSource, VideoResolution},
+        video_frame::{EncodedVideoFrame, FrameMetadata},
+        video_source::{native::NativeVideoSource, VideoResolution},
     },
 };
 
 use crate::{
     encoded::{
-        CodecSpecific, EncodedAccessUnit, EncodedLayerInfo, EncodedPayload, EncodedRateControl,
-        EncodedVideoCodec,
+        CodecSpecific, EncodedAccessUnit, EncodedLayerInfo, EncodedPayload, EncodedVideoCodec,
     },
     error::CaptureError,
 };

--- a/livekit-capture/src/track.rs
+++ b/livekit-capture/src/track.rs
@@ -16,7 +16,7 @@ use livekit::{
     options::{TrackPublishOptions, VideoEncoderBackend},
     webrtc::{
         video_frame::{EncodedVideoFrame, FrameMetadata},
-        video_source::{native::NativeVideoSource, VideoResolution},
+        video_source::native::NativeVideoSource,
     },
 };
 
@@ -110,7 +110,7 @@ impl NativeVideoSourceExt for NativeVideoSource {
             payload,
             timestamp_us: access_unit.timestamp_us,
             frame_type: access_unit.frame_type.into(),
-            resolution: VideoResolution { width: access_unit.width, height: access_unit.height },
+            resolution: access_unit.dimensions.into(),
             frame_metadata,
         };
         self.capture_encoded_frame(&frame).then_some(()).ok_or(CaptureError::CaptureFailed)
@@ -150,7 +150,7 @@ fn validate_encoded_access_unit(access_unit: &EncodedAccessUnit<'_>) -> Result<(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::encoded::EncodedFrameType;
+    use crate::{encoded::EncodedFrameType, primitives::VideoResolution};
 
     #[test]
     fn accepts_vp8_vp9_and_av1_access_units() {
@@ -160,8 +160,7 @@ mod tests {
                 &[1, 2, 3],
                 0,
                 EncodedFrameType::Key,
-                640,
-                480,
+                VideoResolution::new(640, 480),
             );
 
             assert!(validate_encoded_access_unit(&access_unit).is_ok());
@@ -175,8 +174,7 @@ mod tests {
             &[],
             0,
             EncodedFrameType::Key,
-            640,
-            480,
+            VideoResolution::new(640, 480),
         );
 
         assert_eq!(validate_encoded_access_unit(&access_unit), Err(CaptureError::EmptyPayload));
@@ -189,8 +187,7 @@ mod tests {
             &[1, 2, 3],
             0,
             EncodedFrameType::Key,
-            640,
-            480,
+            VideoResolution::new(640, 480),
         );
         access_unit.codec_specific = CodecSpecific::default_for(EncodedVideoCodec::AV1);
 
@@ -204,8 +201,7 @@ mod tests {
             &[1, 2, 3],
             0,
             EncodedFrameType::Key,
-            640,
-            480,
+            VideoResolution::new(640, 480),
         );
         access_unit.layers = EncodedLayerInfo { spatial_id: None, temporal_id: Some(1) };
 
@@ -222,8 +218,7 @@ mod tests {
             &[1, 2, 3],
             0,
             EncodedFrameType::Key,
-            640,
-            480,
+            VideoResolution::new(640, 480),
         );
         access_unit.codec_specific = CodecSpecific::VP8 { temporal_id: Some(1), layer_sync: true };
 

--- a/livekit-capture/src/track.rs
+++ b/livekit-capture/src/track.rs
@@ -29,47 +29,8 @@ use crate::{
     error::CaptureError,
 };
 
-#[cfg(target_os = "linux")]
-use crate::dmabuf::DmaBufFrame;
-
-/// Capture source backed by a LiveKit local video track.
-#[derive(Debug, Clone)]
-pub struct VideoCaptureTrack {
-    source: NativeVideoSource,
-    track: LocalVideoTrack,
-}
-
-impl VideoCaptureTrack {
-    /// Creates a capture track with the supplied resolution.
-    pub fn new(name: &str, resolution: VideoResolution, is_screencast: bool) -> Self {
-        let source = NativeVideoSource::new(resolution, is_screencast);
-        let track =
-            LocalVideoTrack::create_video_track(name, RtcVideoSource::Native(source.clone()));
-        Self { source, track }
-    }
-
-    /// Creates a capture track for pre-encoded access units.
-    ///
-    /// Unlike [`VideoCaptureTrack::new`], no raw keepalive frames are
-    /// injected before the first capture, so the sender starts directly on
-    /// the passthrough encoder instead of briefly encoding black frames.
-    pub fn new_encoded(name: &str, resolution: VideoResolution) -> Self {
-        let source = NativeVideoSource::new_encoded(resolution);
-        let track =
-            LocalVideoTrack::create_video_track(name, RtcVideoSource::Native(source.clone()));
-        Self { source, track }
-    }
-
-    /// Returns the publishable local video track.
-    pub fn track(&self) -> LocalVideoTrack {
-        self.track.clone()
-    }
-
-    /// Captures one decoded video frame.
-    pub fn capture_frame<T: AsRef<dyn VideoBuffer>>(&self, frame: &VideoFrame<T>) {
-        self.source.capture_frame(frame);
-    }
-
+/// Additional methods for [`NativeVideoSource`] to support capture from sources.
+pub trait NativeVideoSourceExt {
     /// Captures one DMA-BUF backed frame.
     ///
     /// The native capture path hands a single file descriptor to the driver
@@ -79,7 +40,32 @@ impl VideoCaptureTrack {
     /// layout. Frames whose planes span multiple file descriptors or start
     /// at a nonzero offset are rejected rather than silently truncated.
     #[cfg(target_os = "linux")]
-    pub fn capture_dmabuf(&self, frame: &DmaBufFrame) -> Result<(), CaptureError> {
+    fn capture_dmabuf(&self, frame: &DmaBufFrame) -> Result<(), CaptureError>;
+
+    /// Captures one encoded video access unit.
+    ///
+    /// The passthrough path forwards single-layer streams: access units
+    /// carrying temporal/spatial layer ids, an AV1 dependency descriptor, or
+    /// a non-`L1T1` scalability mode are rejected so callers are not misled
+    /// into thinking that metadata reaches the wire.
+    fn capture_encoded(&self, access_unit: &EncodedAccessUnit<'_>) -> Result<(), CaptureError>;
+
+    /// Captures one encoded video access unit with optional frame metadata.
+    ///
+    /// Metadata is only propagated to subscribers when the corresponding
+    /// [`TrackPublishOptions::frame_metadata_features`] are enabled before
+    /// publishing the local track.
+    fn capture_encoded_with_metadata(
+        &self,
+        access_unit: &EncodedAccessUnit<'_>,
+        frame_metadata: Option<FrameMetadata>,
+    ) -> Result<(), CaptureError>;
+}
+
+impl NativeVideoSourceExt for NativeVideoSource {
+    #[cfg(target_os = "linux")]
+    fn capture_dmabuf(&self, frame: &DmaBufFrame) -> Result<(), CaptureError> {
+        use crate::dmabuf::DmaBufFrame;
         let plane = frame.planes.first().ok_or(CaptureError::MissingDmaBufPlane)?;
         if frame.planes.iter().any(|other| other.fd != plane.fd) {
             return Err(CaptureError::UnsupportedDmaBufLayout(
@@ -101,22 +87,11 @@ impl VideoCaptureTrack {
         ok.then_some(()).ok_or(CaptureError::CaptureFailed)
     }
 
-    /// Captures one encoded video access unit.
-    ///
-    /// The passthrough path forwards single-layer streams: access units
-    /// carrying temporal/spatial layer ids, an AV1 dependency descriptor, or
-    /// a non-`L1T1` scalability mode are rejected so callers are not misled
-    /// into thinking that metadata reaches the wire.
-    pub fn capture_encoded(&self, access_unit: &EncodedAccessUnit<'_>) -> Result<(), CaptureError> {
+    fn capture_encoded(&self, access_unit: &EncodedAccessUnit<'_>) -> Result<(), CaptureError> {
         self.capture_encoded_with_metadata(access_unit, None)
     }
 
-    /// Captures one encoded video access unit with optional frame metadata.
-    ///
-    /// Metadata is only propagated to subscribers when the corresponding
-    /// [`TrackPublishOptions::frame_metadata_features`] are enabled before
-    /// publishing the local track.
-    pub fn capture_encoded_with_metadata(
+    fn capture_encoded_with_metadata(
         &self,
         access_unit: &EncodedAccessUnit<'_>,
         frame_metadata: Option<FrameMetadata>,
@@ -140,38 +115,17 @@ impl VideoCaptureTrack {
             resolution: VideoResolution { width: access_unit.width, height: access_unit.height },
             frame_metadata,
         };
-        self.source.capture_encoded_frame(&frame).then_some(()).ok_or(CaptureError::CaptureFailed)
+        self.capture_encoded_frame(&frame).then_some(()).ok_or(CaptureError::CaptureFailed)
     }
+}
 
-    /// Returns and clears the pending keyframe request raised by the
-    /// passthrough encoder (PLI/FIR from the SFU, late subscriber join, or
-    /// sender reconfiguration).
-    ///
-    /// Poll this from the capture loop and forward the request to the
-    /// upstream encoder so it produces an IDR; until one arrives, new
-    /// subscribers cannot render the track.
-    pub fn take_keyframe_request(&self) -> bool {
-        self.source.take_keyframe_request()
-    }
-
-    /// Returns and clears the pending rate-control target raised by the
-    /// passthrough encoder.
-    ///
-    /// Poll this from the capture loop and forward the target to the
-    /// upstream encoder so congestion control can adjust the produced
-    /// bitrate.
-    pub fn take_rate_control_request(&self) -> Option<EncodedRateControl> {
-        self.source.take_rate_control_request()
-    }
-
-    /// Returns publish options appropriate for encoded passthrough.
-    pub fn encoded_publish_options(codec: EncodedVideoCodec) -> TrackPublishOptions {
-        TrackPublishOptions {
-            video_codec: codec.into(),
-            video_encoder: VideoEncoderBackend::PreEncoded,
-            simulcast: false,
-            ..Default::default()
-        }
+/// Returns publish options appropriate for encoded passthrough.
+pub fn encoded_publish_options(codec: EncodedVideoCodec) -> TrackPublishOptions {
+    TrackPublishOptions {
+        video_codec: codec.into(),
+        video_encoder: VideoEncoderBackend::PreEncoded,
+        simulcast: false,
+        ..Default::default()
     }
 }
 


### PR DESCRIPTION
## Summary

Add the new `livekit-capture` crate with the shared infrastructure needed by capture backends:

- Common device, format, and capture-path types
- Raw, native, DMA-BUF, and encoded frame abstractions
- `VideoCaptureTrack` publishing helpers
- Codec-neutral H.264, H.265, VP8, VP9, and AV1 access units
- H.26x parsing and RTP depacketization
- Generic encoded-ingress and source traits

This PR intentionally does not add concrete capture sources. AVFoundation, V4L2, LibArgus, TCP, RTSP, and GStreamer support will follow in separate PRs.

## Testing

- `cargo test -p livekit-capture --no-default-features`
  - 59 tests passed
- `cargo fmt --all -- --check`
- `git diff --check`