### PR TITLE
Fix knope changeset detection

### DIFF
--- a/.changeset/agent-deployment-docs.md
+++ b/.changeset/agent-deployment-docs.md
@@ -1,5 +1,5 @@
 ---
-"livekit-api": patch
+livekit-api: patch
 ---
 
 Add deployment field documentation for agent dispatch

--- a/.changeset/cleanup-libwebrtc-warnings.md
+++ b/.changeset/cleanup-libwebrtc-warnings.md
@@ -1,5 +1,5 @@
 ---
-"libwebrtc": minor
+libwebrtc: minor
 ---
 
 fix compiler warnings in libwebrtc

--- a/.changeset/compress-initial-offer-in-url.md
+++ b/.changeset/compress-initial-offer-in-url.md
@@ -1,5 +1,5 @@
 ---
-"livekit-api": patch
+livekit-api: patch
 ---
 
 Compress initial offer in URL for single PC mode

--- a/.changeset/delete_wgpu_room_example.md
+++ b/.changeset/delete_wgpu_room_example.md
@@ -1,4 +1,0 @@
----
----
-
-Delete the `wgpu_room` example; it now lives in its own repository at https://github.com/livekit-examples/rust-dev-client

--- a/.changeset/fix-ffi-room-eos.md
+++ b/.changeset/fix-ffi-room-eos.md
@@ -1,6 +1,6 @@
 ---
-"livekit": patch
-"livekit-ffi": patch
+livekit: patch
+livekit-ffi: patch
 ---
 
 Emit room EOS when the underlying LiveKit room event channel closes after a server-initiated disconnect, and ignore duplicate disconnect events during teardown.

--- a/.changeset/preencoded-passthrough-core.md
+++ b/.changeset/preencoded-passthrough-core.md
@@ -1,7 +1,7 @@
 ---
-"webrtc-sys": minor
-"libwebrtc": minor
-"livekit": minor
+webrtc-sys: minor
+libwebrtc: minor
+livekit: minor
 ---
 
 Add a pre-encoded video publish path: a passthrough video encoder and encoded video frame buffer in webrtc-sys, and `EncodedVideoFrame`/`EncodedVideoCodec`/`EncodedFrameType` publish APIs with a `VideoEncoderBackend::PreEncoded` backend in libwebrtc. WebRTC rate-control targets and keyframe requests are forwarded to encoded sources, and pre-encoded AV1 and H265 access units are validated on ingest.

--- a/.changeset/simplify-start-bitrate-and-degradation-defaults.md
+++ b/.changeset/simplify-start-bitrate-and-degradation-defaults.md
@@ -1,5 +1,5 @@
 ---
-"livekit": patch
+livekit: patch
 ---
 
 Simplify x-google-start-bitrate logic and update degradation preference defaults

--- a/.github/scripts/changeset_detect.py
+++ b/.github/scripts/changeset_detect.py
@@ -34,6 +34,7 @@ Output (JSON on stdout):
     "required":          [pkg, ...],         # direct + downstream (full closure)
     "present":           [[pkg, bump], ...], # bumps already in the changeset
     "missing":           [pkg, ...],         # required packages not yet covered
+    "invalid":           [{...}, ...],       # bump lines in a format knope would ignore
     "changeset_content": str,               # a changeset prefilled with `missing`
   }
 """
@@ -45,6 +46,10 @@ import subprocess
 import sys
 
 BUMP_ORDER = {"patch": 0, "minor": 1, "major": 2}
+
+# Knope only recognizes unquoted `package: bump` lines in changeset front
+# matter; quoted names (the JS changesets convention) are silently ignored.
+VALID_BUMP_LINE = re.compile(r"^([A-Za-z0-9_-]+):\s*(patch|minor|major)$")
 
 
 def emit(data):
@@ -66,9 +71,15 @@ def load_knope_packages():
 def parse_present_bumps(changeset_files, knope_packages):
     """Parse the highest bump declared per package across the PR's changeset files.
 
-    Changeset front matter looks like:  "livekit-api": patch
+    Valid front-matter lines use knope's format:  livekit-api: patch
+
+    Returns (present, invalid). `present` maps package -> highest declared
+    bump. `invalid` lists lines that clearly intend to declare a bump but are
+    in a format knope would silently ignore (e.g. the quoted JS-changesets
+    convention, `"livekit-api": patch`), as {file, line, content, fixed}.
     """
     present = {}
+    invalid = []
     for filepath in changeset_files:
         try:
             with open(filepath) as f:
@@ -78,17 +89,26 @@ def parse_present_bumps(changeset_files, knope_packages):
         match = re.match(r"^---\s*\n(.*?)\n---", content, re.DOTALL)
         if not match:
             continue
-        for line in match.group(1).strip().split("\n"):
-            line = line.strip()
+        for offset, raw_line in enumerate(match.group(1).split("\n")):
+            line = raw_line.strip()
             if ":" not in line:
                 continue
             pkg, bump = line.split(":", 1)
             pkg = pkg.strip().strip('"').strip("'").strip()
             bump = bump.strip().strip('"').strip("'").strip()
-            if bump in BUMP_ORDER and pkg in knope_packages:
-                if pkg not in present or BUMP_ORDER[bump] > BUMP_ORDER[present[pkg]]:
-                    present[pkg] = bump
-    return present
+            if bump not in BUMP_ORDER or pkg not in knope_packages:
+                continue
+            if not VALID_BUMP_LINE.match(line):
+                invalid.append({
+                    "file": filepath,
+                    "line": offset + 2,  # front matter starts on line 2
+                    "content": line,
+                    "fixed": f"{pkg}: {bump}",
+                })
+                continue
+            if pkg not in present or BUMP_ORDER[bump] > BUMP_ORDER[present[pkg]]:
+                present[pkg] = bump
+    return present, invalid
 
 
 def build_reverse_dep_graph(meta, knope_packages):
@@ -135,7 +155,7 @@ def build_changeset_content(missing, pr_title=None, pr_number=None, pr_author=No
     pr_author = pr_author if pr_author is not None else os.environ.get("PR_AUTHOR", "")
     lines = ["---"]
     for pkg in missing:
-        lines.append(f'"{pkg}": patch')
+        lines.append(f"{pkg}: patch")
     lines.extend(["---", "", f"{pr_title} - #{pr_number} (@{pr_author})"])
     return "\n".join(lines)
 
@@ -197,7 +217,7 @@ def main():
     changeset_files = read_lines("CHANGESET_FILES")
 
     knope_packages = load_knope_packages()
-    present = parse_present_bumps(changeset_files, knope_packages)
+    present, invalid = parse_present_bumps(changeset_files, knope_packages)
 
     try:
         meta = load_cargo_metadata()
@@ -206,11 +226,14 @@ def main():
             "error": str(e),
             "direct": [], "downstream": [], "required": [],
             "present": sorted(present.items()), "missing": [],
+            "invalid": invalid,
             "changeset_content": "",
         })
         return  # emit calls sys.exit, but guard against falling through
 
-    emit(detect(meta, knope_packages, changed_files, present))
+    result = detect(meta, knope_packages, changed_files, present)
+    result["invalid"] = invalid
+    emit(result)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_changeset_detect.py
+++ b/.github/scripts/test_changeset_detect.py
@@ -133,38 +133,52 @@ class TestParsePresentBumps(unittest.TestCase):
             f.write(body)
         return path
 
-    def test_parses_quoted_names(self):
+    def test_parses_unquoted_names(self):
         with tempfile.TemporaryDirectory() as tmp:
-            p = self._write(tmp, "a.md", '---\n"a-sys": patch\n"b": minor\n---\n\ndesc\n')
+            p = self._write(tmp, "a.md", "---\na-sys: patch\nb: minor\n---\n\ndesc\n")
             self.assertEqual(
-                cd.parse_present_bumps([p], KNOPE), {"a-sys": "patch", "b": "minor"}
+                cd.parse_present_bumps([p], KNOPE), ({"a-sys": "patch", "b": "minor"}, [])
             )
+
+    def test_quoted_names_flagged_invalid(self):
+        # Knope silently ignores the quoted JS-changesets format; it must be
+        # reported as invalid rather than counted as coverage.
+        with tempfile.TemporaryDirectory() as tmp:
+            p = self._write(tmp, "a.md", '---\n"a-sys": patch\nb: minor\n---\n\ndesc\n')
+            present, invalid = cd.parse_present_bumps([p], KNOPE)
+            self.assertEqual(present, {"b": "minor"})
+            self.assertEqual(invalid, [{
+                "file": p,
+                "line": 2,
+                "content": '"a-sys": patch',
+                "fixed": "a-sys: patch",
+            }])
 
     def test_ignores_unknown_packages(self):
         with tempfile.TemporaryDirectory() as tmp:
-            p = self._write(tmp, "a.md", '---\n"not-a-package": patch\n"b": patch\n---\n\nd\n')
-            self.assertEqual(cd.parse_present_bumps([p], KNOPE), {"b": "patch"})
+            p = self._write(tmp, "a.md", "---\nnot-a-package: patch\nb: patch\n---\n\nd\n")
+            self.assertEqual(cd.parse_present_bumps([p], KNOPE), ({"b": "patch"}, []))
 
     def test_highest_bump_wins_across_files(self):
         with tempfile.TemporaryDirectory() as tmp:
-            p1 = self._write(tmp, "a.md", '---\n"b": patch\n---\n\nd\n')
-            p2 = self._write(tmp, "z.md", '---\n"b": major\n---\n\nd\n')
-            self.assertEqual(cd.parse_present_bumps([p1, p2], KNOPE), {"b": "major"})
+            p1 = self._write(tmp, "a.md", "---\nb: patch\n---\n\nd\n")
+            p2 = self._write(tmp, "z.md", "---\nb: major\n---\n\nd\n")
+            self.assertEqual(cd.parse_present_bumps([p1, p2], KNOPE), ({"b": "major"}, []))
             # order independent
-            self.assertEqual(cd.parse_present_bumps([p2, p1], KNOPE), {"b": "major"})
+            self.assertEqual(cd.parse_present_bumps([p2, p1], KNOPE), ({"b": "major"}, []))
 
     def test_ignores_invalid_bump_values(self):
         with tempfile.TemporaryDirectory() as tmp:
-            p = self._write(tmp, "a.md", '---\n"b": bogus\n---\n\nd\n')
-            self.assertEqual(cd.parse_present_bumps([p], KNOPE), {})
+            p = self._write(tmp, "a.md", "---\nb: bogus\n---\n\nd\n")
+            self.assertEqual(cd.parse_present_bumps([p], KNOPE), ({}, []))
 
     def test_missing_front_matter(self):
         with tempfile.TemporaryDirectory() as tmp:
             p = self._write(tmp, "a.md", "just a description, no front matter\n")
-            self.assertEqual(cd.parse_present_bumps([p], KNOPE), {})
+            self.assertEqual(cd.parse_present_bumps([p], KNOPE), ({}, []))
 
     def test_missing_file_is_skipped(self):
-        self.assertEqual(cd.parse_present_bumps(["/nonexistent/x.md"], KNOPE), {})
+        self.assertEqual(cd.parse_present_bumps(["/nonexistent/x.md"], KNOPE), ({}, []))
 
 
 class TestDetect(unittest.TestCase):
@@ -201,9 +215,9 @@ class TestDetect(unittest.TestCase):
     def test_changeset_content_prefills_missing(self):
         r = cd.detect(META, KNOPE, ["a-sys/src/lib.rs"], {"a-sys": "patch"})
         # missing == [b, c]; the prefilled changeset must bump exactly those
-        self.assertIn('"b": patch', r["changeset_content"])
-        self.assertIn('"c": patch', r["changeset_content"])
-        self.assertNotIn('"a-sys"', r["changeset_content"])
+        self.assertIn("b: patch", r["changeset_content"])
+        self.assertIn("c: patch", r["changeset_content"])
+        self.assertNotIn("a-sys", r["changeset_content"])
 
 
 class TestBuildChangesetContent(unittest.TestCase):
@@ -213,7 +227,7 @@ class TestBuildChangesetContent(unittest.TestCase):
         )
         self.assertEqual(
             content,
-            '---\n"b": patch\n"c": patch\n---\n\nMy change - #42 (@alice)',
+            "---\nb: patch\nc: patch\n---\n\nMy change - #42 (@alice)",
         )
 
     def test_empty_missing_produces_empty_front_matter(self):

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -107,6 +107,25 @@ jobs:
             echo "::warning::Failed to detect packages via cargo metadata: $ERROR"
           fi
 
+          # --- Reject bump lines knope can't parse (e.g. quoted package names) ---
+          # Knope silently ignores entries like `"livekit": patch` (the JS
+          # changesets convention), so they'd never be released.
+          NUM_INVALID=$(echo "$DETECTION" | jq '.invalid | length')
+          if [ "$NUM_INVALID" != "0" ]; then
+            INVALID_LIST=$(echo "$DETECTION" | jq -r '.invalid[] | "- `\(.file)` line \(.line): `\(.content)` should be `\(.fixed)`"')
+            COMMENT_BODY=$(
+              echo "$COMMENT_MARKER"
+              echo "### Changeset format error"
+              echo ""
+              echo "Knope requires unquoted package names in changeset front matter and silently ignores entries in any other format, so the following lines would never be released:"
+              echo ""
+              echo "$INVALID_LIST"
+            )
+            upsert_comment "$COMMENT_BODY" || true
+            echo "::error::Changeset front matter contains bump lines knope would ignore (quoted package names). See the PR comment for fixes."
+            exit 1
+          fi
+
           # --- If no versioned packages are affected, no changeset is required ---
           NUM_REQUIRED=$(echo "$DETECTION" | jq '.required | length')
           if [ "$NUM_REQUIRED" = "0" ]; then


### PR DESCRIPTION
For some reason, Knope won't parse packages listed in changset if they are quoted (see [_change.rs_](https://github.com/knope-dev/changesets/blob/main/src/change.rs)), leading to no release PR being created with current changes.