### PR TITLE
livekit-api: Strip query params from info-level connect log

### DIFF
--- a/.changeset/trim-info-log.md
+++ b/.changeset/trim-info-log.md
@@ -1,0 +1,5 @@
+---
+livekit-api: patch
+---
+
+Strip query params from the info-level connect log

--- a/livekit-api/src/signal_client/signal_stream.rs
+++ b/livekit-api/src/signal_client/signal_stream.rs
@@ -101,7 +101,10 @@ impl SignalStream {
         url: url::Url,
         token: &str,
     ) -> SignalResult<(Self, mpsc::UnboundedReceiver<Box<proto::signal_response::Message>>)> {
-        log::info!("connecting to {}", url);
+        let mut log_url = url.clone();
+        log_url.set_query(None);
+        log::info!("connecting to {}", log_url);
+        log::debug!("connecting to {}", url);
         let mut request = url.clone().into_client_request()?;
         let auth_header = HeaderValue::from_str(&format!("Bearer {token}"))
             .map_err(|_| SignalError::TokenFormat)?;


### PR DESCRIPTION
The signal websocket URL's query string can include a rather large encoded `join_request` blob. I'm not sure whether it contains secrets, but it has that appearance, and it's a lot of clutter for an info-level log statement.

This change updates the connect method to log the URL without query parameters at info level. The full URL is still logged at debug level.

@jhugman: Looks like this might conflict with #1258.