### PR TITLE
build(livekit-uniffi): keep uniffi `cli` out of shipped library builds

### DIFF
--- a/.changeset/remove_uniffi_cli_from_staticlib.md
+++ b/.changeset/remove_uniffi_cli_from_staticlib.md
@@ -1,0 +1,5 @@
+---
+livekit-uniffi: patch
+---
+
+Gate the uniffi `cli` feature (clap + bindgen backends) behind an opt-in feature so it is no longer compiled into shipped library builds, shrinking the static archive by ~43 MiB. The dynamic library is byte-unchanged. - #1275 (@jhugman)

--- a/livekit-datatrack/Cargo.toml
+++ b/livekit-datatrack/Cargo.toml
@@ -21,7 +21,7 @@ tokio-stream = { workspace = true, features = ["sync"] }
 anyhow = { workspace = true } # For internal error handling only
 rand = { workspace = true }
 fake = { version = "4.4", features = ["derive"], optional = true }
-uniffi = { workspace = true, features = ["cli", "scaffolding-ffi-buffer-fns"], optional = true }
+uniffi = { workspace = true, features = ["scaffolding-ffi-buffer-fns"], optional = true }
 indexmap = "2"
 
 [features]

--- a/livekit-uniffi/Cargo.toml
+++ b/livekit-uniffi/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 livekit-protocol = { workspace = true }
 livekit-api = { workspace = true }
 livekit-datatrack = { workspace = true, features = ["uniffi"] }
-uniffi = { workspace = true, features = ["cli", "scaffolding-ffi-buffer-fns", "tokio"] }
+uniffi = { workspace = true, features = ["scaffolding-ffi-buffer-fns", "tokio"] }
 log = { workspace = true }
 tokio = { workspace = true, features = ["sync", "rt-multi-thread"] }
 tokio-util =  "0.7.18"
@@ -31,6 +31,11 @@ uniffi-dart = { git = "https://github.com/Uniffi-Dart/uniffi-dart", rev = "90f2c
 camino = { version = "1", optional = true }
 
 [features]
+# Enables the `uniffi-bindgen` bin (uniffi's CLI: clap + the bindings backends).
+# Tooling-only — kept off library builds so the shipped cdylib/staticlib don't
+# carry the bindgen machinery. Enable it when running the bin:
+# `cargo run --features cli --bin uniffi-bindgen generate ...`.
+cli = ["uniffi/cli"]
 # Enables the `uniffi-bindgen-dart` bin. Not enabled for library builds.
 dart-bindgen = ["dep:uniffi-dart", "dep:camino"]
 
@@ -40,6 +45,7 @@ uniffi = { workspace = true, features = ["build", "scaffolding-ffi-buffer-fns"] 
 [[bin]]
 name = "uniffi-bindgen"
 path = "bindgen.rs"
+required-features = ["cli"]
 
 [[bin]]
 name = "uniffi-bindgen-dart"

--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -152,7 +152,9 @@ dependencies = ["build", "locate-lib"]
 script_runner = "@duckscript"
 script = """
 out_dir = join_path ${PACKAGES_DIR} ${LANG}
-exec cargo run --bin uniffi-bindgen generate \
+# `--features cli` builds the bindgen bin (gated off library builds so the
+# shipped cdylib/staticlib don't carry uniffi's CLI machinery).
+exec cargo run --features cli --bin uniffi-bindgen generate \
     --language ${LANG} \
     --out-dir ${out_dir} \
     --library ${LIB_PATH}


### PR DESCRIPTION
The uniffi `cli` feature (clap + the bindings backends) is only needed by the `uniffi-bindgen` bin, but it was a hard dependency feature — so it was compiled into every library build of the shipped cdylib/staticlib, and was also pulled in transitively through livekit-datatrack's `uniffi` feature.

Gate it behind an opt-in `cli` feature with `required-features` on the bin (mirroring the existing `dart-bindgen` pattern), drop the spurious `cli` from livekit-datatrack (a plain library that never calls the bindgen CLI), and pass `--features cli` in the Makefile bindgen task. Bindgen already runs in library mode against the compiled cdylib, so it stays fully decoupled.

Removes clap + the bindgen backends (~43 MiB) from the static archive and cuts crate compile time ~3x. The LTO'd shipped dylib already dead-stripped the unreachable cli code, so the dynamic artifact is byte-unchanged.

### Before you submit your PR

Make sure the following is true before submitting your PR:

- [ ] I have read the [contributing guidelines](https://github.com/livekit/rust-sdks/blob/main/CONTRIBUTING.md) and validated that this PR will be accepted.
- [ ] I have read and followed the principles regarding breaking changes, testing, and code quality.

### PR description

Describe the changes in this PR. Explain what the PR is meant to solve and how to reproduce the issue in the first place.

### Breaking changes

If this PR introduces breaking changes, list them here and document the rationale for introducing such a change.

### MSRV

If the PR modifies the crate's MSRV (Minimum Supported Rust Version), document it here.

### Testing

Ideally, unit test the code you add, but ensure you're not repeating existing test cases. Use as many already written scaffolding, utilities as possible; write your own, when needed. If external services, APIs, tokens are required (e.g., running an LK server instance), provide the necessary information. Make sure your tests perform useful, context-aware assertions and do not simply emulate "happy paths".

### Async

We want the project to be runtime-agnostic, so please reuse what's already in [livekit-runtime](https://github.com/livekit/rust-sdks/blob/main/livekit-runtime/) and feel free to add anything missing. It's ok to use Tokio directly, when writing unit tests, if necessary. When testing, do not use artificial delays for the state to "catch up"; instead, respect the event flow and subscribe properly using channels or other mechanisms.


