### PR TITLE
fix: initialize I420Buffer pixel data to black

### DIFF
--- a/.changeset/emit_black_keepalive_frames_instead_of_uninitialized_memory.md
+++ b/.changeset/emit_black_keepalive_frames_instead_of_uninitialized_memory.md
@@ -1,0 +1,8 @@
+---
+libwebrtc: patch
+livekit: patch
+livekit-ffi: patch
+webrtc-sys: patch
+---
+
+Emit black keepalive frames from NativeVideoSource instead of uninitialized memory. webrtc::I420Buffer::Create leaves the pixel planes uninitialized, so the pre-capture keepalive frames could leak recycled heap contents (often fragments of earlier frames from the same process) to subscribers as the first keyframes - #1271 (@eh-steve)

--- a/libwebrtc/src/native/video_frame.rs
+++ b/libwebrtc/src/native/video_frame.rs
@@ -215,6 +215,26 @@ impl I420Buffer {
         }
     }
 
+    pub fn new_black(
+        width: u32,
+        height: u32,
+        stride_y: u32,
+        stride_u: u32,
+        stride_v: u32,
+    ) -> vf::I420Buffer {
+        vf::I420Buffer {
+            handle: I420Buffer {
+                sys_handle: vfb_sys::ffi::new_black_i420_buffer(
+                    width.try_into().unwrap(),
+                    height.try_into().unwrap(),
+                    stride_y.try_into().unwrap(),
+                    stride_u.try_into().unwrap(),
+                    stride_v.try_into().unwrap(),
+                ),
+            },
+        }
+    }
+
     pub fn sys_handle(&self) -> &vfb_sys::ffi::VideoFrameBuffer {
         unsafe { &*recursive_cast!(&*self.sys_handle, i420_to_yuv8, yuv8_to_yuv, yuv_to_vfb) }
     }

--- a/libwebrtc/src/native/video_source.rs
+++ b/libwebrtc/src/native/video_source.rs
@@ -81,7 +81,11 @@ impl NativeVideoSource {
         if raw_keepalive {
             livekit_runtime::spawn({
                 let source = source.clone();
-                let i420 = I420Buffer::new(resolution.width, resolution.height);
+                // This buffer reaches the encoder without any plane ever being
+                // written, so it must be black-initialized: `I420Buffer::new`
+                // leaves the pixel data uninitialized and would leak recycled
+                // heap memory to subscribers in the first keyframes.
+                let i420 = I420Buffer::new_black(resolution.width, resolution.height);
                 async move {
                     let mut interval = interval(Duration::from_millis(100)); // 10 fps
 

--- a/libwebrtc/src/video_frame.rs
+++ b/libwebrtc/src/video_frame.rs
@@ -301,6 +301,12 @@ impl I420Buffer {
         Self::with_strides(width, height, width, (width + 1) / 2, (width + 1) / 2)
     }
 
+    /// Like [`I420Buffer::new`], but with the pixel data initialized to black
+    /// (Y=0, U=V=128) instead of left uninitialized.
+    pub fn new_black(width: u32, height: u32) -> I420Buffer {
+        vf_imp::I420Buffer::new_black(width, height, width, (width + 1) / 2, (width + 1) / 2)
+    }
+
     pub fn chroma_width(&self) -> u32 {
         self.handle.chroma_width()
     }
@@ -624,4 +630,18 @@ pub mod web {
     pub struct WebGlBuffer {}
 
     impl VideoFrameBuffer for WebGlBuffer {}
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::I420Buffer;
+
+    #[test]
+    fn new_black_initializes_every_plane() {
+        let buffer = I420Buffer::new_black(64, 32);
+        let (data_y, data_u, data_v) = buffer.data();
+        assert!(data_y.iter().all(|&px| px == 0));
+        assert!(data_u.iter().all(|&px| px == 128));
+        assert!(data_v.iter().all(|&px| px == 128));
+    }
 }

--- a/webrtc-sys/include/livekit/video_frame_buffer.h
+++ b/webrtc-sys/include/livekit/video_frame_buffer.h
@@ -214,6 +214,7 @@ class NV12Buffer : public BiplanarYuv8Buffer {
 std::unique_ptr<I420Buffer> copy_i420_buffer(
     const std::unique_ptr<I420Buffer>& i420);
 std::unique_ptr<I420Buffer> new_i420_buffer(int width, int height, int stride_y, int stride_u, int stride_v);
+std::unique_ptr<I420Buffer> new_black_i420_buffer(int width, int height, int stride_y, int stride_u, int stride_v);
 std::unique_ptr<I422Buffer> new_i422_buffer(int width, int height, int stride_y, int stride_u, int stride_v);
 std::unique_ptr<I444Buffer> new_i444_buffer(int width, int height, int stride_y, int stride_u, int stride_v);
 std::unique_ptr<I010Buffer> new_i010_buffer(int width, int height, int stride_y, int stride_u, int stride_v);

--- a/webrtc-sys/src/video_frame_buffer.cpp
+++ b/webrtc-sys/src/video_frame_buffer.cpp
@@ -308,6 +308,21 @@ std::unique_ptr<I420Buffer> new_i420_buffer(int width,
       webrtc::I420Buffer::Create(width, height, stride_y, stride_u, stride_v));
 }
 
+std::unique_ptr<I420Buffer> new_black_i420_buffer(int width,
+                                                  int height,
+                                                  int stride_y,
+                                                  int stride_u,
+                                                  int stride_v) {
+  // I420Buffer::Create does not initialize the pixel data. Callers that may
+  // hand the buffer to the encoder before writing every plane (e.g. the
+  // pre-capture keepalive frames NativeVideoSource emits) must start from a
+  // real black frame, or they would send recycled heap memory to subscribers.
+  webrtc::scoped_refptr<webrtc::I420Buffer> buffer =
+      webrtc::I420Buffer::Create(width, height, stride_y, stride_u, stride_v);
+  webrtc::I420Buffer::SetBlack(buffer.get());
+  return std::make_unique<I420Buffer>(std::move(buffer));
+}
+
 std::unique_ptr<I422Buffer> new_i422_buffer(int width,
                                             int height,
                                             int stride_y,

--- a/webrtc-sys/src/video_frame_buffer.rs
+++ b/webrtc-sys/src/video_frame_buffer.rs
@@ -112,6 +112,16 @@ pub mod ffi {
             stride_v: i32,
         ) -> UniquePtr<I420Buffer>;
 
+        /// Like `new_i420_buffer`, but with the pixel data set to black
+        /// (Y=0, U=V=128) instead of left uninitialized.
+        fn new_black_i420_buffer(
+            width: i32,
+            height: i32,
+            stride_y: i32,
+            stride_u: i32,
+            stride_v: i32,
+        ) -> UniquePtr<I420Buffer>;
+
         fn new_i422_buffer(
             width: i32,
             height: i32,


### PR DESCRIPTION
`webrtc::I420Buffer::Create` allocates the pixel planes without initializing them, and `NativeVideoSource`'s pre-capture keepalive publishes such a buffer as-is every 100 ms until the first capture_frame. Subscribers receive recycled heap memory — often fragments of earlier frames from the same process — decoded as garbage in the first keyframes. This exposes a `new_black_i420_buffer` constructor (`I420Buffer::SetBlack`) and uses it for the keepalive buffer only, rather than paying a full-frame clear on every I420 allocation.

### Before you submit your PR

Make sure the following is true before submitting your PR:

- [X] I have read the [contributing guidelines](https://github.com/livekit/rust-sdks/blob/main/CONTRIBUTING.md) and validated that this PR will be accepted.
- [X] I have read and followed the principles regarding breaking changes, testing, and code quality.

### PR description

Describe the changes in this PR. Explain what the PR is meant to solve and how to reproduce the issue in the first place.

### Breaking changes

If this PR introduces breaking changes, list them here and document the rationale for introducing such a change.

### MSRV

If the PR modifies the crate's MSRV (Minimum Supported Rust Version), document it here.

### Testing

Ideally, unit test the code you add, but ensure you're not repeating existing test cases. Use as many already written scaffolding, utilities as possible; write your own, when needed. If external services, APIs, tokens are required (e.g., running an LK server instance), provide the necessary information. Make sure your tests perform useful, context-aware assertions and do not simply emulate "happy paths".

### Async

We want the project to be runtime-agnostic, so please reuse what's already in [livekit-runtime](https://github.com/livekit/rust-sdks/blob/main/livekit-runtime/) and feel free to add anything missing. It's ok to use Tokio directly, when writing unit tests, if necessary. When testing, do not use artificial delays for the state to "catch up"; instead, respect the event flow and subscribe properly using channels or other mechanisms.


