### PR TITLE
allow for audio filters to be registered after initial room connection

### DIFF
--- a/.changeset/allow_for_audio_filters_to_be_registered_after_initial_room_.md
+++ b/.changeset/allow_for_audio_filters_to_be_registered_after_initial_room_.md
@@ -1,0 +1,6 @@
+---
+livekit: patch
+livekit-ffi: patch
+---
+
+allow for audio filters to be registered after initial room connection - #1273 (@lukasIO)

--- a/livekit-ffi/src/server/audio_filter_tests.rs
+++ b/livekit-ffi/src/server/audio_filter_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 LiveKit, Inc.
+// Copyright 2026 LiveKit, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/livekit-ffi/src/server/audio_filter_tests.rs
+++ b/livekit-ffi/src/server/audio_filter_tests.rs
@@ -28,13 +28,19 @@
 //! Requires a C compiler (`cc`) on PATH to build a minimal test plugin.
 
 use std::{
+    collections::HashSet,
     path::{Path, PathBuf},
     time::{Duration, Instant},
 };
 
+use livekit::prelude::DisconnectReason;
 use livekit_api::access_token::{AccessToken, VideoGrants};
 
-use crate::{proto, server::requests, FFI_SERVER};
+use crate::{
+    proto,
+    server::{requests, room::FfiRoom},
+    FFI_SERVER,
+};
 
 /// A minimal audio-filter plugin. Its `on_load` appends the options JSON it
 /// receives (which embeds the room url + token) to the file named by
@@ -83,6 +89,29 @@ fn build_test_plugin(dir: &Path) -> PathBuf {
     out
 }
 
+struct ConnectedRoom(FfiRoom);
+
+impl ConnectedRoom {
+    fn new(room: FfiRoom) -> Self {
+        room.ready_for_room_event();
+        Self(room)
+    }
+
+    fn handle_id(&self) -> u64 {
+        self.0.inner.handle_id
+    }
+}
+
+impl Drop for ConnectedRoom {
+    fn drop(&mut self) {
+        let handle_id = self.handle_id();
+        FFI_SERVER
+            .async_runtime
+            .block_on(self.0.close(&FFI_SERVER, DisconnectReason::ClientInitiated));
+        FFI_SERVER.drop_handle(handle_id);
+    }
+}
+
 #[test]
 #[ignore = "requires a live LiveKit server (LK_TEST_URL / LK_TEST_API_KEY / LK_TEST_API_SECRET) and a C compiler"]
 fn on_load_runs_for_plugin_registered_after_connect() {
@@ -99,6 +128,7 @@ fn on_load_runs_for_plugin_registered_after_connect() {
 
     let token = AccessToken::with_api_key(&api_key, &api_secret)
         .with_grants(VideoGrants {
+            room_join: true,
             room: "livekit-ffi-af-late-reg".to_string(),
             ..Default::default()
         })
@@ -109,14 +139,21 @@ fn on_load_runs_for_plugin_registered_after_connect() {
     // Connect a room. `connect` returns immediately and drives the actual
     // connection on the server runtime; the room is stored in the handle map
     // once connected, so poll `list_rooms()` rather than the event callback.
+    let existing_room_handles: HashSet<_> =
+        FFI_SERVER.list_rooms().into_iter().map(|room| room.inner.handle_id).collect();
     let _ = crate::server::room::FfiRoom::connect(
         &FFI_SERVER,
         proto::ConnectRequest { url: url.clone(), token, ..Default::default() },
     );
 
-    let room = wait_for(Duration::from_secs(15), || FFI_SERVER.list_rooms().into_iter().next())
-        .expect("room did not connect within 15s");
-    let room_handle = room.inner.handle_id;
+    let room = wait_for(Duration::from_secs(15), || {
+        FFI_SERVER
+            .list_rooms()
+            .into_iter()
+            .find(|room| !existing_room_handles.contains(&room.inner.handle_id))
+    })
+    .expect("room did not connect within 15s");
+    let room = ConnectedRoom::new(room);
 
     // Sanity: the plugin must not be registered yet, and thus no on_load.
     assert!(!log_path.exists() || read_log(&log_path).is_empty());
@@ -157,16 +194,8 @@ fn on_load_runs_for_plugin_registered_after_connect() {
         "on_load ran but not for the connected room's url; got: {logged}"
     );
 
-    // Cleanup: disconnect the room.
-    let _ = requests::handle_request(
-        &FFI_SERVER,
-        proto::FfiRequest {
-            message: Some(proto::ffi_request::Message::Disconnect(proto::DisconnectRequest {
-                room_handle,
-                ..Default::default()
-            })),
-        },
-    );
+    // Cleanup waits for the room to close and removes its FFI handle.
+    drop(room);
     let _ = std::fs::remove_dir_all(&tmp);
 }
 

--- a/livekit-ffi/src/server/audio_filter_tests.rs
+++ b/livekit-ffi/src/server/audio_filter_tests.rs
@@ -1,0 +1,188 @@
+// Copyright 2025 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration test for the "plugin registered after a room connects" fix.
+//!
+//! `on_load` is normally run for every registered audio-filter plugin when a
+//! room connects (a one-time snapshot). A plugin registered *after* connect
+//! must still be initialized for already-connected rooms, otherwise its
+//! `create` fails because the connection was never authenticated. This test
+//! exercises exactly that ordering against a real room.
+//!
+//! Gated behind `#[ignore]`: it needs a live LiveKit server. Run with:
+//! ```text
+//! LK_TEST_URL=... LK_TEST_API_KEY=... LK_TEST_API_SECRET=... \
+//!   cargo test -p livekit-ffi --lib -- --ignored on_load_runs_for_plugin_registered_after_connect
+//! ```
+//! Requires a C compiler (`cc`) on PATH to build a minimal test plugin.
+
+use std::{
+    path::{Path, PathBuf},
+    time::{Duration, Instant},
+};
+
+use livekit_api::access_token::{AccessToken, VideoGrants};
+
+use crate::{proto, server::requests, FFI_SERVER};
+
+/// A minimal audio-filter plugin. Its `on_load` appends the options JSON it
+/// receives (which embeds the room url + token) to the file named by
+/// `$LK_TEST_ONLOAD_LOG`, so the test can observe whether — and with which
+/// url — `on_load` ran. The other exported symbols are the bare minimum
+/// required for `AudioFilterPlugin` to load.
+const TEST_PLUGIN_SRC: &str = r#"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+int audio_filter_on_load(const char* options) {
+    const char* path = getenv("LK_TEST_ONLOAD_LOG");
+    if (path) {
+        FILE* f = fopen(path, "a");
+        if (f) { fprintf(f, "%s\n", options ? options : ""); fclose(f); }
+    }
+    return 0;
+}
+void* audio_filter_create(uint32_t sr, const char* opts, const char* si) { return malloc(1); }
+void audio_filter_destroy(const void* p) { free((void*)p); }
+void audio_filter_process_int16(const void* p, size_t n, const int16_t* in, int16_t* out) {
+    memcpy(out, in, n * sizeof(int16_t));
+}
+void audio_filter_process_float(const void* p, size_t n, const float* in, float* out) {
+    memcpy(out, in, n * sizeof(float));
+}
+void audio_filter_update_stream_info(const void* p, const char* si) {}
+"#;
+
+fn build_test_plugin(dir: &Path) -> PathBuf {
+    let src = dir.join("test_filter.c");
+    std::fs::write(&src, TEST_PLUGIN_SRC).unwrap();
+
+    let ext = if cfg!(target_os = "macos") { "dylib" } else { "so" };
+    let out = dir.join(format!("libtestfilter.{ext}"));
+
+    let status = std::process::Command::new("cc")
+        .args(["-shared", "-fPIC", "-o"])
+        .arg(&out)
+        .arg(&src)
+        .status()
+        .expect("failed to invoke `cc` to build the test plugin");
+    assert!(status.success(), "cc failed to build the test plugin");
+    out
+}
+
+#[test]
+#[ignore = "requires a live LiveKit server (LK_TEST_URL / LK_TEST_API_KEY / LK_TEST_API_SECRET) and a C compiler"]
+fn on_load_runs_for_plugin_registered_after_connect() {
+    let url = std::env::var("LK_TEST_URL").expect("LK_TEST_URL isn't set");
+    let api_key = std::env::var("LK_TEST_API_KEY").expect("LK_TEST_API_KEY isn't set");
+    let api_secret = std::env::var("LK_TEST_API_SECRET").expect("LK_TEST_API_SECRET isn't set");
+
+    // Per-run temp dir for the plugin dylib and the on_load log.
+    let tmp = std::env::temp_dir().join(format!("lk_af_late_reg_{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let log_path = tmp.join("on_load.log");
+    std::env::set_var("LK_TEST_ONLOAD_LOG", &log_path);
+    let plugin_path = build_test_plugin(&tmp);
+
+    let token = AccessToken::with_api_key(&api_key, &api_secret)
+        .with_grants(VideoGrants {
+            room: "livekit-ffi-af-late-reg".to_string(),
+            ..Default::default()
+        })
+        .with_identity("af_late_reg_test")
+        .to_jwt()
+        .unwrap();
+
+    // Connect a room. `connect` returns immediately and drives the actual
+    // connection on the server runtime; the room is stored in the handle map
+    // once connected, so poll `list_rooms()` rather than the event callback.
+    let _ = crate::server::room::FfiRoom::connect(
+        &FFI_SERVER,
+        proto::ConnectRequest { url: url.clone(), token, ..Default::default() },
+    );
+
+    let room = wait_for(Duration::from_secs(15), || FFI_SERVER.list_rooms().into_iter().next())
+        .expect("room did not connect within 15s");
+    let room_handle = room.inner.handle_id;
+
+    // Sanity: the plugin must not be registered yet, and thus no on_load.
+    assert!(!log_path.exists() || read_log(&log_path).is_empty());
+
+    // Register the plugin *after* the room is connected. Before the fix, its
+    // on_load would never run for this room; the fix re-runs on_load for
+    // already-connected rooms on registration.
+    let res = requests::handle_request(
+        &FFI_SERVER,
+        proto::FfiRequest {
+            message: Some(proto::ffi_request::Message::LoadAudioFilterPlugin(
+                proto::LoadAudioFilterPluginRequest {
+                    plugin_path: plugin_path.to_string_lossy().into_owned(),
+                    module_id: "test-late-reg".to_string(),
+                    dependencies: vec![],
+                },
+            )),
+        },
+    )
+    .expect("handle_request failed");
+    if let Some(proto::ffi_response::Message::LoadAudioFilterPlugin(resp)) = res.message {
+        assert!(resp.error.is_none(), "plugin failed to load: {:?}", resp.error);
+    } else {
+        panic!("unexpected response to LoadAudioFilterPlugin");
+    }
+
+    // The re-run happens on a spawned blocking task; poll for the log entry.
+    let logged = wait_for(Duration::from_secs(10), || {
+        let contents = read_log(&log_path);
+        (!contents.is_empty()).then_some(contents)
+    })
+    .expect("on_load did not run for the already-connected room after registration");
+
+    // on_load received the room's connect url (this is the key that `create`
+    // later looks up — it must match).
+    assert!(
+        logged.contains(&url),
+        "on_load ran but not for the connected room's url; got: {logged}"
+    );
+
+    // Cleanup: disconnect the room.
+    let _ = requests::handle_request(
+        &FFI_SERVER,
+        proto::FfiRequest {
+            message: Some(proto::ffi_request::Message::Disconnect(proto::DisconnectRequest {
+                room_handle,
+                ..Default::default()
+            })),
+        },
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+fn read_log(path: &Path) -> String {
+    std::fs::read_to_string(path).unwrap_or_default()
+}
+
+fn wait_for<T>(timeout: Duration, mut f: impl FnMut() -> Option<T>) -> Option<T> {
+    let start = Instant::now();
+    loop {
+        if let Some(v) = f() {
+            return Some(v);
+        }
+        if start.elapsed() >= timeout {
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}

--- a/livekit-ffi/src/server/mod.rs
+++ b/livekit-ffi/src/server/mod.rs
@@ -159,16 +159,19 @@ impl FfiServer {
         self.config.lock().is_some()
     }
 
+    /// Snapshot of all currently-stored rooms.
+    pub fn list_rooms(&self) -> Vec<room::FfiRoom> {
+        self.ffi_handles
+            .iter()
+            .filter_map(|h| h.value().downcast_ref::<room::FfiRoom>().cloned())
+            .collect()
+    }
+
     pub async fn dispose(&'static self) {
         log::debug!("disposing ffi server");
 
         // Close all rooms
-        let mut rooms = Vec::new();
-        for handle in self.ffi_handles.iter_mut() {
-            if let Some(handle) = handle.value().downcast_ref::<room::FfiRoom>() {
-                rooms.push(handle.clone());
-            }
-        }
+        let rooms = self.list_rooms();
 
         for room in rooms {
             room.close(self, DisconnectReason::ClientInitiated).await;

--- a/livekit-ffi/src/server/mod.rs
+++ b/livekit-ffi/src/server/mod.rs
@@ -52,6 +52,9 @@ pub mod video_stream;
 //#[cfg(test)]
 //mod tests;
 
+#[cfg(test)]
+mod audio_filter_tests;
+
 #[derive(Clone)]
 pub struct FfiConfig {
     pub callback_fn: Arc<dyn Fn(FfiEvent) + Send + Sync>,

--- a/livekit-ffi/src/server/requests.rs
+++ b/livekit-ffi/src/server/requests.rs
@@ -17,7 +17,7 @@ use std::{slice, sync::Arc};
 use colorcvt::cvtimpl;
 use livekit::{
     prelude::*,
-    register_audio_filter_plugin, registered_audio_filter_plugin,
+    register_audio_filter_plugin,
     webrtc::{native::apm, native::audio_resampler, prelude::*},
     AudioFilterPlugin, SimulateScenario,
 };
@@ -1050,24 +1050,16 @@ fn on_load_audio_filter_plugin(
         }
     };
 
-    // A re-registration of the same module id means already-connected rooms
-    // were `on_load`'d for it on their first registration; re-running below
-    // would call the plugin's `on_load` a second time for them. Skip it so
-    // the host doesn't depend on plugins being idempotent.
-    let is_new = registered_audio_filter_plugin(&request.module_id).is_none();
-
     register_audio_filter_plugin(request.module_id, plugin.clone());
-
-    if !is_new {
-        return Ok(proto::LoadAudioFilterPluginResponse { error: None });
-    }
 
     // `on_load` is normally called for every registered plugin when a room
     // connects, but that is a one-time snapshot: a plugin registered *after*
     // a room has already connected would otherwise never be initialized for
     // it (its `create` would then fail because the connection was never
     // authenticated). Run `on_load` now for any already-connected rooms so
-    // registration order doesn't matter.
+    // registration order doesn't matter. `on_load` is expected to be
+    // idempotent (it is already called once per connected room), so a repeat
+    // registration re-running it here is harmless.
     for room in server.list_rooms() {
         let plugin = plugin.clone();
         let url = room.inner.url();

--- a/livekit-ffi/src/server/requests.rs
+++ b/livekit-ffi/src/server/requests.rs
@@ -1039,7 +1039,7 @@ fn on_perform_rpc(
 }
 
 fn on_load_audio_filter_plugin(
-    _server: &'static FfiServer,
+    server: &'static FfiServer,
     request: proto::LoadAudioFilterPluginRequest,
 ) -> FfiResult<proto::LoadAudioFilterPluginResponse> {
     let deps: Vec<_> = request.dependencies.iter().map(|d| d).collect();
@@ -1050,7 +1050,26 @@ fn on_load_audio_filter_plugin(
         }
     };
 
-    register_audio_filter_plugin(request.module_id, plugin);
+    register_audio_filter_plugin(request.module_id, plugin.clone());
+
+    // `on_load` is normally called for every registered plugin when a room
+    // connects, but that is a one-time snapshot: a plugin registered *after*
+    // a room has already connected would otherwise never be initialized for
+    // it (its `create` would then fail because the connection was never
+    // authenticated). Run `on_load` now for any already-connected rooms so
+    // registration order doesn't matter.
+    for room in server.list_rooms() {
+        let plugin = plugin.clone();
+        let url = room.inner.url();
+        let token = room.inner.room.token();
+        // Spawn (don't block the request): a plugin's `on_load` may perform
+        // network I/O, and this must not stall the FFI request thread.
+        server.async_runtime.spawn_blocking(move || {
+            if let Err(e) = plugin.on_load(&url, &token) {
+                log::error!("audio filter on_load failed for an already-connected room: {e}");
+            }
+        });
+    }
 
     Ok(proto::LoadAudioFilterPluginResponse { error: None })
 }

--- a/livekit-ffi/src/server/requests.rs
+++ b/livekit-ffi/src/server/requests.rs
@@ -17,7 +17,7 @@ use std::{slice, sync::Arc};
 use colorcvt::cvtimpl;
 use livekit::{
     prelude::*,
-    register_audio_filter_plugin,
+    register_audio_filter_plugin, registered_audio_filter_plugin,
     webrtc::{native::apm, native::audio_resampler, prelude::*},
     AudioFilterPlugin, SimulateScenario,
 };
@@ -1050,7 +1050,17 @@ fn on_load_audio_filter_plugin(
         }
     };
 
+    // A re-registration of the same module id means already-connected rooms
+    // were `on_load`'d for it on their first registration; re-running below
+    // would call the plugin's `on_load` a second time for them. Skip it so
+    // the host doesn't depend on plugins being idempotent.
+    let is_new = registered_audio_filter_plugin(&request.module_id).is_none();
+
     register_audio_filter_plugin(request.module_id, plugin.clone());
+
+    if !is_new {
+        return Ok(proto::LoadAudioFilterPluginResponse { error: None });
+    }
 
     // `on_load` is normally called for every registered plugin when a room
     // connects, but that is a one-time snapshot: a plugin registered *after*

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -872,6 +872,12 @@ impl Room {
         self.inner.info.read().name.clone()
     }
 
+    /// The current signalling token (the initial token, or the latest
+    /// refreshed one). Used to (re-)authenticate audio filter plugins.
+    pub fn token(&self) -> String {
+        self.inner.rtc_engine.session().signal_client().token()
+    }
+
     pub fn metadata(&self) -> String {
         self.inner.info.read().metadata.clone()
     }


### PR DESCRIPTION
## Problem

Audio-filter plugins are authenticated in a one-time pass: when a room
connects, `FfiRoom::connect` calls `on_load(url, token)` for every plugin
registered *at that moment*. A plugin registered **after** the room has
connected is never initialized for it — its later `create` then fails
because the connection was never authenticated (surfacing downstream as
"failed to initialize the audio filter").

Because `room.connect()` is async, any registration that lands in that
window loses the race.

## Fix

When a plugin is registered (`LoadAudioFilterPlugin`), also run its `on_load`
against every already-connected room, using each room's connect URL and
current token — so registration order no longer matters.

- New `Room::token()` accessor (livekit): current signalling token, needed to
  authenticate late-registered plugins.
- New `FfiServer::list_rooms()` (livekit-ffi): snapshot of connected rooms
  (refactored out of the existing `dispose` logic).
- `on_load_audio_filter_plugin` runs `on_load` per room on `spawn_blocking`
  (fire-and-forget), so a plugin whose `on_load` does network I/O can't stall
  the request thread. `on_load` is idempotent per URL, so this can't conflict
  with the connect-time pass. Registration happens before the loop so a
  concurrently-connecting room is still covered by the normal path.

## Notes

- Uses the room's connect URL (not the resolved signalling URL) so the auth
  key matches what `create` later looks up.