### PR TITLE
Handle dmabuf using existing capture path

### DIFF
--- a/.changeset/handle_capture_of_dmabuf_using_existing_capture_path.md
+++ b/.changeset/handle_capture_of_dmabuf_using_existing_capture_path.md
@@ -1,0 +1,8 @@
+---
+libwebrtc: minor
+webrtc-sys: minor
+livekit: patch
+livekit-ffi: patch
+---
+
+# Handle capture of dmabuf using existing capture path

--- a/examples/local_video/src/publisher.rs
+++ b/examples/local_video/src/publisher.rs
@@ -6,6 +6,8 @@ use livekit::options::{
     VideoEncoderBackend, VideoEncoding, VideoPreset,
 };
 use livekit::prelude::*;
+#[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+use livekit::webrtc::video_frame::native::{DmaBufPixelFormat, NativeBuffer};
 use livekit::webrtc::video_frame::{FrameMetadata, I420Buffer, VideoFrame, VideoRotation};
 use livekit::webrtc::video_source::native::NativeVideoSource;
 use livekit::webrtc::video_source::{RtcVideoSource, VideoResolution};
@@ -1713,8 +1715,8 @@ async fn run_capture_loop(
 ///
 /// Argus blocks inside `acquireFrame`, pacing capture itself, so this loop runs in a
 /// dedicated OS thread and pushes NV12 DMA-buffer fds straight into `NativeVideoSource`
-/// via [`NativeVideoSource::capture_dmabuf_frame_with_metadata`] for zero-copy hand-off
-/// to the Jetson hardware encoder.
+/// as [`NativeBuffer::from_dmabuf`] frames for zero-copy hand-off to the Jetson
+/// hardware encoder.
 #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
 async fn run_argus_capture_loop(
     config: CaptureConfig,
@@ -1848,14 +1850,16 @@ async fn run_argus_capture_loop(
                     None
                 };
 
-                rtc_source.capture_dmabuf_frame_with_metadata(
-                    argus_frame.dmabuf_fd,
-                    width,
-                    height,
-                    0, // NV12
-                    start_ts.elapsed().as_micros() as i64,
+                rtc_source.capture_frame(&VideoFrame {
+                    rotation: VideoRotation::VideoRotation0,
+                    timestamp_us: start_ts.elapsed().as_micros() as i64,
                     frame_metadata,
-                );
+                    buffer: NativeBuffer::from_dmabuf(
+                        argus_frame.dmabuf_fd,
+                        VideoResolution { width, height },
+                        DmaBufPixelFormat::NV12,
+                    ),
+                });
                 let capture_finished_at = Instant::now();
 
                 frames += 1;

--- a/libwebrtc/src/native/video_frame.rs
+++ b/libwebrtc/src/native/video_frame.rs
@@ -166,6 +166,30 @@ impl NativeBuffer {
         unsafe { vfb_sys::ffi::native_buffer_to_platform_image_buffer(&self.sys_handle) as *mut _ }
     }
 
+    #[cfg(target_os = "linux")]
+    pub fn from_dmabuf(
+        dmabuf_fd: vf::native::DmaBufFileDescriptor,
+        resolution: crate::video_source::VideoResolution,
+        pixel_format: vf::native::DmaBufPixelFormat,
+    ) -> vf::native::NativeBuffer {
+        vf::native::NativeBuffer {
+            handle: NativeBuffer {
+                sys_handle: vfb_sys::ffi::new_native_buffer_from_dmabuf(
+                    dmabuf_fd,
+                    resolution.width as i32,
+                    resolution.height as i32,
+                    pixel_format as i32,
+                ),
+            },
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn get_dmabuf_fd(&self) -> Option<vf::native::DmaBufFileDescriptor> {
+        let fd = vfb_sys::ffi::native_buffer_to_dmabuf_fd(&self.sys_handle);
+        (fd >= 0).then_some(fd)
+    }
+
     pub fn sys_handle(&self) -> &vfb_sys::ffi::VideoFrameBuffer {
         &self.sys_handle
     }

--- a/libwebrtc/src/native/video_source.rs
+++ b/libwebrtc/src/native/video_source.rs
@@ -24,8 +24,6 @@ use cxx::SharedPtr;
 use livekit_runtime::interval;
 use webrtc_sys::{video_frame as vf_sys, video_frame::ffi::VideoRotation, video_track as vt_sys};
 
-#[cfg(target_os = "linux")]
-use crate::video_frame::FrameMetadata;
 use crate::{
     native::packet_trailer::PacketTrailerHandler,
     video_frame::{EncodedVideoFrame, I420Buffer, VideoBuffer, VideoFrame},
@@ -124,7 +122,9 @@ impl NativeVideoSource {
         self.sys_handle.clone()
     }
 
-    pub fn capture_frame<T: AsRef<dyn VideoBuffer>>(&self, frame: &VideoFrame<T>) {
+    /// Returns `false` if the frame was dropped by the adapter (e.g. due to
+    /// resolution/frame-rate adaptation) instead of being forwarded.
+    pub fn capture_frame<T: AsRef<dyn VideoBuffer>>(&self, frame: &VideoFrame<T>) -> bool {
         let mut builder = vf_sys::ffi::new_video_frame_builder();
         builder.pin_mut().set_rotation(frame.rotation.into());
         builder.pin_mut().set_video_frame_buffer(frame.buffer.as_ref().sys_handle());
@@ -157,7 +157,7 @@ impl NativeVideoSource {
                 frame_id: fid,
                 user_data,
             },
-        );
+        )
     }
 
     pub fn capture_encoded_frame(&self, frame: &EncodedVideoFrame<'_>) -> bool {
@@ -212,67 +212,6 @@ impl NativeVideoSource {
             target_bitrate_bps: request.target_bitrate_bps,
             framerate_fps: request.framerate_fps,
         })
-    }
-
-    /// Captures a Jetson DMA-buffer backed video frame.
-    ///
-    /// `pixel_format` is `0` for NV12 and `1` for YUV420M.
-    #[cfg(target_os = "linux")]
-    pub fn capture_dmabuf_frame(
-        &self,
-        dmabuf_fd: i32,
-        width: u32,
-        height: u32,
-        pixel_format: i32,
-        timestamp_us: i64,
-    ) -> bool {
-        self.capture_dmabuf_frame_with_metadata(
-            dmabuf_fd,
-            width,
-            height,
-            pixel_format,
-            timestamp_us,
-            None,
-        )
-    }
-
-    /// Captures a Jetson DMA-buffer backed video frame with packet trailer metadata.
-    ///
-    /// `pixel_format` is `0` for NV12 and `1` for YUV420M.
-    #[cfg(target_os = "linux")]
-    pub fn capture_dmabuf_frame_with_metadata(
-        &self,
-        dmabuf_fd: i32,
-        width: u32,
-        height: u32,
-        pixel_format: i32,
-        timestamp_us: i64,
-        frame_metadata: Option<FrameMetadata>,
-    ) -> bool {
-        let (has_trailer, user_ts, fid, user_data) = match frame_metadata {
-            Some(meta) => (
-                true,
-                meta.user_timestamp.unwrap_or(0),
-                meta.frame_id.unwrap_or(0),
-                meta.user_data.unwrap_or_default(),
-            ),
-            None => (false, 0, 0, Vec::new()),
-        };
-
-        self.captured_frames.fetch_add(1, Ordering::Relaxed);
-        self.sys_handle.capture_dmabuf_frame(
-            dmabuf_fd,
-            width as i32,
-            height as i32,
-            pixel_format,
-            timestamp_us,
-            &vt_sys::ffi::FrameMetadata {
-                has_packet_trailer: has_trailer,
-                user_timestamp: user_ts,
-                frame_id: fid,
-                user_data,
-            },
-        )
     }
 
     /// Set the packet trailer handler used by this source.

--- a/libwebrtc/src/video_frame.rs
+++ b/libwebrtc/src/video_frame.rs
@@ -568,8 +568,27 @@ pub mod native {
     use std::fmt::Debug;
 
     use super::{vf_imp, I420Buffer, VideoBuffer, VideoBufferType, VideoFormatType};
+    #[cfg(target_os = "linux")]
+    use crate::video_source::VideoResolution;
 
     new_buffer_type!(NativeBuffer, Native, as_native);
+
+    /// A borrowed DMA-BUF file descriptor.
+    ///
+    /// This is a plain [`RawFd`](std::os::fd::RawFd) (a C `int`, hence `i32`):
+    /// APIs taking this type borrow the descriptor rather than own it, so the
+    /// caller remains responsible for keeping it valid and closing it.
+    #[cfg(target_os = "linux")]
+    pub type DmaBufFileDescriptor = std::os::fd::RawFd;
+
+    /// Pixel format of a DMA-BUF backed video buffer.
+    #[cfg(target_os = "linux")]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[non_exhaustive]
+    pub enum DmaBufPixelFormat {
+        NV12 = 0,
+        YUV420M = 1,
+    }
 
     impl NativeBuffer {
         /// Creates a `NativeBuffer` from a `CVPixelBufferRef` pointer.
@@ -589,6 +608,31 @@ pub mod native {
         #[cfg(any(target_os = "macos", target_os = "ios"))]
         pub fn get_cv_pixel_buffer(&self) -> *mut std::ffi::c_void {
             self.handle.get_cv_pixel_buffer()
+        }
+
+        /// Creates a `NativeBuffer` backed by a DMA-BUF file descriptor
+        /// (Jetson `NvBufSurface`), for zero-copy hand-off to the hardware
+        /// encoder.
+        ///
+        /// This function does not take ownership of the fd: the caller must
+        /// keep it valid until every frame captured from it has been consumed
+        /// by the encoder.
+        #[cfg(target_os = "linux")]
+        pub fn from_dmabuf(
+            dmabuf_fd: DmaBufFileDescriptor,
+            resolution: VideoResolution,
+            pixel_format: DmaBufPixelFormat,
+        ) -> Self {
+            vf_imp::NativeBuffer::from_dmabuf(dmabuf_fd, resolution, pixel_format)
+        }
+
+        /// Returns the DMA-BUF fd that backs this buffer, or `None` if this
+        /// buffer is not DMA-BUF backed.
+        ///
+        /// This function does not transfer ownership of the fd.
+        #[cfg(target_os = "linux")]
+        pub fn get_dmabuf_fd(&self) -> Option<DmaBufFileDescriptor> {
+            self.handle.get_dmabuf_fd()
         }
     }
 

--- a/libwebrtc/src/video_source.rs
+++ b/libwebrtc/src/video_source.rs
@@ -59,7 +59,10 @@ pub mod native {
     use super::*;
     use crate::native::packet_trailer::PacketTrailerHandler;
     #[cfg(target_os = "linux")]
-    use crate::video_frame::FrameMetadata;
+    use crate::video_frame::{
+        native::{DmaBufPixelFormat, NativeBuffer},
+        FrameMetadata, VideoRotation,
+    };
     use crate::video_frame::{EncodedVideoFrame, VideoBuffer, VideoFrame};
 
     #[derive(Clone)]
@@ -91,7 +94,66 @@ pub mod native {
         }
 
         pub fn capture_frame<T: AsRef<dyn VideoBuffer>>(&self, frame: &VideoFrame<T>) {
-            self.handle.capture_frame(frame)
+            self.handle.capture_frame(frame);
+        }
+
+        /// Captures a Jetson DMA-buffer backed video frame.
+        ///
+        /// `pixel_format` is `0` for NV12 and `1` for YUV420M.
+        #[cfg(target_os = "linux")]
+        #[deprecated(
+            note = "wrap the fd with `NativeBuffer::from_dmabuf` and use `capture_frame` instead"
+        )]
+        #[allow(deprecated)]
+        pub fn capture_dmabuf_frame(
+            &self,
+            dmabuf_fd: i32,
+            width: u32,
+            height: u32,
+            pixel_format: i32,
+            timestamp_us: i64,
+        ) -> bool {
+            self.capture_dmabuf_frame_with_metadata(
+                dmabuf_fd,
+                width,
+                height,
+                pixel_format,
+                timestamp_us,
+                None,
+            )
+        }
+
+        /// Captures a Jetson DMA-buffer backed video frame with packet trailer metadata.
+        ///
+        /// `pixel_format` is `0` for NV12 and `1` for YUV420M.
+        #[cfg(target_os = "linux")]
+        #[deprecated(
+            note = "wrap the fd with `NativeBuffer::from_dmabuf` and use `capture_frame` instead"
+        )]
+        pub fn capture_dmabuf_frame_with_metadata(
+            &self,
+            dmabuf_fd: i32,
+            width: u32,
+            height: u32,
+            pixel_format: i32,
+            timestamp_us: i64,
+            frame_metadata: Option<FrameMetadata>,
+        ) -> bool {
+            let pixel_format = if pixel_format == 0 {
+                DmaBufPixelFormat::NV12
+            } else {
+                DmaBufPixelFormat::YUV420M
+            };
+            self.handle.capture_frame(&VideoFrame {
+                rotation: VideoRotation::VideoRotation0,
+                timestamp_us,
+                frame_metadata,
+                buffer: NativeBuffer::from_dmabuf(
+                    dmabuf_fd,
+                    VideoResolution { width, height },
+                    pixel_format,
+                ),
+            })
         }
 
         /// Captures one pre-encoded video access unit.
@@ -109,44 +171,6 @@ pub mod native {
         /// pass-through encoder.
         pub fn take_rate_control_request(&self) -> Option<EncodedRateControl> {
             self.handle.take_rate_control_request()
-        }
-
-        /// Captures a Jetson DMA-buffer backed video frame.
-        ///
-        /// `pixel_format` is `0` for NV12 and `1` for YUV420M.
-        #[cfg(target_os = "linux")]
-        pub fn capture_dmabuf_frame(
-            &self,
-            dmabuf_fd: i32,
-            width: u32,
-            height: u32,
-            pixel_format: i32,
-            timestamp_us: i64,
-        ) -> bool {
-            self.handle.capture_dmabuf_frame(dmabuf_fd, width, height, pixel_format, timestamp_us)
-        }
-
-        /// Captures a Jetson DMA-buffer backed video frame with packet trailer metadata.
-        ///
-        /// `pixel_format` is `0` for NV12 and `1` for YUV420M.
-        #[cfg(target_os = "linux")]
-        pub fn capture_dmabuf_frame_with_metadata(
-            &self,
-            dmabuf_fd: i32,
-            width: u32,
-            height: u32,
-            pixel_format: i32,
-            timestamp_us: i64,
-            frame_metadata: Option<FrameMetadata>,
-        ) -> bool {
-            self.handle.capture_dmabuf_frame_with_metadata(
-                dmabuf_fd,
-                width,
-                height,
-                pixel_format,
-                timestamp_us,
-                frame_metadata,
-            )
         }
 
         /// Set the packet trailer handler used by this source.

--- a/libwebrtc/src/video_source.rs
+++ b/libwebrtc/src/video_source.rs
@@ -93,8 +93,8 @@ pub mod native {
             Self { handle: vs_imp::NativeVideoSource::new_encoded(resolution) }
         }
 
-        pub fn capture_frame<T: AsRef<dyn VideoBuffer>>(&self, frame: &VideoFrame<T>) {
-            self.handle.capture_frame(frame);
+        pub fn capture_frame<T: AsRef<dyn VideoBuffer>>(&self, frame: &VideoFrame<T>) -> bool {
+            self.handle.capture_frame(frame)
         }
 
         /// Captures a Jetson DMA-buffer backed video frame.

--- a/webrtc-sys/include/livekit/video_frame_buffer.h
+++ b/webrtc-sys/include/livekit/video_frame_buffer.h
@@ -223,6 +223,9 @@ std::unique_ptr<NV12Buffer> new_nv12_buffer(int width, int height, int stride_y,
 std::unique_ptr<VideoFrameBuffer> new_native_buffer_from_platform_image_buffer(PlatformImageBuffer *buffer);
 PlatformImageBuffer* native_buffer_to_platform_image_buffer(const std::unique_ptr<VideoFrameBuffer> &);
 
+std::unique_ptr<VideoFrameBuffer> new_native_buffer_from_dmabuf(int dmabuf_fd, int width, int height, int pixel_format);
+int native_buffer_to_dmabuf_fd(const std::unique_ptr<VideoFrameBuffer> &);
+
 static const VideoFrameBuffer* yuv_to_vfb(const PlanarYuvBuffer* yuv) {
   return yuv;
 }

--- a/webrtc-sys/include/livekit/video_track.h
+++ b/webrtc-sys/include/livekit/video_track.h
@@ -138,16 +138,6 @@ class VideoTrackSource {
                          const FrameMetadata& frame_metadata)
       const;  // frames pushed from Rust (+interior mutability)
 
-  // Single-call DmaBuf capture: creates the DmaBufVideoFrameBuffer and
-  // VideoFrame internally, avoiding multiple FFI round-trips and heap
-  // allocations on the hot path.
-  bool capture_dmabuf_frame(int dmabuf_fd,
-                            int width,
-                            int height,
-                            int pixel_format,
-                            int64_t timestamp_us,
-                            const FrameMetadata& frame_metadata) const;
-
   bool capture_encoded_frame(int width,
                              int height,
                              const EncodedVideoFrameData& frame,

--- a/webrtc-sys/src/video_frame_buffer.cpp
+++ b/webrtc-sys/src/video_frame_buffer.cpp
@@ -17,6 +17,7 @@
 #include "livekit/video_frame_buffer.h"
 
 #include "api/make_ref_counted.h"
+#include "livekit/dmabuf_video_frame_buffer.h"
 
 namespace livekit_ffi {
 
@@ -356,6 +357,24 @@ std::unique_ptr<NV12Buffer> new_nv12_buffer(int width,
                                             int stride_uv) {
   return std::make_unique<NV12Buffer>(
       webrtc::NV12Buffer::Create(width, height, stride_y, stride_uv));
+}
+
+std::unique_ptr<VideoFrameBuffer> new_native_buffer_from_dmabuf(
+    int dmabuf_fd,
+    int width,
+    int height,
+    int pixel_format) {
+  return std::make_unique<VideoFrameBuffer>(
+      webrtc::make_ref_counted<livekit::DmaBufVideoFrameBuffer>(
+          dmabuf_fd, width, height,
+          static_cast<livekit::DmaBufPixelFormat>(pixel_format)));
+}
+
+int native_buffer_to_dmabuf_fd(
+    const std::unique_ptr<VideoFrameBuffer>& buffer) {
+  auto* dmabuf =
+      livekit::DmaBufVideoFrameBuffer::FromNative(buffer->get().get());
+  return dmabuf ? dmabuf->dmabuf_fd() : -1;
 }
 
 #ifndef __APPLE__

--- a/webrtc-sys/src/video_frame_buffer.rs
+++ b/webrtc-sys/src/video_frame_buffer.rs
@@ -160,6 +160,23 @@ pub mod ffi {
             buffer: &UniquePtr<VideoFrameBuffer>,
         ) -> *mut PlatformImageBuffer;
 
+        /// Creates a native buffer backed by a DMA-BUF file descriptor
+        /// (Jetson `NvBufSurface`). `pixel_format` is a
+        /// `livekit::DmaBufPixelFormat` value: `0` for NV12, `1` for YUV420M.
+        ///
+        /// The buffer does not take ownership of the fd: it must remain valid
+        /// until every frame captured from it has been consumed downstream.
+        fn new_native_buffer_from_dmabuf(
+            dmabuf_fd: i32,
+            width: i32,
+            height: i32,
+            pixel_format: i32,
+        ) -> UniquePtr<VideoFrameBuffer>;
+
+        /// Returns the DMA-BUF fd backing this buffer, or `-1` if this buffer
+        /// is not DMA-BUF backed.
+        fn native_buffer_to_dmabuf_fd(buffer: &UniquePtr<VideoFrameBuffer>) -> i32;
+
         unsafe fn yuv_to_vfb(yuv: *const PlanarYuvBuffer) -> *const VideoFrameBuffer;
         unsafe fn biyuv_to_vfb(yuv: *const BiplanarYuvBuffer) -> *const VideoFrameBuffer;
         unsafe fn yuv8_to_yuv(yuv8: *const PlanarYuv8Buffer) -> *const PlanarYuvBuffer;

--- a/webrtc-sys/src/video_track.cpp
+++ b/webrtc-sys/src/video_track.cpp
@@ -17,7 +17,6 @@
 #include "livekit/video_track.h"
 
 #include <algorithm>
-#include <chrono>
 #include <iostream>
 #include <memory>
 
@@ -26,7 +25,6 @@
 #include "api/video/video_rotation.h"
 #include "audio/remix_resample.h"
 #include "common_audio/include/audio_util.h"
-#include "livekit/dmabuf_video_frame_buffer.h"
 #include "livekit/encoded_video_frame_buffer.h"
 #include "livekit/media_stream.h"
 #include "livekit/packet_trailer.h"
@@ -265,32 +263,6 @@ bool VideoTrackSource::on_captured_frame(
     const FrameMetadata& frame_metadata) const {
   auto rtc_frame = frame->get();
   return source_->on_captured_frame(rtc_frame, frame_metadata);
-}
-
-bool VideoTrackSource::capture_dmabuf_frame(int dmabuf_fd,
-                                            int width,
-                                            int height,
-                                            int pixel_format,
-                                            int64_t timestamp_us,
-                                            const FrameMetadata& frame_metadata) const {
-  auto dmabuf_pixel_format =
-      static_cast<livekit::DmaBufPixelFormat>(pixel_format);
-  auto buffer = webrtc::make_ref_counted<livekit::DmaBufVideoFrameBuffer>(
-      dmabuf_fd, width, height, dmabuf_pixel_format);
-
-  int64_t ts = timestamp_us;
-  if (ts == 0) {
-    auto now = std::chrono::system_clock::now().time_since_epoch();
-    ts = std::chrono::duration_cast<std::chrono::microseconds>(now).count();
-  }
-
-  auto frame = webrtc::VideoFrame::Builder()
-                   .set_video_frame_buffer(std::move(buffer))
-                   .set_rotation(webrtc::kVideoRotation_0)
-                   .set_timestamp_us(ts)
-                   .build();
-
-  return source_->on_captured_frame(frame, frame_metadata);
 }
 
 bool VideoTrackSource::capture_encoded_frame(

--- a/webrtc-sys/src/video_track.rs
+++ b/webrtc-sys/src/video_track.rs
@@ -116,15 +116,6 @@ pub mod ffi {
             frame: &UniquePtr<VideoFrame>,
             frame_metadata: &FrameMetadata,
         ) -> bool;
-        fn capture_dmabuf_frame(
-            self: &VideoTrackSource,
-            dmabuf_fd: i32,
-            width: i32,
-            height: i32,
-            pixel_format: i32,
-            timestamp_us: i64,
-            frame_metadata: &FrameMetadata,
-        ) -> bool;
         fn capture_encoded_frame(
             self: &VideoTrackSource,
             width: i32,


### PR DESCRIPTION
Previously, dedicated methods on `NativeVideoSource` were used to capture dmabuf; these have been deprecated and dmabuf is now handled by `NativeBuffer` (also handles analogous zero-copy `CVPixelBuffer` for Apple platforms). See the updated example for new usage.