### PR TITLE
ensure failing audio filter init doesn't degrade audio quality

### DIFF
--- a/.changeset/ensure_failing_audio_filter_init_doesn_t_degrade_audio_quali.md
+++ b/.changeset/ensure_failing_audio_filter_init_doesn_t_degrade_audio_quali.md
@@ -1,0 +1,5 @@
+---
+livekit-ffi: patch
+---
+
+ensure failing audio filter init doesn't degrade audio quality - #1270 (@lukasIO)

--- a/livekit-ffi/src/server/audio_stream.rs
+++ b/livekit-ffi/src/server/audio_stream.rs
@@ -106,9 +106,9 @@ impl FfiAudioStream {
                         .map(|capacity| capacity as usize),
                 };
 
-                // When the audio filter supports separate rates (v2), create
-                // the WebRTC sink at the codec's native rate to skip
-                // resampling — the filter handles rate conversion.
+                // When the audio filter supports separate rates (v2), it
+                // converts from the codec's native rate to the requested
+                // output rate, so the WebRTC sink runs at the codec rate.
                 let input_sample_rate =
                     if audio_filter.as_ref().is_some_and(|f| f.supports_separate_rates()) {
                         ffi_track.track.codec_clock_rate().unwrap_or(48000)
@@ -116,40 +116,49 @@ impl FfiAudioStream {
                         output_sample_rate
                     };
 
+                // Create the filter session (if requested) before the sink,
+                // so the sink's rate can depend on whether the filter is
+                // actually available.
+                let audio_filter_options = new_stream.audio_filter_options.unwrap_or_default();
+                let filter_session = match &audio_filter {
+                    Some(audio_filter) => {
+                        let session = audio_filter.clone().new_session(
+                            input_sample_rate,
+                            output_sample_rate,
+                            &audio_filter_options,
+                            info.as_ref().map(|i| i.stream_info.clone()).unwrap(),
+                        );
+                        if session.is_none() {
+                            log::error!("failed to initialize the audio filter. it will not be enabled for this session.");
+                        }
+                        session
+                    }
+                    None => None,
+                };
+
+                // Without a live filter session (none requested, or creation
+                // failed) the sink must run at the requested output rate
+                // directly — otherwise codec-rate audio would be forwarded
+                // mislabeled as the output rate, dilating it downstream.
+                let sink_rate =
+                    if filter_session.is_some() { input_sample_rate } else { output_sample_rate };
                 let native_stream = NativeAudioStream::with_options(
                     rtc_track,
-                    input_sample_rate as i32,
+                    sink_rate as i32,
                     num_channels as i32,
                     options,
                 );
 
-                let stream = if let Some(audio_filter) = &audio_filter {
-                    let session = audio_filter.clone().new_session(
+                let stream = match filter_session {
+                    Some(session) => AudioStreamKind::Filtered(AudioFilterAudioStream::new(
+                        native_stream,
+                        session,
+                        Duration::from_millis(10),
                         input_sample_rate,
                         output_sample_rate,
-                        new_stream.audio_filter_options.unwrap_or("".into()),
-                        info.as_ref().map(|i| i.stream_info.clone()).unwrap(),
-                    );
-
-                    match session {
-                        Some(session) => {
-                            let stream = AudioFilterAudioStream::new(
-                                native_stream,
-                                session,
-                                Duration::from_millis(10),
-                                input_sample_rate,
-                                output_sample_rate,
-                                num_channels,
-                            );
-                            AudioStreamKind::Filtered(stream)
-                        }
-                        None => {
-                            log::error!("failed to initialize the audio filter. it will not be enabled for this session.");
-                            AudioStreamKind::Native(native_stream)
-                        }
-                    }
-                } else {
-                    AudioStreamKind::Native(native_stream)
+                        num_channels,
+                    )),
+                    None => AudioStreamKind::Native(native_stream),
                 };
 
                 let handle = server.async_runtime.spawn(Self::native_audio_stream_task(
@@ -327,12 +336,17 @@ impl FfiAudioStream {
                     None => (None, None),
                 };
 
-                let native_stream = NativeAudioStream::with_options(
-                    rtc_track,
-                    input_sample_rate,
-                    num_channels,
-                    options,
-                );
+                // Without a live filter session (none requested, or creation
+                // failed) the sink must run at the requested output rate
+                // directly — otherwise codec-rate audio would be forwarded
+                // mislabeled as the output rate, dilating it downstream.
+                let sink_rate = if audio_filter_session.is_some() {
+                    input_sample_rate
+                } else {
+                    output_sample_rate
+                };
+                let native_stream =
+                    NativeAudioStream::with_options(rtc_track, sink_rate, num_channels, options);
 
                 let stream = if let Some(session) = audio_filter_session.take() {
                     let stream = AudioFilterAudioStream::new(


### PR DESCRIPTION
## Problem

When a noise-cancellation filter is requested and the plugin supports
separate rates (v2), the WebRTC sink is created at the codec's native rate
on the assumption that the filter will resample to the requested output
rate. If the filter session fails to initialize, the code fell back to a
plain native stream **reusing that codec-rate sink** — so codec-rate audio
was forwarded downstream mislabeled as the output rate.

Whenever the codec rate differs from the requested output rate (e.g. a SIP
telephony call, or any track where STT asks for a lower rate than the codec),
this dilates the audio in time: on a failed init we observed STT
`transcription_delay` jump from ~0.3–0.5s to ~5.5s, with the agent responding
seconds late. Removing the NC option restored baseline latency, because
without the option the sink is already created at the output rate.

## Fix

Decide the sink's rate based on whether a filter session actually exists:
run at the codec rate only when a live filter is there to resample it,
otherwise run directly at the requested output rate. A failed (or absent)
filter now degrades to clean, correctly-rated native audio — identical to the
no-option path.

Applied to both `FfiAudioStream::from_track` and `from_participant`.

## Notes

- Pure host-side fix; no protocol or plugin change. Orthogonal to *why* a
  given filter session fails to initialize.
- Verified: `livekit-ffi` builds clean (no new warnings). Runtime check
  pending — a SIP call with the option set should return `transcription_delay`
  to baseline with no pitch/speed shift.