### PR TITLE
Bugfix: Emit room EOS when event channel closes, ignore duplicate disconnect events during teardown

### DIFF
--- a/.changeset/fix-ffi-room-eos.md
+++ b/.changeset/fix-ffi-room-eos.md
@@ -1,5 +1,6 @@
 ---
+"livekit": patch
 "livekit-ffi": patch
 ---
 
-Emit room EOS when the underlying LiveKit room event channel closes after a server-initiated disconnect.
+Emit room EOS when the underlying LiveKit room event channel closes after a server-initiated disconnect, and ignore duplicate disconnect events during teardown.

--- a/.changeset/fix-ffi-room-eos.md
+++ b/.changeset/fix-ffi-room-eos.md
@@ -1,0 +1,5 @@
+---
+"livekit-ffi": patch
+---
+
+Emit room EOS when the underlying LiveKit room event channel closes after a server-initiated disconnect.

--- a/livekit-ffi/src/server/room.rs
+++ b/livekit-ffi/src/server/room.rs
@@ -1033,7 +1033,7 @@ async fn room_task(
     let present_state = Arc::new(Mutex::new(ActualState { reconnecting: false }));
 
     while let Some(event) = next_room_event(&mut events, &mut close_rx).await {
-        let debug = format!("{:?}", event);
+        let event_for_debug = event.clone();
         let inner = inner.clone();
         let present_state = present_state.clone();
         let (tx, rx) = oneshot::channel();
@@ -1046,7 +1046,7 @@ async fn room_task(
         tokio::select! {
             _ = rx => {},
             _ = tokio::time::sleep(Duration::from_secs(10)) => {
-                log::error!("signal_event taking too much time: {}", debug);
+                log::error!("signal_event taking too much time: {:?}", event_for_debug);
             }
         }
 

--- a/livekit-ffi/src/server/room.rs
+++ b/livekit-ffi/src/server/room.rs
@@ -1013,7 +1013,7 @@ struct ActualState {
     reconnecting: bool,
 }
 
-/// Forward events to the ffi client
+/// Wait for the next [`RoomEvent`] or a close signal, returning `None` on shutdown.
 async fn next_room_event(
     events: &mut mpsc::UnboundedReceiver<RoomEvent>,
     close_rx: &mut broadcast::Receiver<()>,

--- a/livekit-ffi/src/server/room.rs
+++ b/livekit-ffi/src/server/room.rs
@@ -1014,6 +1014,16 @@ struct ActualState {
 }
 
 /// Forward events to the ffi client
+async fn next_room_event(
+    events: &mut mpsc::UnboundedReceiver<RoomEvent>,
+    close_rx: &mut broadcast::Receiver<()>,
+) -> Option<RoomEvent> {
+    tokio::select! {
+        event = events.recv() => event,
+        _ = close_rx.recv() => None,
+    }
+}
+
 async fn room_task(
     server: &'static FfiServer,
     inner: Arc<RoomInner>,
@@ -1022,32 +1032,25 @@ async fn room_task(
 ) {
     let present_state = Arc::new(Mutex::new(ActualState { reconnecting: false }));
 
-    loop {
+    while let Some(event) = next_room_event(&mut events, &mut close_rx).await {
+        let debug = format!("{:?}", event);
+        let inner = inner.clone();
+        let present_state = present_state.clone();
+        let (tx, rx) = oneshot::channel();
+        let task = tokio::spawn(async move {
+            forward_event(server, &inner, event, present_state).await;
+            let _ = tx.send(());
+        });
+
+        // Monitor sync/async blockings
         tokio::select! {
-            Some(event) = events.recv() => {
-                let debug = format!("{:?}", event);
-                let inner = inner.clone();
-                let present_state = present_state.clone();
-                let (tx, rx) = oneshot::channel();
-                let task = tokio::spawn(async move {
-                    forward_event(server, &inner, event, present_state).await;
-                    let _ = tx.send(());
-                });
-
-                // Monitor sync/async blockings
-                tokio::select! {
-                    _ = rx => {},
-                    _ = tokio::time::sleep(Duration::from_secs(10)) => {
-                        log::error!("signal_event taking too much time: {}", debug);
-                    }
-                }
-
-                let _ = server.watch_panic(task).await;
-            },
-            _ = close_rx.recv() => {
-                break;
+            _ = rx => {},
+            _ = tokio::time::sleep(Duration::from_secs(10)) => {
+                log::error!("signal_event taking too much time: {}", debug);
             }
-        };
+        }
+
+        let _ = server.watch_panic(task).await;
     }
 
     let _ = server.send_event(
@@ -1652,4 +1655,25 @@ fn build_initial_states(
         },
         remote_infos,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn closed_event_channel_ends_room_event_stream() {
+        let (event_tx, mut events) = mpsc::unbounded_channel();
+        let (_close_tx, mut close_rx) = broadcast::channel(1);
+        drop(event_tx);
+
+        let event = tokio::time::timeout(
+            Duration::from_secs(1),
+            next_room_event(&mut events, &mut close_rx),
+        )
+        .await
+        .expect("closed room event channel should end the event stream");
+
+        assert!(event.is_none());
+    }
 }

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -1687,7 +1687,11 @@ impl RoomSession {
         }
 
         self.dispatcher.dispatch(&RoomEvent::Disconnected { reason });
-        log::info!("disconnected from room with reason: {:?}", reason);
+        log::info!(
+            "Disconnected from room \"{}\" with reason: {:?}",
+            self.info.read().name,
+            reason
+        );
         if reason != DisconnectReason::ClientInitiated {
             livekit_runtime::spawn({
                 let inner = self.clone();

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -1682,10 +1682,11 @@ impl RoomSession {
     }
 
     fn handle_disconnected(self: &Arc<Self>, reason: DisconnectReason) {
-        if self.update_connection_state(ConnectionState::Disconnected) {
-            self.dispatcher.dispatch(&RoomEvent::Disconnected { reason });
+        if !self.update_connection_state(ConnectionState::Disconnected) {
+            return;
         }
 
+        self.dispatcher.dispatch(&RoomEvent::Disconnected { reason });
         log::info!("disconnected from room with reason: {:?}", reason);
         if reason != DisconnectReason::ClientInitiated {
             livekit_runtime::spawn({


### PR DESCRIPTION
Terminate FFI event forwarding when core room teardown closes its dispatcher so server-initiated disconnects deliver RoomEOS.

### Before you submit your PR

Make sure the following is true before submitting your PR:

- [x] I have read the [contributing guidelines](https://github.com/livekit/rust-sdks/blob/main/CONTRIBUTING.md) and validated that this PR will be accepted.
- [x] I have read and followed the principles regarding breaking changes, testing, and code quality.

### PR description

It was discovered in C++ Client SDK triage of a server-initiated room closure that the EOS event never fired. In the Python Client SDK, the EOS event is treated as the event loop exit condition/cleanup case: https://github.com/livekit/python-sdks/blob/main/livekit-rtc/livekit/rtc/room.py#L693-L719

In confirmed in the Python Client SDK this EOS was also not firing.

This PR updates the following:

- Refactors out a "next event" method to better handle this
- Also fixes a duplicate room disconnect log, adding room name for visbility:

```
# Before
[2026-07-15T18:42:03Z INFO  livekit::room] disconnected from room with reason: RoomDeleted
[2026-07-15T18:42:03Z INFO  livekit::room] disconnected from room with reason: RoomDeleted

# After
[2026-07-15T19:53:37Z INFO  livekit::room] Disconnected from room "cpp-test" with reason: RoomDeleted
```

### Breaking changes

N/A

### MSRV

N/A

### Testing

- Verified in C++ Client SDK integration test that ensures the room events fire in this order `Disconnected` -> `EOS`
- Verified in Python Client SDK that this PR build submodule resolved the issue
- Added test in this PR as well

### Async

We want the project to be runtime-agnostic, so please reuse what's already in [livekit-runtime](https://github.com/livekit/rust-sdks/blob/main/livekit-runtime/) and feel free to add anything missing. It's ok to use Tokio directly, when writing unit tests, if necessary. When testing, do not use artificial delays for the state to "catch up"; instead, respect the event flow and subscribe properly using channels or other mechanisms.


