### PR TITLE
Address typo in parsing rpc server version

### DIFF
--- a/.changeset/address_typo_in_parsing_rpc_server_version.md
+++ b/.changeset/address_typo_in_parsing_rpc_server_version.md
@@ -1,0 +1,6 @@
+---
+livekit: patch
+livekit-ffi: patch
+---
+
+Address typo in parsing rpc server version - #1268 (@1egoman)

--- a/livekit/src/room/rpc/mod.rs
+++ b/livekit/src/room/rpc/mod.rs
@@ -100,7 +100,7 @@ impl RpcTransport for SessionTransport {
             .signal_client()
             .join_response()
             .server_info
-            .and_then(|info| info.version.is_empty().then(|| info.version))
+            .and_then(|info| (!info.version.is_empty()).then(|| info.version))
     }
 }
 

--- a/livekit/src/room/rpc/tests.rs
+++ b/livekit/src/room/rpc/tests.rs
@@ -60,6 +60,11 @@ impl MockTransport {
         self
     }
 
+    fn with_server_version(mut self, version: Option<&str>) -> Self {
+        self.server_ver = version.map(str::to_string);
+        self
+    }
+
     /// Wait until at least one packet has been sent.
     async fn wait_for_packet(&self) {
         self.packet_sent.notified().await;
@@ -743,6 +748,34 @@ async fn test_v2_response_stream_resolves_caller() {
 
     let result: Result<String, RpcError> = rx.await.unwrap();
     assert_eq!(result.unwrap(), "stream-result");
+}
+
+// =========================================================================
+// Server version check tests
+// =========================================================================
+
+/// A server older than the minimum required version is rejected with
+/// UNSUPPORTED_SERVER before any request is sent.
+#[tokio::test]
+async fn test_server_below_minimum_version_rejected() {
+    let client = RpcClientManager::new();
+    let transport = MockTransport::new()
+        .with_remote_protocol("dest", CLIENT_PROTOCOL_DATA_STREAM_RPC)
+        .with_server_version(Some("1.7.9"));
+
+    let result = client
+        .perform_rpc(
+            PerformRpcData::new("dest", "greet")
+                .with_payload("hi")
+                .with_response_timeout(Duration::from_millis(50)),
+            &transport,
+        )
+        .await;
+
+    let err = result.unwrap_err();
+    assert_eq!(err.code, RpcErrorCode::UnsupportedServer as u32);
+    assert!(transport.packets().is_empty());
+    assert!(transport.texts().is_empty());
 }
 
 /// Verify unregistered method returns UNSUPPORTED_METHOD error via v2 path.


### PR DESCRIPTION
The version check was incorrect - it looks like this has been broken and not actually properly validating that the server vefsion is 1.8.0 or greater.

### Breaking changes

No breaking changes.

### MSRV

N/A

### Testing

Added a test to prevent another regression like this.
