### PR TITLE
Add Windows hardware H264 encode/decode via MediaFoundation

### DIFF
--- a/.changeset/mf-h264-windows-backend.md
+++ b/.changeset/mf-h264-windows-backend.md
@@ -1,0 +1,5 @@
+---
+"webrtc-sys": minor
+---
+
+Add Windows hardware H264 encode/decode via MediaFoundation (covers Intel QuickSync, AMD VCN and NVIDIA through the driver-registered MFTs; no new dependencies)

--- a/webrtc-sys/build.rs
+++ b/webrtc-sys/build.rs
@@ -152,6 +152,14 @@ fn main() {
             println!("cargo:rustc-link-lib=dylib=dwmapi");
             println!("cargo:rustc-link-lib=dylib=shcore");
 
+            // Media Foundation hardware H264 (Intel QuickSync, AMD VCN,
+            // NVIDIA NVENC via the driver-registered MFT). All system
+            // libraries; no external dependencies.
+            println!("cargo:rustc-link-lib=dylib=mfplat");
+            println!("cargo:rustc-link-lib=dylib=mfuuid");
+            println!("cargo:rustc-link-lib=dylib=mf");
+            println!("cargo:rustc-link-lib=dylib=dxguid");
+
             //let path = env::current_dir().unwrap();
             //println!("cargo:rustc-link-search=native={}/vaapi-windows/x64/lib", path.display());
             //println!("cargo:rustc-link-lib=dylib=va");
@@ -165,6 +173,12 @@ fn main() {
                 //.file("src/vaapi/vaapi_h264_encoder_wrapper.cpp")
                 //.file("src/vaapi/vaapi_encoder_factory.cpp")
                 //.file("src/vaapi/h264_encoder_impl.cpp")
+                .file("src/mf/mf_common.cpp")
+                .file("src/mf/mf_encoder_factory.cpp")
+                .file("src/mf/mf_decoder_factory.cpp")
+                .file("src/mf/h264_encoder_impl.cpp")
+                .file("src/mf/h264_decoder_impl.cpp")
+                .flag("/DUSE_MF_VIDEO_CODEC=1")
                 .flag("/std:c++20")
                 //.flag("/wd4819")
                 //.flag("/wd4068")

--- a/webrtc-sys/src/mf/h264_decoder_impl.cpp
+++ b/webrtc-sys/src/mf/h264_decoder_impl.cpp
@@ -1,0 +1,579 @@
+/*
+ * Copyright 2025 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "h264_decoder_impl.h"
+
+#include <codecapi.h>
+#include <d3d10.h>
+#include <wmcodecdsp.h>
+
+#include <algorithm>
+#include <cstring>
+
+#include <api/video/i420_buffer.h>
+#include <api/video/video_codec_type.h>
+#include <modules/video_coding/include/video_error_codes.h>
+#include <third_party/libyuv/include/libyuv/convert.h>
+
+#include "rtc_base/checks.h"
+#include "rtc_base/logging.h"
+
+namespace webrtc {
+
+using livekit_ffi::ComPtr;
+using livekit_ffi::HResultToString;
+
+namespace {
+
+// RTP video timestamps run at 90 kHz; MF sample times are 100 ns units. The
+// timestamp is only used to carry the RTP value through the transform, so the
+// conversion just needs to round-trip exactly for 32-bit inputs.
+int64_t RtpToSampleTime(uint32_t rtp_timestamp) {
+  return static_cast<int64_t>(rtp_timestamp) * 1000 / 9;
+}
+
+uint32_t SampleTimeToRtp(int64_t sample_time) {
+  return static_cast<uint32_t>((sample_time * 9 + 500) / 1000);
+}
+
+}  // namespace
+
+MFH264DecoderImpl::MFH264DecoderImpl() : buffer_pool_(false) {}
+
+MFH264DecoderImpl::~MFH264DecoderImpl() {
+  Release();
+}
+
+VideoDecoder::DecoderInfo MFH264DecoderImpl::GetDecoderInfo() const {
+  VideoDecoder::DecoderInfo info;
+  info.implementation_name = use_d3d_
+                                 ? "MediaFoundation H264 Decoder (DXVA)"
+                                 : "MediaFoundation H264 Decoder (software)";
+  info.is_hardware_accelerated = use_d3d_;
+  return info;
+}
+
+HRESULT MFH264DecoderImpl::SetupD3D() {
+  UINT flags = D3D11_CREATE_DEVICE_VIDEO_SUPPORT;
+  const D3D_FEATURE_LEVEL feature_levels[] = {
+      D3D_FEATURE_LEVEL_11_1,
+      D3D_FEATURE_LEVEL_11_0,
+      D3D_FEATURE_LEVEL_10_1,
+      D3D_FEATURE_LEVEL_10_0,
+  };
+  HRESULT hr = D3D11CreateDevice(
+      nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, flags, feature_levels,
+      ARRAYSIZE(feature_levels), D3D11_SDK_VERSION, &d3d_device_, nullptr,
+      &d3d_context_);
+  if (FAILED(hr)) {
+    return hr;
+  }
+
+  // The decoder MFT accesses the device from its own threads.
+  ComPtr<ID3D10Multithread> multithread;
+  hr = d3d_device_.As(&multithread);
+  if (FAILED(hr)) {
+    return hr;
+  }
+  multithread->SetMultithreadProtected(TRUE);
+
+  UINT reset_token = 0;
+  hr = MFCreateDXGIDeviceManager(&reset_token, &dxgi_manager_);
+  if (FAILED(hr)) {
+    return hr;
+  }
+  hr = dxgi_manager_->ResetDevice(d3d_device_.Get(), reset_token);
+  if (FAILED(hr)) {
+    return hr;
+  }
+
+  hr = transform_->ProcessMessage(
+      MFT_MESSAGE_SET_D3D_MANAGER,
+      reinterpret_cast<ULONG_PTR>(dxgi_manager_.Get()));
+  return hr;
+}
+
+bool MFH264DecoderImpl::Configure(const Settings& settings) {
+  if (settings.codec_type() != kVideoCodecH264) {
+    RTC_LOG(LS_ERROR)
+        << "initialization failed on codectype is not kVideoCodecH264";
+    return false;
+  }
+  if (!settings.max_render_resolution().Valid()) {
+    RTC_LOG(LS_ERROR)
+        << "initialization failed on codec_settings width < 0 or height < 0";
+    return false;
+  }
+
+  settings_ = settings;
+
+  if (!livekit_ffi::EnsureComInitialized() || !livekit_ffi::EnsureMFStarted()) {
+    return false;
+  }
+
+  HRESULT hr =
+      CoCreateInstance(CLSID_CMSH264DecoderMFT, nullptr, CLSCTX_INPROC_SERVER,
+                       IID_PPV_ARGS(&transform_));
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "Failed to create inbox H264 decoder MFT: "
+                      << HResultToString(hr);
+    return false;
+  }
+
+  DWORD input_ids[1] = {0};
+  DWORD output_ids[1] = {0};
+  hr = transform_->GetStreamIDs(1, input_ids, 1, output_ids);
+  if (hr == E_NOTIMPL) {
+    input_ids[0] = 0;
+    output_ids[0] = 0;
+  } else if (FAILED(hr)) {
+    return false;
+  }
+  input_stream_id_ = input_ids[0];
+  output_stream_id_ = output_ids[0];
+
+  // Without the D3D manager the inbox MFT decodes in software; that still
+  // works, so treat D3D failure (headless boxes, RDP sessions, broken
+  // drivers) as a downgrade rather than an error.
+  hr = SetupD3D();
+  use_d3d_ = SUCCEEDED(hr);
+  if (!use_d3d_) {
+    RTC_LOG(LS_WARNING)
+        << "D3D11 unavailable for H264 decode, falling back to software: "
+        << HResultToString(hr);
+    d3d_device_.Reset();
+    d3d_context_.Reset();
+    dxgi_manager_.Reset();
+  }
+
+  // Cap internal reordering/buffering so frames come out ~1-in/1-out.
+  ComPtr<IMFAttributes> attributes;
+  if (SUCCEEDED(transform_->GetAttributes(&attributes)) && attributes) {
+    attributes->SetUINT32(MF_LOW_LATENCY, TRUE);
+  }
+  ComPtr<ICodecAPI> codec_api;
+  if (SUCCEEDED(transform_.As(&codec_api))) {
+    VARIANT v = {};
+    v.vt = VT_BOOL;
+    v.boolVal = VARIANT_TRUE;
+    codec_api->SetValue(&CODECAPI_AVLowLatencyMode, &v);
+  }
+
+  ComPtr<IMFMediaType> input_type;
+  hr = MFCreateMediaType(&input_type);
+  if (FAILED(hr)) {
+    return false;
+  }
+  input_type->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video);
+  input_type->SetGUID(MF_MT_SUBTYPE, MFVideoFormat_H264);
+  const RenderResolution& resolution = settings.max_render_resolution();
+  MFSetAttributeSize(input_type.Get(), MF_MT_FRAME_SIZE,
+                     static_cast<UINT32>(resolution.Width()),
+                     static_cast<UINT32>(resolution.Height()));
+  hr = transform_->SetInputType(input_stream_id_, input_type.Get(), 0);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "Decoder SetInputType failed: "
+                      << HResultToString(hr);
+    return false;
+  }
+
+  hr = NegotiateOutputType();
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "Decoder output negotiation failed: "
+                      << HResultToString(hr);
+    return false;
+  }
+
+  transform_->ProcessMessage(MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, 0);
+  transform_->ProcessMessage(MFT_MESSAGE_NOTIFY_START_OF_STREAM, 0);
+
+  RTC_LOG(LS_INFO) << "MediaFoundation H264 decoder initialized ("
+                   << (use_d3d_ ? "DXVA hardware" : "software") << ").";
+  return true;
+}
+
+HRESULT MFH264DecoderImpl::NegotiateOutputType() {
+  HRESULT hr = E_FAIL;
+  for (DWORD i = 0;; i++) {
+    ComPtr<IMFMediaType> candidate;
+    hr = transform_->GetOutputAvailableType(output_stream_id_, i, &candidate);
+    if (FAILED(hr)) {
+      return hr;
+    }
+    GUID subtype = GUID_NULL;
+    candidate->GetGUID(MF_MT_SUBTYPE, &subtype);
+    if (subtype != MFVideoFormat_NV12) {
+      continue;
+    }
+    hr = transform_->SetOutputType(output_stream_id_, candidate.Get(), 0);
+    if (FAILED(hr)) {
+      return hr;
+    }
+    break;
+  }
+
+  ComPtr<IMFMediaType> current;
+  hr = transform_->GetOutputCurrentType(output_stream_id_, &current);
+  if (FAILED(hr)) {
+    return hr;
+  }
+  hr = MFGetAttributeSize(current.Get(), MF_MT_FRAME_SIZE, &coded_width_,
+                          &coded_height_);
+  if (FAILED(hr)) {
+    return hr;
+  }
+
+  // 1080p decodes as 1920x1088 coded size; the display aperture carries the
+  // real dimensions.
+  has_aperture_ =
+      SUCCEEDED(current->GetBlob(MF_MT_MINIMUM_DISPLAY_APERTURE,
+                                 reinterpret_cast<UINT8*>(&display_aperture_),
+                                 sizeof(display_aperture_), nullptr));
+
+  UINT32 stride = 0;
+  if (SUCCEEDED(current->GetUINT32(MF_MT_DEFAULT_STRIDE, &stride)) &&
+      static_cast<INT32>(stride) > 0) {
+    default_stride_ = stride;
+  } else {
+    default_stride_ = coded_width_;
+  }
+
+  // Coded size may have changed; the staging texture is recreated lazily.
+  staging_texture_.Reset();
+  return S_OK;
+}
+
+int32_t MFH264DecoderImpl::RegisterDecodeCompleteCallback(
+    DecodedImageCallback* callback) {
+  this->decoded_complete_callback_ = callback;
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+int32_t MFH264DecoderImpl::Release() {
+  if (transform_) {
+    transform_->ProcessMessage(MFT_MESSAGE_NOTIFY_END_OF_STREAM,
+                               input_stream_id_);
+    transform_->ProcessMessage(MFT_MESSAGE_COMMAND_FLUSH, 0);
+    transform_->ProcessMessage(MFT_MESSAGE_NOTIFY_END_STREAMING, 0);
+    transform_->ProcessMessage(MFT_MESSAGE_SET_D3D_MANAGER, 0);
+  }
+  staging_texture_.Reset();
+  transform_.Reset();
+  dxgi_manager_.Reset();
+  d3d_context_.Reset();
+  d3d_device_.Reset();
+  use_d3d_ = false;
+  buffer_pool_.Release();
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+int32_t MFH264DecoderImpl::Decode(const EncodedImage& input_image,
+                                  bool missing_frames,
+                                  int64_t render_time_ms) {
+  if (!transform_) {
+    RTC_LOG(LS_ERROR) << "decode failed: decoder not configured";
+    return WEBRTC_VIDEO_CODEC_UNINITIALIZED;
+  }
+  if (decoded_complete_callback_ == nullptr) {
+    RTC_LOG(LS_ERROR) << "decode failed on not set decoded_complete_callback";
+    return WEBRTC_VIDEO_CODEC_UNINITIALIZED;
+  }
+  if (!input_image.data() || !input_image.size()) {
+    RTC_LOG(LS_ERROR) << "decode failed on input image is null";
+    return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
+  }
+
+  h264_bitstream_parser_.ParseBitstream(input_image);
+  std::optional<int> qp = h264_bitstream_parser_.GetLastSliceQp();
+
+  // Pass on color space from the input frame if explicitly specified.
+  if (input_image.ColorSpace()) {
+    input_color_space_ = *input_image.ColorSpace();
+  }
+
+  ComPtr<IMFMediaBuffer> buffer;
+  HRESULT hr = MFCreateMemoryBuffer(
+      static_cast<DWORD>(input_image.size()), &buffer);
+  if (FAILED(hr)) {
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  BYTE* data = nullptr;
+  hr = buffer->Lock(&data, nullptr, nullptr);
+  if (FAILED(hr)) {
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  std::memcpy(data, input_image.data(), input_image.size());
+  buffer->Unlock();
+  buffer->SetCurrentLength(static_cast<DWORD>(input_image.size()));
+
+  ComPtr<IMFSample> sample;
+  hr = MFCreateSample(&sample);
+  if (FAILED(hr)) {
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  sample->AddBuffer(buffer.Get());
+  sample->SetSampleTime(RtpToSampleTime(input_image.RtpTimestamp()));
+
+  for (int attempt = 0; attempt < 2; attempt++) {
+    hr = transform_->ProcessInput(input_stream_id_, sample.Get(), 0);
+    if (hr != MF_E_NOTACCEPTING) {
+      break;
+    }
+    // The transform is full; empty it and try once more.
+    int32_t ret = DrainOutputs(qp);
+    if (ret != WEBRTC_VIDEO_CODEC_OK) {
+      return ret;
+    }
+  }
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "Decoder ProcessInput failed: "
+                      << HResultToString(hr);
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  return DrainOutputs(qp);
+}
+
+int32_t MFH264DecoderImpl::DrainOutputs(std::optional<int> qp) {
+  for (;;) {
+    MFT_OUTPUT_STREAM_INFO stream_info = {};
+    HRESULT hr =
+        transform_->GetOutputStreamInfo(output_stream_id_, &stream_info);
+    if (FAILED(hr)) {
+      return WEBRTC_VIDEO_CODEC_ERROR;
+    }
+    const bool transform_allocates =
+        stream_info.dwFlags & (MFT_OUTPUT_STREAM_PROVIDES_SAMPLES |
+                               MFT_OUTPUT_STREAM_CAN_PROVIDE_SAMPLES);
+
+    ComPtr<IMFSample> allocated;
+    if (!transform_allocates) {
+      hr = MFCreateSample(&allocated);
+      if (FAILED(hr)) {
+        return WEBRTC_VIDEO_CODEC_ERROR;
+      }
+      ComPtr<IMFMediaBuffer> out_buffer;
+      const DWORD size =
+          stream_info.cbSize
+              ? stream_info.cbSize
+              : coded_width_ * coded_height_ * 3 / 2;
+      hr = MFCreateAlignedMemoryBuffer(
+          size, stream_info.cbAlignment > 1 ? stream_info.cbAlignment - 1 : 0,
+          &out_buffer);
+      if (FAILED(hr)) {
+        return WEBRTC_VIDEO_CODEC_ERROR;
+      }
+      allocated->AddBuffer(out_buffer.Get());
+    }
+
+    MFT_OUTPUT_DATA_BUFFER output = {};
+    output.dwStreamID = output_stream_id_;
+    output.pSample = transform_allocates ? nullptr : allocated.Get();
+    DWORD status = 0;
+    hr = transform_->ProcessOutput(0, 1, &output, &status);
+    if (output.pEvents) {
+      output.pEvents->Release();
+    }
+
+    if (hr == MF_E_TRANSFORM_NEED_MORE_INPUT) {
+      return WEBRTC_VIDEO_CODEC_OK;
+    }
+    if (hr == MF_E_TRANSFORM_STREAM_CHANGE) {
+      HRESULT nhr = NegotiateOutputType();
+      if (FAILED(nhr)) {
+        RTC_LOG(LS_ERROR) << "Decoder output renegotiation failed: "
+                          << HResultToString(nhr);
+        return WEBRTC_VIDEO_CODEC_ERROR;
+      }
+      continue;
+    }
+    if (FAILED(hr)) {
+      RTC_LOG(LS_ERROR) << "Decoder ProcessOutput failed: "
+                        << HResultToString(hr);
+      return WEBRTC_VIDEO_CODEC_ERROR;
+    }
+
+    ComPtr<IMFSample> sample;
+    if (transform_allocates) {
+      sample.Attach(output.pSample);
+    } else {
+      sample = allocated;
+    }
+    if (!sample) {
+      continue;
+    }
+    int32_t ret = DeliverSample(sample.Get(), qp);
+    if (ret != WEBRTC_VIDEO_CODEC_OK) {
+      return ret;
+    }
+  }
+}
+
+int32_t MFH264DecoderImpl::DeliverSample(IMFSample* sample,
+                                         std::optional<int> qp) {
+  int64_t sample_time = 0;
+  sample->GetSampleTime(&sample_time);
+  const uint32_t rtp_timestamp = SampleTimeToRtp(sample_time);
+
+  ComPtr<IMFMediaBuffer> buffer;
+  HRESULT hr = sample->GetBufferByIndex(0, &buffer);
+  if (FAILED(hr)) {
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  // Crop offsets within the coded frame (1088-line 1080p etc.).
+  const UINT32 crop_x = has_aperture_ ? display_aperture_.OffsetX.value : 0;
+  const UINT32 crop_y = has_aperture_ ? display_aperture_.OffsetY.value : 0;
+
+  ComPtr<IMFDXGIBuffer> dxgi_buffer;
+  if (use_d3d_ && SUCCEEDED(buffer.As(&dxgi_buffer))) {
+    ComPtr<ID3D11Texture2D> texture;
+    hr = dxgi_buffer->GetResource(IID_PPV_ARGS(&texture));
+    if (FAILED(hr)) {
+      return WEBRTC_VIDEO_CODEC_ERROR;
+    }
+    UINT subresource = 0;
+    dxgi_buffer->GetSubresourceIndex(&subresource);
+
+    D3D11_TEXTURE2D_DESC desc = {};
+    texture->GetDesc(&desc);
+
+    if (staging_texture_) {
+      D3D11_TEXTURE2D_DESC staging_desc = {};
+      staging_texture_->GetDesc(&staging_desc);
+      if (staging_desc.Width != desc.Width ||
+          staging_desc.Height != desc.Height) {
+        staging_texture_.Reset();
+      }
+    }
+    if (!staging_texture_) {
+      D3D11_TEXTURE2D_DESC staging_desc = {};
+      staging_desc.Width = desc.Width;
+      staging_desc.Height = desc.Height;
+      staging_desc.MipLevels = 1;
+      staging_desc.ArraySize = 1;
+      staging_desc.Format = DXGI_FORMAT_NV12;
+      staging_desc.SampleDesc.Count = 1;
+      staging_desc.Usage = D3D11_USAGE_STAGING;
+      staging_desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+      hr = d3d_device_->CreateTexture2D(&staging_desc, nullptr,
+                                        &staging_texture_);
+      if (FAILED(hr)) {
+        RTC_LOG(LS_ERROR) << "Failed to create staging texture: "
+                          << HResultToString(hr);
+        return WEBRTC_VIDEO_CODEC_ERROR;
+      }
+    }
+
+    // GPU -> CPU readback: the known copy-back cost of this design.
+    d3d_context_->CopySubresourceRegion(staging_texture_.Get(), 0, 0, 0, 0,
+                                        texture.Get(), subresource, nullptr);
+    D3D11_MAPPED_SUBRESOURCE mapped = {};
+    hr = d3d_context_->Map(staging_texture_.Get(), 0, D3D11_MAP_READ, 0,
+                           &mapped);
+    if (FAILED(hr)) {
+      return WEBRTC_VIDEO_CODEC_ERROR;
+    }
+    const uint8_t* base = static_cast<const uint8_t*>(mapped.pData);
+    const uint8_t* data_y = base + crop_y * mapped.RowPitch + crop_x;
+    const uint8_t* data_uv = base +
+                             static_cast<size_t>(mapped.RowPitch) *
+                                 desc.Height +
+                             (crop_y / 2) * mapped.RowPitch + crop_x;
+    int32_t ret = DeliverNV12(data_y, mapped.RowPitch, data_uv,
+                              mapped.RowPitch, rtp_timestamp, qp);
+    d3d_context_->Unmap(staging_texture_.Get(), 0);
+    return ret;
+  }
+
+  // Software path: system-memory NV12.
+  ComPtr<IMF2DBuffer> buffer_2d;
+  if (SUCCEEDED(buffer.As(&buffer_2d))) {
+    BYTE* scanline0 = nullptr;
+    LONG pitch = 0;
+    hr = buffer_2d->Lock2D(&scanline0, &pitch);
+    if (FAILED(hr) || pitch <= 0) {
+      if (SUCCEEDED(hr)) {
+        buffer_2d->Unlock2D();
+      }
+      return WEBRTC_VIDEO_CODEC_ERROR;
+    }
+    const uint8_t* data_y = scanline0 + crop_y * pitch + crop_x;
+    const uint8_t* data_uv = scanline0 +
+                             static_cast<size_t>(pitch) * coded_height_ +
+                             (crop_y / 2) * pitch + crop_x;
+    int32_t ret =
+        DeliverNV12(data_y, pitch, data_uv, pitch, rtp_timestamp, qp);
+    buffer_2d->Unlock2D();
+    return ret;
+  }
+
+  ComPtr<IMFMediaBuffer> contiguous;
+  hr = sample->ConvertToContiguousBuffer(&contiguous);
+  if (FAILED(hr)) {
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  BYTE* data = nullptr;
+  DWORD length = 0;
+  hr = contiguous->Lock(&data, nullptr, &length);
+  if (FAILED(hr)) {
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  const UINT32 stride = default_stride_;
+  const uint8_t* data_y = data + crop_y * stride + crop_x;
+  const uint8_t* data_uv = data + static_cast<size_t>(stride) * coded_height_ +
+                           (crop_y / 2) * stride + crop_x;
+  int32_t ret = DeliverNV12(data_y, stride, data_uv, stride, rtp_timestamp, qp);
+  contiguous->Unlock();
+  return ret;
+}
+
+int32_t MFH264DecoderImpl::DeliverNV12(const uint8_t* data_y,
+                                       int stride_y,
+                                       const uint8_t* data_uv,
+                                       int stride_uv,
+                                       uint32_t rtp_timestamp,
+                                       std::optional<int> qp) {
+  const int width = has_aperture_ ? display_aperture_.Area.cx : coded_width_;
+  const int height = has_aperture_ ? display_aperture_.Area.cy : coded_height_;
+
+  webrtc::scoped_refptr<webrtc::I420Buffer> i420_buffer =
+      buffer_pool_.CreateI420Buffer(width, height);
+  if (!i420_buffer) {
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  int result = libyuv::NV12ToI420(
+      data_y, stride_y, data_uv, stride_uv, i420_buffer->MutableDataY(),
+      i420_buffer->StrideY(), i420_buffer->MutableDataU(),
+      i420_buffer->StrideU(), i420_buffer->MutableDataV(),
+      i420_buffer->StrideV(), width, height);
+  if (result) {
+    RTC_LOG(LS_INFO) << "libyuv::NV12ToI420 failed. error:" << result;
+  }
+
+  VideoFrame decoded_frame = VideoFrame::Builder()
+                                 .set_video_frame_buffer(i420_buffer)
+                                 .set_timestamp_rtp(rtp_timestamp)
+                                 .set_color_space(input_color_space_)
+                                 .build();
+
+  std::optional<int32_t> decode_time;
+  decoded_complete_callback_->Decoded(decoded_frame, decode_time, qp);
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+}  // namespace webrtc

--- a/webrtc-sys/src/mf/h264_decoder_impl.cpp
+++ b/webrtc-sys/src/mf/h264_decoder_impl.cpp
@@ -17,7 +17,7 @@
 #include "h264_decoder_impl.h"
 
 #include <codecapi.h>
-#include <d3d10.h>
+#include <d3d10_1.h>  // ID3D10Multithread; d3d10.h directly breaks SAL ordering
 #include <wmcodecdsp.h>
 
 #include <algorithm>
@@ -213,7 +213,7 @@ HRESULT MFH264DecoderImpl::NegotiateOutputType() {
     if (FAILED(hr)) {
       return hr;
     }
-    GUID subtype = GUID_NULL;
+    GUID subtype = {};
     candidate->GetGUID(MF_MT_SUBTYPE, &subtype);
     if (subtype != MFVideoFormat_NV12) {
       continue;

--- a/webrtc-sys/src/mf/h264_decoder_impl.h
+++ b/webrtc-sys/src/mf/h264_decoder_impl.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WEBRTC_MF_H264_DECODER_IMPL_H_
+#define WEBRTC_MF_H264_DECODER_IMPL_H_
+
+#include "mf_common.h"
+
+#include <d3d11.h>
+
+#include <optional>
+
+#include <api/video/color_space.h>
+#include <api/video_codecs/video_decoder.h>
+#include <common_video/h264/h264_bitstream_parser.h>
+#include <common_video/include/video_frame_buffer_pool.h>
+
+namespace webrtc {
+
+// H264 decoder on top of the Windows inbox decoder MFT
+// (CLSID_CMSH264DecoderMFT). The inbox decoder fronts DXVA hardware decode
+// for every GPU vendor, but only when it is handed a D3D11 device manager —
+// without one it silently decodes in software on the CPU. Output samples wrap
+// D3D11 textures which are copied back through a staging texture into I420
+// for webrtc (same copy-back cost the NVDEC backend pays).
+class MFH264DecoderImpl : public VideoDecoder {
+ public:
+  MFH264DecoderImpl();
+  MFH264DecoderImpl(const MFH264DecoderImpl&) = delete;
+  MFH264DecoderImpl& operator=(const MFH264DecoderImpl&) = delete;
+  ~MFH264DecoderImpl() override;
+
+  bool Configure(const Settings& settings) override;
+  int32_t Decode(const EncodedImage& input_image,
+                 bool missing_frames,
+                 int64_t render_time_ms) override;
+  int32_t RegisterDecodeCompleteCallback(
+      DecodedImageCallback* callback) override;
+  int32_t Release() override;
+  DecoderInfo GetDecoderInfo() const override;
+
+ private:
+  HRESULT SetupD3D();
+  // Selects an NV12 output type and refreshes coded size, display aperture
+  // and stride. Also called on MF_E_TRANSFORM_STREAM_CHANGE (fires on
+  // resolution change).
+  HRESULT NegotiateOutputType();
+  int32_t DrainOutputs(std::optional<int> qp);
+  int32_t DeliverSample(IMFSample* sample, std::optional<int> qp);
+  int32_t DeliverNV12(const uint8_t* data_y,
+                      int stride_y,
+                      const uint8_t* data_uv,
+                      int stride_uv,
+                      uint32_t rtp_timestamp,
+                      std::optional<int> qp);
+
+  livekit_ffi::ComPtr<IMFTransform> transform_;
+  livekit_ffi::ComPtr<ID3D11Device> d3d_device_;
+  livekit_ffi::ComPtr<ID3D11DeviceContext> d3d_context_;
+  livekit_ffi::ComPtr<IMFDXGIDeviceManager> dxgi_manager_;
+  livekit_ffi::ComPtr<ID3D11Texture2D> staging_texture_;
+  bool use_d3d_ = false;
+  DWORD input_stream_id_ = 0;
+  DWORD output_stream_id_ = 0;
+
+  UINT32 coded_width_ = 0;
+  UINT32 coded_height_ = 0;
+  MFVideoArea display_aperture_ = {};
+  bool has_aperture_ = false;
+  UINT32 default_stride_ = 0;
+
+  Settings settings_;
+  std::optional<webrtc::ColorSpace> input_color_space_;
+  DecodedImageCallback* decoded_complete_callback_ = nullptr;
+  webrtc::VideoFrameBufferPool buffer_pool_;
+  webrtc::H264BitstreamParser h264_bitstream_parser_;
+};
+
+}  // namespace webrtc
+
+#endif  // WEBRTC_MF_H264_DECODER_IMPL_H_

--- a/webrtc-sys/src/mf/h264_encoder_impl.cpp
+++ b/webrtc-sys/src/mf/h264_encoder_impl.cpp
@@ -1,0 +1,1042 @@
+/*
+ * Copyright 2025 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "h264_encoder_impl.h"
+
+#include <algorithm>
+#include <limits>
+#include <string>
+#include <utility>
+
+#include <common_video/h264/h264_common.h>
+#include "common_video/libyuv/include/webrtc_libyuv.h"
+#include "mf_common.h"
+#include "modules/video_coding/include/video_codec_interface.h"
+#include "modules/video_coding/include/video_error_codes.h"
+#include "modules/video_coding/utility/simulcast_rate_allocator.h"
+#include "rtc_base/checks.h"
+#include "rtc_base/logging.h"
+#include "system_wrappers/include/metrics.h"
+#include "third_party/libyuv/include/libyuv/convert_from.h"
+
+namespace webrtc {
+
+using livekit_ffi::ComPtr;
+using livekit_ffi::HResultToString;
+
+namespace {
+
+// Used by histograms. Values of entries should not be changed.
+enum H264EncoderImplEvent {
+  kH264EncoderEventInit = 0,
+  kH264EncoderEventError = 1,
+  kH264EncoderEventMax = 16,
+};
+
+// Async hardware MFTs post METransformNeedInput almost immediately, but the
+// very first request after initialization can lag while the driver spins up.
+constexpr int kNeedInputTimeoutMs = 500;
+constexpr int kOutputWaitTimeoutMs = 500;
+// How many frames may be in flight inside the MFT before Encode() blocks
+// waiting for output. Low-latency mode keeps this near 1 in practice.
+constexpr size_t kMaxPendingFrames = 4;
+
+HRESULT SetCodecApiUInt32(ICodecAPI* api, const GUID& guid, UINT32 value) {
+  VARIANT v = {};
+  v.vt = VT_UI4;
+  v.ulVal = value;
+  return api->SetValue(&guid, &v);
+}
+
+HRESULT SetCodecApiBool(ICodecAPI* api, const GUID& guid, bool value) {
+  VARIANT v = {};
+  v.vt = VT_BOOL;
+  v.boolVal = value ? VARIANT_TRUE : VARIANT_FALSE;
+  return api->SetValue(&guid, &v);
+}
+
+UINT32 H264ProfileToMFProfile(H264Profile profile) {
+  switch (profile) {
+    // eAVEncH264VProfile_ConstrainedBase is not understood by every vendor
+    // MFT; Base with webrtc's own constraints applied is the interoperable
+    // choice (matches what other MF-based WebRTC stacks negotiate).
+    case H264Profile::kProfileConstrainedBaseline:
+    case H264Profile::kProfileBaseline:
+      return eAVEncH264VProfile_Base;
+    case H264Profile::kProfileMain:
+      return eAVEncH264VProfile_Main;
+    case H264Profile::kProfileConstrainedHigh:
+    case H264Profile::kProfileHigh:
+      return eAVEncH264VProfile_High;
+    default:
+      return eAVEncH264VProfile_Base;
+  }
+}
+
+UINT32 H264LevelToMFLevel(H264Level level) {
+  switch (level) {
+    case H264Level::kLevel1_b:
+      return eAVEncH264VLevel1_b;
+    case H264Level::kLevel1:
+      return eAVEncH264VLevel1;
+    case H264Level::kLevel1_1:
+      return eAVEncH264VLevel1_1;
+    case H264Level::kLevel1_2:
+      return eAVEncH264VLevel1_2;
+    case H264Level::kLevel1_3:
+      return eAVEncH264VLevel1_3;
+    case H264Level::kLevel2:
+      return eAVEncH264VLevel2;
+    case H264Level::kLevel2_1:
+      return eAVEncH264VLevel2_1;
+    case H264Level::kLevel2_2:
+      return eAVEncH264VLevel2_2;
+    case H264Level::kLevel3:
+      return eAVEncH264VLevel3;
+    case H264Level::kLevel3_1:
+      return eAVEncH264VLevel3_1;
+    case H264Level::kLevel3_2:
+      return eAVEncH264VLevel3_2;
+    case H264Level::kLevel4:
+      return eAVEncH264VLevel4;
+    case H264Level::kLevel4_1:
+      return eAVEncH264VLevel4_1;
+    case H264Level::kLevel4_2:
+      return eAVEncH264VLevel4_2;
+    case H264Level::kLevel5:
+      return eAVEncH264VLevel5;
+    case H264Level::kLevel5_1:
+      return eAVEncH264VLevel5_1;
+    case H264Level::kLevel5_2:
+      return eAVEncH264VLevel5_2;
+  }
+  return eAVEncH264VLevel4;
+}
+
+}  // namespace
+
+MFH264EncoderImpl::MFH264EncoderImpl(const Environment& env,
+                                     const SdpVideoFormat& format)
+    : env_(env), format_(format) {
+  std::optional<H264ProfileLevelId> profile_level_id =
+      ParseSdpForH264ProfileLevelId(format.parameters);
+  if (profile_level_id.has_value()) {
+    profile_ = profile_level_id->profile;
+    level_ = profile_level_id->level;
+  }
+}
+
+MFH264EncoderImpl::~MFH264EncoderImpl() {
+  Release();
+}
+
+void MFH264EncoderImpl::ReportInit() {
+  if (has_reported_init_)
+    return;
+  RTC_HISTOGRAM_ENUMERATION("WebRTC.Video.H264EncoderImpl.Event",
+                            kH264EncoderEventInit, kH264EncoderEventMax);
+  has_reported_init_ = true;
+}
+
+void MFH264EncoderImpl::ReportError() {
+  if (has_reported_error_)
+    return;
+  RTC_HISTOGRAM_ENUMERATION("WebRTC.Video.H264EncoderImpl.Event",
+                            kH264EncoderEventError, kH264EncoderEventMax);
+  has_reported_error_ = true;
+}
+
+int32_t MFH264EncoderImpl::InitEncode(const VideoCodec* inst,
+                                      const VideoEncoder::Settings& settings) {
+  if (!inst || inst->codecType != kVideoCodecH264) {
+    ReportError();
+    return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
+  }
+  if (inst->maxFramerate == 0) {
+    ReportError();
+    return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
+  }
+  if (inst->width < 1 || inst->height < 1) {
+    ReportError();
+    return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
+  }
+
+  int32_t release_ret = Release();
+  if (release_ret != WEBRTC_VIDEO_CODEC_OK) {
+    ReportError();
+    return release_ret;
+  }
+
+  codec_ = *inst;
+
+  // Code expects simulcastStream resolutions to be correct, make sure they are
+  // filled even when there are no simulcast layers.
+  if (codec_.numberOfSimulcastStreams == 0) {
+    codec_.simulcastStream[0].width = codec_.width;
+    codec_.simulcastStream[0].height = codec_.height;
+  }
+
+  // Initialize encoded image. Default buffer size: size of unencoded data.
+  const size_t new_capacity =
+      CalcBufferSize(VideoType::kI420, codec_.width, codec_.height);
+  encoded_image_.SetEncodedData(EncodedImageBuffer::Create(new_capacity));
+  encoded_image_._encodedWidth = codec_.width;
+  encoded_image_._encodedHeight = codec_.height;
+  encoded_image_.set_size(0);
+
+  configuration_.sending = false;
+  configuration_.frame_dropping_on = codec_.GetFrameDropEnabled();
+  configuration_.key_frame_interval = codec_.H264()->keyFrameInterval;
+  configuration_.width = codec_.width;
+  configuration_.height = codec_.height;
+  configuration_.max_frame_rate = codec_.maxFramerate;
+  configuration_.target_bps = codec_.startBitrate * 1000;
+  configuration_.max_bps = codec_.maxBitrate * 1000;
+
+  if (!livekit_ffi::EnsureComInitialized() || !livekit_ffi::EnsureMFStarted()) {
+    ReportError();
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  int32_t ret = CreateTransform();
+  if (ret != WEBRTC_VIDEO_CODEC_OK) {
+    ReportError();
+    return ret;
+  }
+  ret = ConfigureTransform();
+  if (ret != WEBRTC_VIDEO_CODEC_OK) {
+    ReportError();
+    return ret;
+  }
+
+  RTC_LOG(LS_INFO) << "MediaFoundation H264 encoder initialized ("
+                   << friendly_name_ << "): " << codec_.width << "x"
+                   << codec_.height << " @ " << codec_.maxFramerate
+                   << "fps, target_bps=" << configuration_.target_bps;
+
+  SimulcastRateAllocator init_allocator(env_, codec_);
+  VideoBitrateAllocation allocation =
+      init_allocator.Allocate(VideoBitrateAllocationParameters(
+          DataRate::KilobitsPerSec(codec_.startBitrate), codec_.maxFramerate));
+  SetRates(RateControlParameters(allocation, codec_.maxFramerate));
+  ReportInit();
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+int32_t MFH264EncoderImpl::CreateTransform() {
+  MFT_REGISTER_TYPE_INFO input_info = {MFMediaType_Video, MFVideoFormat_NV12};
+  MFT_REGISTER_TYPE_INFO output_info = {MFMediaType_Video, MFVideoFormat_H264};
+
+  IMFActivate** activates = nullptr;
+  UINT32 count = 0;
+  HRESULT hr = MFTEnumEx(MFT_CATEGORY_VIDEO_ENCODER,
+                         MFT_ENUM_FLAG_HARDWARE | MFT_ENUM_FLAG_SORTANDFILTER,
+                         &input_info, &output_info, &activates, &count);
+  if (FAILED(hr) || count == 0) {
+    RTC_LOG(LS_ERROR) << "No hardware H264 encoder MFT found: "
+                      << HResultToString(hr);
+    if (activates) {
+      CoTaskMemFree(activates);
+    }
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  activate_ = activates[0];
+  for (UINT32 i = 0; i < count; i++) {
+    activates[i]->Release();
+  }
+  CoTaskMemFree(activates);
+
+  WCHAR* name = nullptr;
+  UINT32 name_len = 0;
+  if (SUCCEEDED(activate_->GetAllocatedString(MFT_FRIENDLY_NAME_Attribute,
+                                              &name, &name_len))) {
+    // Log-only string; lossy narrowing is fine.
+    friendly_name_.assign(name, name + name_len);
+    CoTaskMemFree(name);
+  }
+
+  hr = activate_->ActivateObject(IID_PPV_ARGS(&transform_));
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "Failed to activate H264 encoder MFT \""
+                      << friendly_name_ << "\": " << HResultToString(hr);
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  ComPtr<IMFAttributes> attributes;
+  if (SUCCEEDED(transform_->GetAttributes(&attributes)) && attributes) {
+    UINT32 is_async = 0;
+    attributes->GetUINT32(MF_TRANSFORM_ASYNC, &is_async);
+    is_async_ = is_async != 0;
+    if (is_async_) {
+      hr = attributes->SetUINT32(MF_TRANSFORM_ASYNC_UNLOCK, TRUE);
+      if (FAILED(hr)) {
+        RTC_LOG(LS_ERROR) << "Failed to unlock async MFT: "
+                          << HResultToString(hr);
+        return WEBRTC_VIDEO_CODEC_ERROR;
+      }
+    }
+  }
+
+  if (is_async_) {
+    hr = transform_.As(&event_generator_);
+    if (FAILED(hr)) {
+      RTC_LOG(LS_ERROR) << "Async MFT without IMFMediaEventGenerator: "
+                        << HResultToString(hr);
+      return WEBRTC_VIDEO_CODEC_ERROR;
+    }
+  }
+
+  // ICodecAPI is how rate control is configured; refuse encoders without it
+  // rather than running with driver-default VBR.
+  hr = transform_.As(&codec_api_);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "H264 encoder MFT does not expose ICodecAPI: "
+                      << HResultToString(hr);
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+int32_t MFH264EncoderImpl::ConfigureTransform() {
+  DWORD input_ids[1] = {0};
+  DWORD output_ids[1] = {0};
+  HRESULT hr = transform_->GetStreamIDs(1, input_ids, 1, output_ids);
+  if (hr == E_NOTIMPL) {
+    input_ids[0] = 0;
+    output_ids[0] = 0;
+  } else if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "GetStreamIDs failed: " << HResultToString(hr);
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  input_stream_id_ = input_ids[0];
+  output_stream_id_ = output_ids[0];
+
+  const UINT32 fps =
+      std::max(1u, static_cast<UINT32>(configuration_.max_frame_rate + 0.5f));
+
+  // Output type first: encoder MFTs require it before the input type.
+  ComPtr<IMFMediaType> output_type;
+  hr = MFCreateMediaType(&output_type);
+  if (FAILED(hr)) {
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  output_type->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video);
+  output_type->SetGUID(MF_MT_SUBTYPE, MFVideoFormat_H264);
+  output_type->SetUINT32(MF_MT_AVG_BITRATE, configuration_.target_bps);
+  MFSetAttributeSize(output_type.Get(), MF_MT_FRAME_SIZE, configuration_.width,
+                     configuration_.height);
+  MFSetAttributeRatio(output_type.Get(), MF_MT_FRAME_RATE, fps, 1);
+  output_type->SetUINT32(MF_MT_INTERLACE_MODE, MFVideoInterlace_Progressive);
+  output_type->SetUINT32(MF_MT_MPEG2_PROFILE, H264ProfileToMFProfile(profile_));
+  output_type->SetUINT32(MF_MT_MPEG2_LEVEL, H264LevelToMFLevel(level_));
+
+  hr = transform_->SetOutputType(output_stream_id_, output_type.Get(), 0);
+  if (FAILED(hr)) {
+    // Some drivers reject an explicit level; let the MFT derive it.
+    output_type->DeleteItem(MF_MT_MPEG2_LEVEL);
+    hr = transform_->SetOutputType(output_stream_id_, output_type.Get(), 0);
+  }
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "SetOutputType failed: " << HResultToString(hr);
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  // Input type: prefer the MFT's own NV12 type so vendor-specific attributes
+  // (strides, apertures) are preserved.
+  ComPtr<IMFMediaType> input_type;
+  for (DWORD i = 0;; i++) {
+    ComPtr<IMFMediaType> candidate;
+    hr = transform_->GetInputAvailableType(input_stream_id_, i, &candidate);
+    if (FAILED(hr)) {
+      break;
+    }
+    GUID subtype = GUID_NULL;
+    candidate->GetGUID(MF_MT_SUBTYPE, &subtype);
+    if (subtype == MFVideoFormat_NV12) {
+      input_type = candidate;
+      break;
+    }
+  }
+  if (!input_type) {
+    hr = MFCreateMediaType(&input_type);
+    if (FAILED(hr)) {
+      return WEBRTC_VIDEO_CODEC_ERROR;
+    }
+    input_type->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video);
+    input_type->SetGUID(MF_MT_SUBTYPE, MFVideoFormat_NV12);
+  }
+  MFSetAttributeSize(input_type.Get(), MF_MT_FRAME_SIZE, configuration_.width,
+                     configuration_.height);
+  MFSetAttributeRatio(input_type.Get(), MF_MT_FRAME_RATE, fps, 1);
+  input_type->SetUINT32(MF_MT_INTERLACE_MODE, MFVideoInterlace_Progressive);
+
+  hr = transform_->SetInputType(input_stream_id_, input_type.Get(), 0);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "SetInputType failed: " << HResultToString(hr);
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  // Rate control: CBR at the target bitrate, low latency, no B-frames (webrtc
+  // cannot tolerate them), and an effectively infinite GOP since webrtc
+  // requests IDR frames itself.
+  hr = SetCodecApiUInt32(codec_api_.Get(), CODECAPI_AVEncCommonRateControlMode,
+                         eAVEncCommonRateControlMode_CBR);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "Failed to set CBR rate control: "
+                      << HResultToString(hr);
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  hr = SetCodecApiUInt32(codec_api_.Get(), CODECAPI_AVEncCommonMeanBitRate,
+                         configuration_.target_bps);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "Failed to set mean bitrate: " << HResultToString(hr);
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  hr = SetCodecApiUInt32(codec_api_.Get(),
+                         CODECAPI_AVEncMPVDefaultBPictureCount, 0);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "Failed to disable B-frames: " << HResultToString(hr);
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  // Best effort from here on: support varies by vendor/driver.
+  if (FAILED(SetCodecApiBool(codec_api_.Get(), CODECAPI_AVLowLatencyMode,
+                             true))) {
+    RTC_LOG(LS_WARNING) << "Encoder MFT rejected AVLowLatencyMode.";
+  }
+  if (FAILED(SetCodecApiUInt32(codec_api_.Get(), CODECAPI_AVEncMPVGOPSize,
+                               0x7FFFFFFF))) {
+    RTC_LOG(LS_WARNING) << "Encoder MFT rejected infinite GOP size.";
+  }
+
+  active_bitrate_bps_ = configuration_.target_bps;
+  dynamic_bitrate_supported_ = true;
+  pending_bitrate_reinit_ = false;
+
+  hr = transform_->ProcessMessage(MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, 0);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "NOTIFY_BEGIN_STREAMING failed: "
+                      << HResultToString(hr);
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  hr = transform_->ProcessMessage(MFT_MESSAGE_NOTIFY_START_OF_STREAM, 0);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "NOTIFY_START_OF_STREAM failed: "
+                      << HResultToString(hr);
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  CacheSequenceHeader();
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+int32_t MFH264EncoderImpl::ReinitTransform() {
+  RTC_LOG(LS_INFO) << "Reinitializing MF H264 encoder (bitrate "
+                   << active_bitrate_bps_ << " -> "
+                   << configuration_.target_bps << " bps).";
+  EncodedImageCallback* callback = encoded_image_callback_;
+  int32_t ret = Release();
+  if (ret != WEBRTC_VIDEO_CODEC_OK) {
+    return ret;
+  }
+  encoded_image_callback_ = callback;
+  ret = CreateTransform();
+  if (ret != WEBRTC_VIDEO_CODEC_OK) {
+    return ret;
+  }
+  ret = ConfigureTransform();
+  if (ret != WEBRTC_VIDEO_CODEC_OK) {
+    return ret;
+  }
+  configuration_.key_frame_request = true;
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+HRESULT MFH264EncoderImpl::NegotiateOutputType() {
+  for (DWORD i = 0;; i++) {
+    ComPtr<IMFMediaType> candidate;
+    HRESULT hr =
+        transform_->GetOutputAvailableType(output_stream_id_, i, &candidate);
+    if (FAILED(hr)) {
+      return hr;
+    }
+    GUID subtype = GUID_NULL;
+    candidate->GetGUID(MF_MT_SUBTYPE, &subtype);
+    if (subtype != MFVideoFormat_H264) {
+      continue;
+    }
+    hr = transform_->SetOutputType(output_stream_id_, candidate.Get(), 0);
+    if (SUCCEEDED(hr)) {
+      sequence_header_.clear();
+      CacheSequenceHeader();
+    }
+    return hr;
+  }
+}
+
+void MFH264EncoderImpl::CacheSequenceHeader() {
+  ComPtr<IMFMediaType> current;
+  if (FAILED(transform_->GetOutputCurrentType(output_stream_id_, &current))) {
+    return;
+  }
+  UINT8* blob = nullptr;
+  UINT32 blob_size = 0;
+  if (SUCCEEDED(current->GetAllocatedBlob(MF_MT_MPEG_SEQUENCE_HEADER, &blob,
+                                          &blob_size)) &&
+      blob_size > 0) {
+    sequence_header_.assign(blob, blob + blob_size);
+  }
+  if (blob) {
+    CoTaskMemFree(blob);
+  }
+}
+
+int32_t MFH264EncoderImpl::RegisterEncodeCompleteCallback(
+    EncodedImageCallback* callback) {
+  encoded_image_callback_ = callback;
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+int32_t MFH264EncoderImpl::Release() {
+  if (transform_) {
+    transform_->ProcessMessage(MFT_MESSAGE_NOTIFY_END_OF_STREAM,
+                               input_stream_id_);
+    transform_->ProcessMessage(MFT_MESSAGE_COMMAND_FLUSH, 0);
+    transform_->ProcessMessage(MFT_MESSAGE_NOTIFY_END_STREAMING, 0);
+  }
+  event_generator_.Reset();
+  codec_api_.Reset();
+  transform_.Reset();
+  if (activate_) {
+    activate_->ShutdownObject();
+    activate_.Reset();
+  }
+  pending_frames_.clear();
+  need_input_credits_ = 0;
+  frame_count_ = 0;
+  sequence_header_.clear();
+  is_async_ = false;
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+HRESULT MFH264EncoderImpl::CreateInputSample(const I420BufferInterface& buffer,
+                                             int64_t sample_time_100ns,
+                                             int64_t duration_100ns,
+                                             IMFSample** sample_out) {
+  const int width = buffer.width();
+  const int height = buffer.height();
+
+  ComPtr<IMFMediaBuffer> media_buffer;
+  HRESULT hr = MFCreate2DMediaBuffer(width, height, MFVideoFormat_NV12.Data1,
+                                     FALSE, &media_buffer);
+  if (FAILED(hr)) {
+    return hr;
+  }
+
+  ComPtr<IMF2DBuffer> buffer_2d;
+  hr = media_buffer.As(&buffer_2d);
+  if (FAILED(hr)) {
+    return hr;
+  }
+
+  BYTE* scanline0 = nullptr;
+  LONG pitch = 0;
+  hr = buffer_2d->Lock2D(&scanline0, &pitch);
+  if (FAILED(hr)) {
+    return hr;
+  }
+  // NV12 is never bottom-up: Y plane at scanline0, interleaved UV plane
+  // directly after it.
+  uint8_t* dst_y = scanline0;
+  uint8_t* dst_uv = scanline0 + static_cast<size_t>(pitch) * height;
+  int ret = libyuv::I420ToNV12(buffer.DataY(), buffer.StrideY(), buffer.DataU(),
+                               buffer.StrideU(), buffer.DataV(),
+                               buffer.StrideV(), dst_y, pitch, dst_uv, pitch,
+                               width, height);
+  buffer_2d->Unlock2D();
+  if (ret != 0) {
+    return E_FAIL;
+  }
+
+  DWORD contiguous_length = 0;
+  if (SUCCEEDED(buffer_2d->GetContiguousLength(&contiguous_length))) {
+    media_buffer->SetCurrentLength(contiguous_length);
+  }
+
+  ComPtr<IMFSample> sample;
+  hr = MFCreateSample(&sample);
+  if (FAILED(hr)) {
+    return hr;
+  }
+  sample->AddBuffer(media_buffer.Get());
+  sample->SetSampleTime(sample_time_100ns);
+  sample->SetSampleDuration(duration_100ns);
+
+  *sample_out = sample.Detach();
+  return S_OK;
+}
+
+int32_t MFH264EncoderImpl::PumpEvents(int timeout_ms,
+                                      bool until_need_input,
+                                      size_t until_pending_at_most) {
+  const ULONGLONG deadline = GetTickCount64() + timeout_ms;
+  for (;;) {
+    const bool goals_met = (!until_need_input || need_input_credits_ > 0) &&
+                           pending_frames_.size() <= until_pending_at_most;
+
+    ComPtr<IMFMediaEvent> event;
+    HRESULT hr = event_generator_->GetEvent(MF_EVENT_FLAG_NO_WAIT, &event);
+    if (hr == MF_E_NO_EVENTS_AVAILABLE) {
+      if (goals_met) {
+        return WEBRTC_VIDEO_CODEC_OK;
+      }
+      if (GetTickCount64() >= deadline) {
+        RTC_LOG(LS_ERROR) << "Timed out waiting for encoder MFT ("
+                          << (until_need_input ? "input slot" : "output")
+                          << ", " << pending_frames_.size()
+                          << " frames in flight).";
+        ReportError();
+        return WEBRTC_VIDEO_CODEC_ENCODER_FAILURE;
+      }
+      Sleep(1);
+      continue;
+    }
+    if (FAILED(hr)) {
+      RTC_LOG(LS_ERROR) << "GetEvent failed: " << HResultToString(hr);
+      ReportError();
+      return WEBRTC_VIDEO_CODEC_ENCODER_FAILURE;
+    }
+
+    MediaEventType type = MEUnknown;
+    event->GetType(&type);
+    if (type == METransformNeedInput) {
+      need_input_credits_++;
+    } else if (type == METransformHaveOutput) {
+      int32_t ret = CollectOneOutput();
+      if (ret != WEBRTC_VIDEO_CODEC_OK) {
+        return ret;
+      }
+    }
+    // Other events (drain complete, markers) need no handling here.
+  }
+}
+
+int32_t MFH264EncoderImpl::Encode(
+    const VideoFrame& input_frame,
+    const std::vector<VideoFrameType>* frame_types) {
+  if (!transform_) {
+    ReportError();
+    return WEBRTC_VIDEO_CODEC_UNINITIALIZED;
+  }
+  if (!encoded_image_callback_) {
+    RTC_LOG(LS_WARNING)
+        << "InitEncode() has been called, but a callback function "
+           "has not been set with RegisterEncodeCompleteCallback()";
+    ReportError();
+    return WEBRTC_VIDEO_CODEC_UNINITIALIZED;
+  }
+
+  if (pending_bitrate_reinit_) {
+    int32_t ret = ReinitTransform();
+    if (ret != WEBRTC_VIDEO_CODEC_OK) {
+      ReportError();
+      return ret;
+    }
+  }
+
+  webrtc::scoped_refptr<I420BufferInterface> frame_buffer =
+      input_frame.video_frame_buffer()->ToI420();
+  if (!frame_buffer) {
+    RTC_LOG(LS_ERROR) << "Failed to convert "
+                      << VideoFrameBufferTypeToString(
+                             input_frame.video_frame_buffer()->type())
+                      << " image to I420. Can't encode frame.";
+    return WEBRTC_VIDEO_CODEC_ENCODER_FAILURE;
+  }
+  RTC_CHECK(frame_buffer->type() == VideoFrameBuffer::Type::kI420);
+
+  bool is_keyframe_needed = false;
+  if (configuration_.key_frame_request && configuration_.sending) {
+    is_keyframe_needed = true;
+  }
+
+  bool send_key_frame =
+      is_keyframe_needed ||
+      (frame_types && (*frame_types)[0] == VideoFrameType::kVideoFrameKey);
+  if (send_key_frame) {
+    is_keyframe_needed = true;
+    configuration_.key_frame_request = false;
+  }
+
+  RTC_DCHECK_EQ(configuration_.width, frame_buffer->width());
+  RTC_DCHECK_EQ(configuration_.height, frame_buffer->height());
+
+  if (!configuration_.sending) {
+    return WEBRTC_VIDEO_CODEC_NO_OUTPUT;
+  }
+
+  if (frame_types != nullptr) {
+    // Skip frame?
+    if ((*frame_types)[0] == VideoFrameType::kEmptyFrame) {
+      return WEBRTC_VIDEO_CODEC_NO_OUTPUT;
+    }
+  }
+
+  if (is_async_) {
+    int32_t ret = PumpEvents(kNeedInputTimeoutMs, /*until_need_input=*/true,
+                             /*until_pending_at_most=*/SIZE_MAX);
+    if (ret != WEBRTC_VIDEO_CODEC_OK) {
+      return ret;
+    }
+  }
+
+  if (is_keyframe_needed) {
+    HRESULT hr = SetCodecApiUInt32(codec_api_.Get(),
+                                   CODECAPI_AVEncVideoForceKeyFrame, 1);
+    if (FAILED(hr)) {
+      RTC_LOG(LS_WARNING) << "ForceKeyFrame rejected: " << HResultToString(hr);
+    }
+  }
+
+  const int64_t fps =
+      std::max<int64_t>(1, static_cast<int64_t>(configuration_.max_frame_rate));
+  const int64_t duration_100ns = 10'000'000 / fps;
+  const int64_t sample_time_100ns = frame_count_ * duration_100ns;
+  frame_count_++;
+
+  ComPtr<IMFSample> sample;
+  HRESULT hr = CreateInputSample(*frame_buffer, sample_time_100ns,
+                                 duration_100ns, &sample);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "Failed to create input sample: "
+                      << HResultToString(hr);
+    ReportError();
+    return WEBRTC_VIDEO_CODEC_ENCODER_FAILURE;
+  }
+
+  PendingFrameInfo info;
+  info.sample_time_100ns = sample_time_100ns;
+  info.rtp_timestamp = input_frame.rtp_timestamp();
+  info.ntp_time_ms = input_frame.ntp_time_ms();
+  info.render_time_ms = input_frame.render_time_ms();
+  info.rotation = input_frame.rotation();
+  info.color_space = input_frame.color_space();
+  pending_frames_.push_back(info);
+
+  hr = transform_->ProcessInput(input_stream_id_, sample.Get(), 0);
+  if (hr == MF_E_NOTACCEPTING && !is_async_) {
+    int32_t ret = CollectOutputsSync();
+    if (ret != WEBRTC_VIDEO_CODEC_OK) {
+      return ret;
+    }
+    hr = transform_->ProcessInput(input_stream_id_, sample.Get(), 0);
+  }
+  if (FAILED(hr)) {
+    pending_frames_.pop_back();
+    RTC_LOG(LS_ERROR) << "ProcessInput failed: " << HResultToString(hr);
+    ReportError();
+    return WEBRTC_VIDEO_CODEC_ENCODER_FAILURE;
+  }
+
+  if (is_async_) {
+    need_input_credits_--;
+    // Collect whatever the MFT already produced; block only when too many
+    // frames are in flight so encoder latency stays bounded.
+    return PumpEvents(kOutputWaitTimeoutMs, /*until_need_input=*/false,
+                      /*until_pending_at_most=*/kMaxPendingFrames);
+  }
+  return CollectOutputsSync();
+}
+
+int32_t MFH264EncoderImpl::CollectOutputsSync() {
+  for (;;) {
+    int32_t ret = CollectOneOutput();
+    if (ret == WEBRTC_VIDEO_CODEC_NO_OUTPUT) {
+      return WEBRTC_VIDEO_CODEC_OK;
+    }
+    if (ret != WEBRTC_VIDEO_CODEC_OK) {
+      return ret;
+    }
+  }
+}
+
+int32_t MFH264EncoderImpl::CollectOneOutput() {
+  MFT_OUTPUT_STREAM_INFO stream_info = {};
+  HRESULT hr = transform_->GetOutputStreamInfo(output_stream_id_, &stream_info);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "GetOutputStreamInfo failed: " << HResultToString(hr);
+    ReportError();
+    return WEBRTC_VIDEO_CODEC_ENCODER_FAILURE;
+  }
+  const bool transform_allocates =
+      stream_info.dwFlags & (MFT_OUTPUT_STREAM_PROVIDES_SAMPLES |
+                             MFT_OUTPUT_STREAM_CAN_PROVIDE_SAMPLES);
+
+  ComPtr<IMFSample> allocated;
+  if (!transform_allocates) {
+    hr = MFCreateSample(&allocated);
+    if (FAILED(hr)) {
+      return WEBRTC_VIDEO_CODEC_ENCODER_FAILURE;
+    }
+    ComPtr<IMFMediaBuffer> out_buffer;
+    const DWORD size = stream_info.cbSize
+                           ? stream_info.cbSize
+                           : static_cast<DWORD>(configuration_.width) *
+                                 configuration_.height * 3 / 2;
+    hr = MFCreateAlignedMemoryBuffer(
+        size, stream_info.cbAlignment > 1 ? stream_info.cbAlignment - 1 : 0,
+        &out_buffer);
+    if (FAILED(hr)) {
+      return WEBRTC_VIDEO_CODEC_ENCODER_FAILURE;
+    }
+    allocated->AddBuffer(out_buffer.Get());
+  }
+
+  for (int attempt = 0; attempt < 2; attempt++) {
+    MFT_OUTPUT_DATA_BUFFER output = {};
+    output.dwStreamID = output_stream_id_;
+    output.pSample = transform_allocates ? nullptr : allocated.Get();
+    DWORD status = 0;
+    hr = transform_->ProcessOutput(0, 1, &output, &status);
+    if (output.pEvents) {
+      output.pEvents->Release();
+    }
+
+    if (hr == MF_E_TRANSFORM_NEED_MORE_INPUT) {
+      return WEBRTC_VIDEO_CODEC_NO_OUTPUT;
+    }
+    if (hr == MF_E_TRANSFORM_STREAM_CHANGE) {
+      HRESULT nhr = NegotiateOutputType();
+      if (FAILED(nhr)) {
+        RTC_LOG(LS_ERROR) << "Output renegotiation failed: "
+                          << HResultToString(nhr);
+        ReportError();
+        return WEBRTC_VIDEO_CODEC_ENCODER_FAILURE;
+      }
+      continue;
+    }
+    if (FAILED(hr)) {
+      RTC_LOG(LS_ERROR) << "ProcessOutput failed: " << HResultToString(hr);
+      ReportError();
+      return WEBRTC_VIDEO_CODEC_ENCODER_FAILURE;
+    }
+
+    ComPtr<IMFSample> sample;
+    if (transform_allocates) {
+      sample.Attach(output.pSample);
+    } else {
+      sample = allocated;
+    }
+    if (!sample) {
+      return WEBRTC_VIDEO_CODEC_NO_OUTPUT;
+    }
+
+    int64_t sample_time = 0;
+    sample->GetSampleTime(&sample_time);
+
+    ComPtr<IMFMediaBuffer> contiguous;
+    hr = sample->ConvertToContiguousBuffer(&contiguous);
+    if (FAILED(hr)) {
+      return WEBRTC_VIDEO_CODEC_ENCODER_FAILURE;
+    }
+    BYTE* data = nullptr;
+    DWORD max_length = 0;
+    DWORD current_length = 0;
+    hr = contiguous->Lock(&data, &max_length, &current_length);
+    if (FAILED(hr)) {
+      return WEBRTC_VIDEO_CODEC_ENCODER_FAILURE;
+    }
+    packet_.assign(data, data + current_length);
+    contiguous->Unlock();
+
+    pending_output_info_ = TakePendingInfo(sample_time);
+    return ProcessEncodedFrame(packet_);
+  }
+
+  RTC_LOG(LS_ERROR) << "Encoder output stream change did not settle.";
+  ReportError();
+  return WEBRTC_VIDEO_CODEC_ENCODER_FAILURE;
+}
+
+MFH264EncoderImpl::PendingFrameInfo MFH264EncoderImpl::TakePendingInfo(
+    int64_t sample_time_100ns) {
+  // With B-frames disabled output order matches input order; the sample time
+  // check only guards against a driver dropping frames internally.
+  while (!pending_frames_.empty() &&
+         pending_frames_.front().sample_time_100ns < sample_time_100ns) {
+    RTC_LOG(LS_WARNING) << "Encoder MFT dropped frame with sample time "
+                        << pending_frames_.front().sample_time_100ns;
+    pending_frames_.pop_front();
+  }
+  PendingFrameInfo info;
+  if (!pending_frames_.empty()) {
+    info = pending_frames_.front();
+    pending_frames_.pop_front();
+  } else {
+    RTC_LOG(LS_WARNING) << "Encoded output without pending frame metadata.";
+    info.sample_time_100ns = sample_time_100ns;
+  }
+  return info;
+}
+
+int32_t MFH264EncoderImpl::ProcessEncodedFrame(std::vector<uint8_t>& packet) {
+  const PendingFrameInfo& info = pending_output_info_;
+
+  bool is_idr = false;
+  bool has_sps = false;
+  std::vector<H264::NaluIndex> nalu_indices =
+      H264::FindNaluIndices(MakeArrayView(packet.data(), packet.size()));
+  for (const H264::NaluIndex& index : nalu_indices) {
+    const H264::NaluType nalu_type =
+        H264::ParseNaluType(packet[index.payload_start_offset]);
+    if (nalu_type == H264::kIdr) {
+      is_idr = true;
+    } else if (nalu_type == H264::kSps) {
+      has_sps = true;
+    }
+  }
+
+  // Some vendor MFTs do not repeat SPS/PPS on every IDR; the RTP packetizer
+  // needs them inline, so prepend the cached sequence header.
+  if (is_idr && !has_sps) {
+    if (sequence_header_.empty()) {
+      CacheSequenceHeader();
+    }
+    if (!sequence_header_.empty()) {
+      packet.insert(packet.begin(), sequence_header_.begin(),
+                    sequence_header_.end());
+    } else {
+      RTC_LOG(LS_WARNING)
+          << "IDR frame without SPS/PPS and no cached sequence header.";
+    }
+  }
+
+  encoded_image_._encodedWidth = configuration_.width;
+  encoded_image_._encodedHeight = configuration_.height;
+  encoded_image_.SetRtpTimestamp(info.rtp_timestamp);
+  encoded_image_.SetSimulcastIndex(0);
+  encoded_image_.ntp_time_ms_ = info.ntp_time_ms;
+  encoded_image_.capture_time_ms_ = info.render_time_ms;
+  encoded_image_.rotation_ = info.rotation;
+  encoded_image_.content_type_ = VideoContentType::UNSPECIFIED;
+  encoded_image_.timing_.flags = VideoSendTiming::kInvalid;
+  encoded_image_._frameType = is_idr ? VideoFrameType::kVideoFrameKey
+                                     : VideoFrameType::kVideoFrameDelta;
+  encoded_image_.SetColorSpace(info.color_space);
+
+  encoded_image_.SetEncodedData(
+      EncodedImageBuffer::Create(packet.data(), packet.size()));
+  encoded_image_.set_size(packet.size());
+
+  h264_bitstream_parser_.ParseBitstream(encoded_image_);
+  encoded_image_.qp_ = h264_bitstream_parser_.GetLastSliceQp().value_or(-1);
+
+  CodecSpecificInfo codec_info;
+  codec_info.codecType = kVideoCodecH264;
+  codec_info.codecSpecific.H264.packetization_mode =
+      H264PacketizationMode::NonInterleaved;
+
+  const auto result =
+      encoded_image_callback_->OnEncodedImage(encoded_image_, &codec_info);
+  if (result.error != EncodedImageCallback::Result::OK) {
+    RTC_LOG(LS_ERROR) << "OnEncodedImage failed " << result.error;
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+VideoEncoder::EncoderInfo MFH264EncoderImpl::GetEncoderInfo() const {
+  EncoderInfo info;
+  info.supports_native_handle = false;
+  info.implementation_name = friendly_name_.empty()
+                                 ? "MediaFoundation H264 Encoder"
+                                 : "MediaFoundation H264 Encoder (" +
+                                       friendly_name_ + ")";
+  info.scaling_settings = VideoEncoder::ScalingSettings::kOff;
+  info.is_hardware_accelerated = true;
+  info.supports_simulcast = false;
+  info.preferred_pixel_formats = {VideoFrameBuffer::Type::kI420};
+  return info;
+}
+
+void MFH264EncoderImpl::ApplyBitrate(uint32_t bitrate_bps) {
+  if (bitrate_bps == active_bitrate_bps_) {
+    return;
+  }
+  if (dynamic_bitrate_supported_) {
+    HRESULT hr = SetCodecApiUInt32(
+        codec_api_.Get(), CODECAPI_AVEncCommonMeanBitRate, bitrate_bps);
+    if (SUCCEEDED(hr)) {
+      active_bitrate_bps_ = bitrate_bps;
+      return;
+    }
+    dynamic_bitrate_supported_ = false;
+    RTC_LOG(LS_WARNING)
+        << "Encoder MFT rejected runtime bitrate update ("
+        << HResultToString(hr)
+        << "); falling back to re-init with hysteresis.";
+  }
+  // Dynamic update unsupported: re-initialize, but only when the target has
+  // moved enough to matter — a full re-init costs a keyframe.
+  const uint32_t reference = std::max(active_bitrate_bps_, 1u);
+  const uint32_t delta = bitrate_bps > active_bitrate_bps_
+                             ? bitrate_bps - active_bitrate_bps_
+                             : active_bitrate_bps_ - bitrate_bps;
+  if (delta * 5 > reference) {  // > 20% change
+    pending_bitrate_reinit_ = true;
+  }
+}
+
+void MFH264EncoderImpl::SetRates(const RateControlParameters& parameters) {
+  if (!transform_) {
+    RTC_LOG(LS_WARNING) << "SetRates() while uninitialized.";
+    return;
+  }
+
+  if (parameters.framerate_fps < 1.0) {
+    RTC_LOG(LS_WARNING) << "Invalid frame rate: " << parameters.framerate_fps;
+    return;
+  }
+
+  if (parameters.bitrate.get_sum_bps() == 0) {
+    configuration_.SetStreamState(false);
+    return;
+  }
+
+  codec_.maxFramerate = static_cast<uint32_t>(parameters.framerate_fps);
+  codec_.maxBitrate = parameters.bitrate.GetSpatialLayerSum(0);
+
+  configuration_.target_bps = parameters.bitrate.GetSpatialLayerSum(0);
+  configuration_.max_frame_rate = parameters.framerate_fps;
+
+  if (configuration_.target_bps) {
+    ApplyBitrate(configuration_.target_bps);
+    configuration_.SetStreamState(true);
+  } else {
+    configuration_.SetStreamState(false);
+  }
+}
+
+void MFH264EncoderImpl::LayerConfig::SetStreamState(bool send_stream) {
+  if (send_stream && !sending) {
+    // Need a key frame if we have not sent this stream before.
+    key_frame_request = true;
+  }
+  sending = send_stream;
+}
+
+}  // namespace webrtc

--- a/webrtc-sys/src/mf/h264_encoder_impl.cpp
+++ b/webrtc-sys/src/mf/h264_encoder_impl.cpp
@@ -365,7 +365,7 @@ int32_t MFH264EncoderImpl::ConfigureTransform() {
     if (FAILED(hr)) {
       break;
     }
-    GUID subtype = GUID_NULL;
+    GUID subtype = {};
     candidate->GetGUID(MF_MT_SUBTYPE, &subtype);
     if (subtype == MFVideoFormat_NV12) {
       input_type = candidate;
@@ -474,7 +474,7 @@ HRESULT MFH264EncoderImpl::NegotiateOutputType() {
     if (FAILED(hr)) {
       return hr;
     }
-    GUID subtype = GUID_NULL;
+    GUID subtype = {};
     candidate->GetGUID(MF_MT_SUBTYPE, &subtype);
     if (subtype != MFVideoFormat_H264) {
       continue;
@@ -826,6 +826,12 @@ int32_t MFH264EncoderImpl::CollectOneOutput() {
                           << HResultToString(nhr);
         ReportError();
         return WEBRTC_VIDEO_CODEC_ENCODER_FAILURE;
+      }
+      // Async MFTs re-signal METransformHaveOutput after a stream change; an
+      // immediate ProcessOutput retry returns E_UNEXPECTED (seen on Intel
+      // QSV). Only sync MFTs retry inline.
+      if (is_async_) {
+        return WEBRTC_VIDEO_CODEC_NO_OUTPUT;
       }
       continue;
     }

--- a/webrtc-sys/src/mf/h264_encoder_impl.h
+++ b/webrtc-sys/src/mf/h264_encoder_impl.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WEBRTC_MF_H264_ENCODER_IMPL_H_
+#define WEBRTC_MF_H264_ENCODER_IMPL_H_
+
+#include "mf_common.h"
+
+#include <codecapi.h>
+
+#include <deque>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "api/environment/environment.h"
+#include "api/video/color_space.h"
+#include "api/video/i420_buffer.h"
+#include "api/video/video_rotation.h"
+#include "api/video_codecs/h264_profile_level_id.h"
+#include "api/video_codecs/video_encoder.h"
+#include "common_video/h264/h264_bitstream_parser.h"
+#include "modules/video_coding/codecs/h264/include/h264.h"
+
+namespace webrtc {
+
+// H264 encoder on top of a hardware Media Foundation transform (MFT). The
+// vendor's driver registers the MFT (Intel QuickSync, AMD VCN, NVIDIA NVENC),
+// so a single implementation covers all of them with no third-party
+// dependencies. Hardware encoder MFTs are asynchronous; Encode() runs a
+// bounded, synchronous event pump so no extra threads are introduced.
+class MFH264EncoderImpl : public VideoEncoder {
+ public:
+  struct LayerConfig {
+    int simulcast_idx = 0;
+    int width = -1;
+    int height = -1;
+    bool sending = true;
+    bool key_frame_request = false;
+    float max_frame_rate = 0;
+    uint32_t target_bps = 0;
+    uint32_t max_bps = 0;
+    bool frame_dropping_on = false;
+    int key_frame_interval = 0;
+
+    void SetStreamState(bool send_stream);
+  };
+
+  MFH264EncoderImpl(const Environment& env, const SdpVideoFormat& format);
+  ~MFH264EncoderImpl() override;
+
+  int32_t InitEncode(const VideoCodec* codec_settings,
+                     const Settings& settings) override;
+
+  int32_t RegisterEncodeCompleteCallback(
+      EncodedImageCallback* callback) override;
+
+  int32_t Release() override;
+
+  int32_t Encode(const VideoFrame& frame,
+                 const std::vector<VideoFrameType>* frame_types) override;
+
+  void SetRates(const RateControlParameters& rc_parameters) override;
+
+  EncoderInfo GetEncoderInfo() const override;
+
+ private:
+  // Metadata for a frame that has been fed to the MFT but whose encoded
+  // output has not been collected yet, keyed by the MF sample timestamp.
+  struct PendingFrameInfo {
+    int64_t sample_time_100ns = 0;
+    uint32_t rtp_timestamp = 0;
+    int64_t ntp_time_ms = 0;
+    int64_t render_time_ms = 0;
+    VideoRotation rotation = kVideoRotation_0;
+    std::optional<webrtc::ColorSpace> color_space;
+  };
+
+  int32_t CreateTransform();
+  int32_t ConfigureTransform();
+  int32_t ReinitTransform();
+  HRESULT NegotiateOutputType();
+  void CacheSequenceHeader();
+  HRESULT CreateInputSample(const I420BufferInterface& buffer,
+                            int64_t sample_time_100ns,
+                            int64_t duration_100ns,
+                            IMFSample** sample_out);
+  // Runs the async MFT event loop until the requested goals are met: an input
+  // credit is available (when `until_need_input`) and at most
+  // `until_pending_at_most` frames are in flight. Encoded output that becomes
+  // available meanwhile is delivered to the callback. Returns an error when
+  // the timeout expires with goals unmet.
+  int32_t PumpEvents(int timeout_ms,
+                     bool until_need_input,
+                     size_t until_pending_at_most);
+  // Collects one encoded output from the MFT; WEBRTC_VIDEO_CODEC_NO_OUTPUT
+  // means the transform needs more input.
+  int32_t CollectOneOutput();
+  // Sync-MFT path: collects outputs until the transform needs more input.
+  int32_t CollectOutputsSync();
+  int32_t ProcessEncodedFrame(std::vector<uint8_t>& packet);
+  PendingFrameInfo TakePendingInfo(int64_t sample_time_100ns);
+  void ApplyBitrate(uint32_t bitrate_bps);
+
+  void ReportInit();
+  void ReportError();
+
+  const webrtc::Environment& env_;
+
+  livekit_ffi::ComPtr<IMFActivate> activate_;
+  livekit_ffi::ComPtr<IMFTransform> transform_;
+  livekit_ffi::ComPtr<ICodecAPI> codec_api_;
+  livekit_ffi::ComPtr<IMFMediaEventGenerator> event_generator_;
+  bool is_async_ = false;
+  DWORD input_stream_id_ = 0;
+  DWORD output_stream_id_ = 0;
+  int need_input_credits_ = 0;
+  std::deque<PendingFrameInfo> pending_frames_;
+  PendingFrameInfo pending_output_info_;
+  int64_t frame_count_ = 0;
+  std::vector<uint8_t> sequence_header_;
+  std::vector<uint8_t> packet_;
+  std::string friendly_name_;
+
+  uint32_t active_bitrate_bps_ = 0;
+  bool dynamic_bitrate_supported_ = true;
+  bool pending_bitrate_reinit_ = false;
+
+  EncodedImageCallback* encoded_image_callback_ = nullptr;
+  LayerConfig configuration_;
+  EncodedImage encoded_image_;
+  VideoCodec codec_;
+  bool has_reported_init_ = false;
+  bool has_reported_error_ = false;
+  webrtc::H264BitstreamParser h264_bitstream_parser_;
+  const SdpVideoFormat format_;
+  H264Profile profile_ = H264Profile::kProfileConstrainedBaseline;
+  H264Level level_ = H264Level::kLevel3_1;
+};
+
+}  // namespace webrtc
+
+#endif  // WEBRTC_MF_H264_ENCODER_IMPL_H_

--- a/webrtc-sys/src/mf/mf_common.cpp
+++ b/webrtc-sys/src/mf/mf_common.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mf_common.h"
+
+// Instantiate the CODECAPI_* GUIDs (codecapi.h only declares them unless
+// INITGUID is in effect). The definitions are DECLSPEC_SELECTANY, so a single
+// translation unit doing this is sufficient and safe; every other file
+// includes codecapi.h without initguid.h and links against these.
+#include <initguid.h>
+
+#include <codecapi.h>
+
+#include <cstdio>
+
+#include "rtc_base/logging.h"
+
+namespace livekit_ffi {
+
+namespace {
+
+struct ThreadComInit {
+  bool ok = false;
+  bool should_uninit = false;
+
+  ThreadComInit() {
+    HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    if (SUCCEEDED(hr)) {
+      // S_FALSE means COM was already initialized on this thread; either way
+      // this thread now owns a reference that must be released on exit.
+      ok = true;
+      should_uninit = true;
+    } else if (hr == RPC_E_CHANGED_MODE) {
+      // Thread is already in an STA; the MF objects used here are
+      // free-threaded, so proceed without taking a reference.
+      ok = true;
+    }
+  }
+
+  ~ThreadComInit() {
+    if (should_uninit) {
+      CoUninitialize();
+    }
+  }
+};
+
+}  // namespace
+
+bool EnsureComInitialized() {
+  thread_local ThreadComInit init;
+  return init.ok;
+}
+
+bool EnsureMFStarted() {
+  static bool ok = [] {
+    HRESULT hr = MFStartup(MF_VERSION, MFSTARTUP_LITE);
+    if (FAILED(hr)) {
+      RTC_LOG(LS_ERROR) << "MFStartup failed: " << HResultToString(hr);
+      return false;
+    }
+    return true;
+  }();
+  return ok;
+}
+
+std::string HResultToString(HRESULT hr) {
+  char buf[16];
+  std::snprintf(buf, sizeof(buf), "0x%08lX", static_cast<unsigned long>(hr));
+  return buf;
+}
+
+}  // namespace livekit_ffi

--- a/webrtc-sys/src/mf/mf_common.h
+++ b/webrtc-sys/src/mf/mf_common.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WEBRTC_MF_COMMON_H_
+#define WEBRTC_MF_COMMON_H_
+
+#include <windows.h>
+
+#include <mfapi.h>
+#include <mferror.h>
+#include <mfidl.h>
+#include <mftransform.h>
+#include <strmif.h>  // ICodecAPI
+#include <wrl/client.h>
+
+#include <cstdint>
+#include <string>
+
+namespace livekit_ffi {
+
+using Microsoft::WRL::ComPtr;
+
+// Ensures COM is initialized (MTA) on the calling thread. webrtc invokes the
+// encoder/decoder on its own task-queue threads which are not guaranteed to
+// have called CoInitializeEx. The initialization is dropped automatically when
+// the thread exits. Safe to call repeatedly and from threads that already
+// initialized COM in either apartment mode.
+bool EnsureComInitialized();
+
+// Process-wide Media Foundation startup. MFStartup is called on first use and
+// intentionally never balanced with MFShutdown: encoders/decoders are created
+// and destroyed on different webrtc threads throughout the process lifetime,
+// and tearing MF down while another thread is mid-create is racy. The OS
+// reclaims MF state at process exit.
+bool EnsureMFStarted();
+
+// Formats an HRESULT as "0x8007000E" for log output.
+std::string HResultToString(HRESULT hr);
+
+}  // namespace livekit_ffi
+
+#endif  // WEBRTC_MF_COMMON_H_

--- a/webrtc-sys/src/mf/mf_decoder_factory.cpp
+++ b/webrtc-sys/src/mf/mf_decoder_factory.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2025 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mf_decoder_factory.h"
+
+#include <d3d11.h>
+#include <wmcodecdsp.h>
+
+#include <memory>
+
+#include <modules/video_coding/codecs/h264/include/h264.h>
+
+#include "h264_decoder_impl.h"
+#include "mf_common.h"
+#include "rtc_base/logging.h"
+
+namespace webrtc {
+
+using livekit_ffi::ComPtr;
+
+namespace {
+
+// The inbox decoder MFT ships with every Windows 10/11, but it only decodes
+// in hardware when a video-capable D3D11 device exists. Without one the MFT
+// would decode in software on the CPU — no better than the built-in decoder —
+// so both are required before this factory registers itself.
+bool ProbeDecodeSupport() {
+  if (!livekit_ffi::EnsureComInitialized() || !livekit_ffi::EnsureMFStarted()) {
+    return false;
+  }
+
+  ComPtr<IMFTransform> transform;
+  HRESULT hr =
+      CoCreateInstance(CLSID_CMSH264DecoderMFT, nullptr, CLSCTX_INPROC_SERVER,
+                       IID_PPV_ARGS(&transform));
+  if (FAILED(hr)) {
+    RTC_LOG(LS_WARNING) << "Inbox H264 decoder MFT unavailable: "
+                        << livekit_ffi::HResultToString(hr);
+    return false;
+  }
+
+  ComPtr<ID3D11Device> device;
+  hr = D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr,
+                         D3D11_CREATE_DEVICE_VIDEO_SUPPORT, nullptr, 0,
+                         D3D11_SDK_VERSION, &device, nullptr, nullptr);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_WARNING)
+        << "No video-capable D3D11 device; MF hardware decode unavailable: "
+        << livekit_ffi::HResultToString(hr);
+    return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+MFVideoDecoderFactory::MFVideoDecoderFactory() {
+  // DXVA H264 decode is >= level 4.1 on any hardware that gets this far;
+  // advertise 5.1 like the NVDEC factory. Both packetization modes are
+  // supported (the depacketized Annex-B stream looks the same to the MFT).
+  for (const char* packetization_mode : {"1", "0"}) {
+    supported_formats_.push_back(
+        CreateH264Format(webrtc::H264Profile::kProfileConstrainedBaseline,
+                         webrtc::H264Level::kLevel5_1, packetization_mode));
+    supported_formats_.push_back(
+        CreateH264Format(webrtc::H264Profile::kProfileBaseline,
+                         webrtc::H264Level::kLevel5_1, packetization_mode));
+    supported_formats_.push_back(
+        CreateH264Format(webrtc::H264Profile::kProfileMain,
+                         webrtc::H264Level::kLevel5_1, packetization_mode));
+    supported_formats_.push_back(
+        CreateH264Format(webrtc::H264Profile::kProfileHigh,
+                         webrtc::H264Level::kLevel5_1, packetization_mode));
+  }
+}
+
+MFVideoDecoderFactory::~MFVideoDecoderFactory() {}
+
+bool MFVideoDecoderFactory::IsSupported() {
+  static const bool supported = [] {
+    if (!ProbeDecodeSupport()) {
+      return false;
+    }
+    RTC_LOG(LS_INFO) << "MediaFoundation hardware H264 decoder is available.";
+    return true;
+  }();
+  return supported;
+}
+
+std::unique_ptr<VideoDecoder> MFVideoDecoderFactory::Create(
+    const Environment& env,
+    const SdpVideoFormat& format) {
+  for (const auto& supported_format : supported_formats_) {
+    if (format.IsSameCodec(supported_format)) {
+      if (format.name == "H264") {
+        RTC_LOG(LS_INFO) << "Using MediaFoundation HW decoder (DXVA) for H264";
+        return std::make_unique<MFH264DecoderImpl>();
+      }
+    }
+  }
+  return nullptr;
+}
+
+std::vector<SdpVideoFormat> MFVideoDecoderFactory::GetSupportedFormats()
+    const {
+  return supported_formats_;
+}
+
+}  // namespace webrtc

--- a/webrtc-sys/src/mf/mf_decoder_factory.h
+++ b/webrtc-sys/src/mf/mf_decoder_factory.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MF_VIDEO_DECODER_FACTORY_H_
+#define MF_VIDEO_DECODER_FACTORY_H_
+
+#include <memory>
+#include <vector>
+
+#include "api/environment/environment.h"
+#include "api/video_codecs/sdp_video_format.h"
+#include "api/video_codecs/video_decoder_factory.h"
+
+namespace webrtc {
+
+// Hardware H264 decoding through the Windows inbox decoder MFT, which fronts
+// DXVA for every GPU vendor when given a D3D11 device manager.
+class MFVideoDecoderFactory : public VideoDecoderFactory {
+ public:
+  MFVideoDecoderFactory();
+  ~MFVideoDecoderFactory() override;
+
+  static bool IsSupported();
+
+  std::vector<webrtc::SdpVideoFormat> GetSupportedFormats() const override;
+  std::unique_ptr<VideoDecoder> Create(const Environment& env,
+                                       const SdpVideoFormat& format) override;
+
+ private:
+  std::vector<SdpVideoFormat> supported_formats_;
+};
+
+}  // namespace webrtc
+
+#endif  // MF_VIDEO_DECODER_FACTORY_H_

--- a/webrtc-sys/src/mf/mf_encoder_factory.cpp
+++ b/webrtc-sys/src/mf/mf_encoder_factory.cpp
@@ -151,8 +151,8 @@ H264Level ProbeMaxLevel(IMFTransform* transform) {
 }  // namespace
 
 MFVideoEncoderFactory::MFVideoEncoderFactory() {
-  ComPtr<IMFTransform> transform = ActivateFirstHwEncoder();
-  if (!transform) {
+  ProbeTransform probe = ActivateFirstHwEncoder();
+  if (!probe) {
     return;
   }
 
@@ -160,7 +160,7 @@ MFVideoEncoderFactory::MFVideoEncoderFactory() {
   // advertise the level the hardware actually accepts so 1080p can be
   // negotiated. Baseline-family only for now, matching the software H264
   // default; High is a possible later addition.
-  const H264Level level = ProbeMaxLevel(transform.Get());
+  const H264Level level = ProbeMaxLevel(probe.transform.Get());
   supported_formats_.push_back(CreateH264Format(
       H264Profile::kProfileConstrainedBaseline, level, "1"));
 }
@@ -171,8 +171,8 @@ bool MFVideoEncoderFactory::IsSupported() {
   // Enumeration + activation can take tens of milliseconds; the answer cannot
   // change within the process lifetime, so probe once.
   static const bool supported = [] {
-    ComPtr<IMFTransform> transform = ActivateFirstHwEncoder();
-    if (!transform) {
+    ProbeTransform probe = ActivateFirstHwEncoder();
+    if (!probe) {
       RTC_LOG(LS_WARNING)
           << "No usable hardware H264 encoder MFT; MF encoding disabled.";
       return false;

--- a/webrtc-sys/src/mf/mf_encoder_factory.cpp
+++ b/webrtc-sys/src/mf/mf_encoder_factory.cpp
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2025 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mf_encoder_factory.h"
+
+#include <memory>
+
+#include "api/video_codecs/h264_profile_level_id.h"
+#include "h264_encoder_impl.h"
+#include "mf_common.h"
+#include "modules/video_coding/codecs/h264/include/h264.h"
+#include "rtc_base/logging.h"
+
+namespace webrtc {
+
+using livekit_ffi::ComPtr;
+using livekit_ffi::HResultToString;
+
+namespace {
+
+// A hardware encoder MFT activated for probing. ShutdownObject() runs on
+// destruction, as IMFActivate::ActivateObject requires.
+struct ProbeTransform {
+  ComPtr<IMFActivate> activate;
+  ComPtr<IMFTransform> transform;
+
+  explicit operator bool() const { return transform != nullptr; }
+
+  ~ProbeTransform() {
+    transform.Reset();
+    if (activate) {
+      activate->ShutdownObject();
+    }
+  }
+};
+
+// Activates the first (best, thanks to MFT_ENUM_FLAG_SORTANDFILTER) hardware
+// H264 encoder MFT, or an empty result when none is present or activation
+// fails. The presence of a registration alone is not enough — old or broken
+// drivers register MFTs that fail to activate, mirroring the NVENC
+// open-a-session probe.
+ProbeTransform ActivateFirstHwEncoder() {
+  ProbeTransform result;
+  if (!livekit_ffi::EnsureComInitialized() || !livekit_ffi::EnsureMFStarted()) {
+    return result;
+  }
+
+  MFT_REGISTER_TYPE_INFO input_info = {MFMediaType_Video, MFVideoFormat_NV12};
+  MFT_REGISTER_TYPE_INFO output_info = {MFMediaType_Video, MFVideoFormat_H264};
+
+  IMFActivate** activates = nullptr;
+  UINT32 count = 0;
+  HRESULT hr = MFTEnumEx(MFT_CATEGORY_VIDEO_ENCODER,
+                         MFT_ENUM_FLAG_HARDWARE | MFT_ENUM_FLAG_SORTANDFILTER,
+                         &input_info, &output_info, &activates, &count);
+  if (FAILED(hr) || count == 0) {
+    if (activates) {
+      CoTaskMemFree(activates);
+    }
+    return result;
+  }
+
+  result.activate = activates[0];
+  for (UINT32 i = 0; i < count; i++) {
+    activates[i]->Release();
+  }
+  CoTaskMemFree(activates);
+
+  hr = result.activate->ActivateObject(IID_PPV_ARGS(&result.transform));
+  if (FAILED(hr)) {
+    RTC_LOG(LS_WARNING) << "Hardware H264 encoder MFT failed to activate: "
+                        << HResultToString(hr);
+    result.transform.Reset();
+  }
+  return result;
+}
+
+// Determines the highest H264 level (of the ones we care about) the MFT
+// accepts, by offering output media types with MFT_SET_TYPE_TEST_ONLY.
+// Level 4.0 is the minimum for 1080p30 — the point of this backend — with
+// 4.2 preferred; 3.1 is the compatibility floor.
+H264Level ProbeMaxLevel(IMFTransform* transform) {
+  ComPtr<IMFAttributes> attributes;
+  if (SUCCEEDED(transform->GetAttributes(&attributes)) && attributes) {
+    UINT32 is_async = 0;
+    attributes->GetUINT32(MF_TRANSFORM_ASYNC, &is_async);
+    if (is_async) {
+      // Media types cannot be set (even TEST_ONLY) while the async MFT is
+      // locked.
+      attributes->SetUINT32(MF_TRANSFORM_ASYNC_UNLOCK, TRUE);
+    }
+  }
+
+  DWORD input_ids[1] = {0};
+  DWORD output_ids[1] = {0};
+  if (transform->GetStreamIDs(1, input_ids, 1, output_ids) == E_NOTIMPL) {
+    output_ids[0] = 0;
+  }
+
+  struct Candidate {
+    H264Level level;
+    UINT32 mf_level;
+    UINT32 width;
+    UINT32 height;
+  };
+  const Candidate candidates[] = {
+      {H264Level::kLevel4_2, eAVEncH264VLevel4_2, 1920, 1080},
+      {H264Level::kLevel4, eAVEncH264VLevel4, 1920, 1080},
+  };
+
+  for (const Candidate& candidate : candidates) {
+    ComPtr<IMFMediaType> type;
+    if (FAILED(MFCreateMediaType(&type))) {
+      break;
+    }
+    type->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video);
+    type->SetGUID(MF_MT_SUBTYPE, MFVideoFormat_H264);
+    type->SetUINT32(MF_MT_AVG_BITRATE, 5'000'000);
+    MFSetAttributeSize(type.Get(), MF_MT_FRAME_SIZE, candidate.width,
+                       candidate.height);
+    MFSetAttributeRatio(type.Get(), MF_MT_FRAME_RATE, 30, 1);
+    type->SetUINT32(MF_MT_INTERLACE_MODE, MFVideoInterlace_Progressive);
+    type->SetUINT32(MF_MT_MPEG2_PROFILE, eAVEncH264VProfile_Base);
+    type->SetUINT32(MF_MT_MPEG2_LEVEL, candidate.mf_level);
+
+    HRESULT hr = transform->SetOutputType(output_ids[0], type.Get(),
+                                          MFT_SET_TYPE_TEST_ONLY);
+    if (SUCCEEDED(hr)) {
+      return candidate.level;
+    }
+  }
+
+  RTC_LOG(LS_WARNING) << "Hardware H264 encoder MFT rejected level 4.0+; "
+                         "advertising level 3.1 (720p cap).";
+  return H264Level::kLevel3_1;
+}
+
+}  // namespace
+
+MFVideoEncoderFactory::MFVideoEncoderFactory() {
+  ComPtr<IMFTransform> transform = ActivateFirstHwEncoder();
+  if (!transform) {
+    return;
+  }
+
+  // Unlike the NVENC factory's hardcoded 42e01f (level 3.1, a 720p30 cap),
+  // advertise the level the hardware actually accepts so 1080p can be
+  // negotiated. Baseline-family only for now, matching the software H264
+  // default; High is a possible later addition.
+  const H264Level level = ProbeMaxLevel(transform.Get());
+  supported_formats_.push_back(CreateH264Format(
+      H264Profile::kProfileConstrainedBaseline, level, "1"));
+}
+
+MFVideoEncoderFactory::~MFVideoEncoderFactory() {}
+
+bool MFVideoEncoderFactory::IsSupported() {
+  // Enumeration + activation can take tens of milliseconds; the answer cannot
+  // change within the process lifetime, so probe once.
+  static const bool supported = [] {
+    ComPtr<IMFTransform> transform = ActivateFirstHwEncoder();
+    if (!transform) {
+      RTC_LOG(LS_WARNING)
+          << "No usable hardware H264 encoder MFT; MF encoding disabled.";
+      return false;
+    }
+    RTC_LOG(LS_INFO) << "MediaFoundation hardware H264 encoder is available.";
+    return true;
+  }();
+  return supported;
+}
+
+std::unique_ptr<VideoEncoder> MFVideoEncoderFactory::Create(
+    const Environment& env,
+    const SdpVideoFormat& format) {
+  for (const auto& supported_format : supported_formats_) {
+    if (format.IsSameCodec(supported_format)) {
+      if (format.name == "H264") {
+        RTC_LOG(LS_INFO) << "Using MediaFoundation HW encoder for H264";
+        return std::make_unique<MFH264EncoderImpl>(env, format);
+      }
+    }
+  }
+  return nullptr;
+}
+
+std::vector<SdpVideoFormat> MFVideoEncoderFactory::GetSupportedFormats()
+    const {
+  return supported_formats_;
+}
+
+std::vector<SdpVideoFormat> MFVideoEncoderFactory::GetImplementations()
+    const {
+  return supported_formats_;
+}
+
+}  // namespace webrtc

--- a/webrtc-sys/src/mf/mf_encoder_factory.h
+++ b/webrtc-sys/src/mf/mf_encoder_factory.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 LiveKit, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MF_VIDEO_ENCODER_FACTORY_H_
+#define MF_VIDEO_ENCODER_FACTORY_H_
+
+#include <memory>
+#include <vector>
+
+#include "api/environment/environment.h"
+#include "api/video_codecs/sdp_video_format.h"
+#include "api/video_codecs/video_encoder_factory.h"
+
+namespace webrtc {
+
+// Hardware H264 encoding through the Media Foundation transform registered by
+// the GPU driver (Intel QuickSync, AMD VCN, NVIDIA NVENC). Requires no
+// third-party dependencies: the MFT ships with the vendor driver and the MF
+// runtime with Windows.
+class MFVideoEncoderFactory : public VideoEncoderFactory {
+ public:
+  MFVideoEncoderFactory();
+  ~MFVideoEncoderFactory() override;
+
+  static bool IsSupported();
+
+  std::unique_ptr<VideoEncoder> Create(const Environment& env,
+                                       const SdpVideoFormat& format) override;
+
+  // Returns a list of supported codecs in order of preference.
+  std::vector<SdpVideoFormat> GetSupportedFormats() const override;
+
+  std::vector<SdpVideoFormat> GetImplementations() const override;
+
+  std::unique_ptr<EncoderSelectorInterface> GetEncoderSelector()
+      const override {
+    return nullptr;
+  }
+
+ private:
+  std::vector<SdpVideoFormat> supported_formats_;
+};
+
+}  // namespace webrtc
+
+#endif  // MF_VIDEO_ENCODER_FACTORY_H_

--- a/webrtc-sys/src/video_decoder_factory.cpp
+++ b/webrtc-sys/src/video_decoder_factory.cpp
@@ -39,6 +39,10 @@
 #include "nvidia/nvidia_decoder_factory.h"
 #endif
 
+#if defined(USE_MF_VIDEO_CODEC)
+#include "mf/mf_decoder_factory.h"
+#endif
+
 namespace livekit_ffi {
 
 VideoDecoderFactory::VideoDecoderFactory() {
@@ -53,6 +57,12 @@ VideoDecoderFactory::VideoDecoderFactory() {
 #if defined(USE_NVIDIA_VIDEO_CODEC)
   if (webrtc::NvidiaVideoDecoderFactory::IsSupported()) {
     factories_.push_back(std::make_unique<webrtc::NvidiaVideoDecoderFactory>());
+  }
+#endif
+
+#if defined(USE_MF_VIDEO_CODEC)
+  if (webrtc::MFVideoDecoderFactory::IsSupported()) {
+    factories_.push_back(std::make_unique<webrtc::MFVideoDecoderFactory>());
   }
 #endif
 }

--- a/webrtc-sys/src/video_encoder_factory.cpp
+++ b/webrtc-sys/src/video_encoder_factory.cpp
@@ -59,6 +59,10 @@
 #include "jetson/jetson_encoder_factory.h"
 #endif
 
+#if defined(USE_MF_VIDEO_CODEC)
+#include "mf/mf_encoder_factory.h"
+#endif
+
 namespace livekit_ffi {
 
 namespace {
@@ -229,6 +233,21 @@ void AddJetsonFactory(
 #endif
 }
 
+void AddMfFactory(
+    std::vector<VideoEncoderBackendFactory>& factories) {
+#if defined(USE_MF_VIDEO_CODEC)
+  if (webrtc::MFVideoEncoderFactory::IsSupported()) {
+    AddBackendFactory(
+        factories,
+        VideoEncoderBackend::Hardware,
+        std::make_unique<webrtc::MFVideoEncoderFactory>());
+    return;
+  }
+#else
+  (void)factories;
+#endif
+}
+
 void AddNvencFactory(
     std::vector<VideoEncoderBackendFactory>& factories,
     bool preferred) {
@@ -321,6 +340,12 @@ rust::Vec<VideoEncoderBackend> video_encoder_backend_list() {
   }
 #endif
 
+#if defined(USE_MF_VIDEO_CODEC)
+  if (webrtc::MFVideoEncoderFactory::IsSupported()) {
+    has_hardware_backend = true;
+  }
+#endif
+
 #if defined(USE_NVIDIA_VIDEO_CODEC)
   if (webrtc::NvidiaVideoEncoderFactory::IsSupported()) {
     backends.push_back(VideoEncoderBackend::Nvenc);
@@ -363,6 +388,7 @@ VideoEncoderFactory::InternalFactory::InternalFactory() {
 #endif
 
   AddJetsonFactory(factories_);
+  AddMfFactory(factories_);
 
   const PreferredHwEncoderConfig preferred_hw_encoder =
       GetPreferredHwEncoderConfig();


### PR DESCRIPTION
### PR description

**Adds a hardware H264 encoder + decoder backend for Windows, using Media Foundation.**

I need to run LiveKit with hardware acceleration for video en/decoding if at all possible,
and found this was not possible on Windows. Without prior experience in LiveKit dev, I
attempted to fill in this gap using LLMs: this PR was created through guided steps with Fable 5.

Windows currently compiles no hardware video factory at all — the NVENC backend
is Linux-only (it dlopens `libnvidia-encode.so.1`), and the `vaapi-windows`
experiment in `build.rs` is commented out. On a typical Intel- or AMD-iGPU
workstation, H264 therefore runs on OpenH264/FFmpeg in software.

This PR adds an encoder and decoder built on the Media Foundation transform
(MFT) registered by the GPU driver. One implementation covers **Intel
QuickSync, AMD VCN, and NVIDIA** — NVIDIA's Windows driver registers an encoder
MFT like the other vendors, so it is included even though the NVENC backend
isn't available on this platform. It links only Windows system libraries
(`mfplat`, `mfuuid`, `mf`, `dxguid`): no third-party dependencies, nothing
downloaded, and no custom libwebrtc build.

#### Layout (mirrors `webrtc-sys/src/nvidia/`)

```
webrtc-sys/src/mf/
  mf_common.h/.cpp          per-thread COM init, MFStartup, CODECAPI GUID instantiation
  mf_encoder_factory.h/.cpp MFTEnumEx(HARDWARE) probe + level probe + Create()
  h264_encoder_impl.h/.cpp  webrtc::VideoEncoder over the async encoder MFT
  mf_decoder_factory.h/.cpp inbox-decoder + D3D11 availability probe
  h264_decoder_impl.h/.cpp  webrtc::VideoDecoder over CLSID_CMSH264DecoderMFT
                            (DXVA via D3D11 device manager, staging readback)
```

Integration is three small edits: `AddMfFactory` under
`#if defined(USE_MF_VIDEO_CODEC)` in `video_encoder_factory.cpp` (registered as
the generic `VideoEncoderBackend::Hardware`, like the Jetson/Android backends,
so there are no cxx bridge changes), one `push_back` in
`video_decoder_factory.cpp`, and five files + `/DUSE_MF_VIDEO_CODEC=1` + four
system libs in the `build.rs` `"windows"` arm. Every failure path falls through
to the existing software fallback.

#### Design notes

- **Encoder.** Hardware MFTs are asynchronous, so `Encode()` runs a bounded
  synchronous event pump — no extra threads, at most 4 frames in flight. CBR via
  `ICodecAPI`, B-frames disabled, effectively-infinite GOP (webrtc drives IDRs
  through `AVEncVideoForceKeyFrame`), `AVLowLatencyMode`. Bitrate is updated at
  runtime where the driver accepts it, otherwise by re-init behind a >20%
  hysteresis. A cached `MF_MT_MPEG_SEQUENCE_HEADER` is prepended to IDRs for
  vendor MFTs that don't inline SPS/PPS. Annex-B output feeds the same NALU-scan
  / `H264BitstreamParser` post-processing as the NVENC implementation.
- **Format advertisement.** The factory probes the level the MFT actually
  accepts (`MFT_SET_TYPE_TEST_ONLY`, 4.2 → 4.0 → 3.1) rather than hardcoding
  `42e01f`, so 1080p can be negotiated. Constrained Baseline only, matching the
  existing default interop posture.
- **Decoder.** The inbox `CLSID_CMSH264DecoderMFT` fronts DXVA for every vendor
  when given a D3D11 device manager. Without one it silently decodes on the CPU,
  which would be strictly worse than the existing decoder path — so the factory
  only registers when a video-capable D3D11 device exists. Handles
  `MF_E_TRANSFORM_STREAM_CHANGE` and the coded-size display aperture (1080p
  arrives as 1920×1088). NV12 texture → staging texture → pooled I420.
- **COM** is initialized per-thread (MTA, STA-tolerant), since webrtc calls in on
  its own task queues; `MFStartup` is process-wide start-once.

#### Known limitations

- AMD VCN and NVIDIA-on-Windows take the identical code path by design, but were
  not run on physical hardware (no machines available). Intel QuickSync is fully
  validated — see Testing.
- System-memory NV12 input (no D3D11 texture input) and CPU readback on decode,
  i.e. the same copy costs as the NVENC backend. Zero-copy is a possible
  follow-up.
- H264 only; H265 and AV1 are out of scope here.

### Breaking changes

None. The change is additive and Windows-only: new files under
`webrtc-sys/src/mf/`, two guarded dispatch registrations, and a `build.rs`
`"windows"` arm. There are no Rust or FFI API changes, no cxx bridge changes and
no new dependencies. On every other platform the diff compiles to nothing, and
on Windows the backend only registers when a hardware MFT (and, for decode, a
video-capable D3D11 device) is actually present — otherwise behaviour is
unchanged.

### MSRV

Unchanged. No Rust language or dependency changes; the only Rust touched is
`build.rs` link/source declarations.

### Async

No async Rust is involved — this is C++ inside `webrtc-sys`, called on webrtc's
own encoder/decoder task queues. Nothing in `livekit-runtime` is used or needed,
and no Tokio dependency is introduced. The MFT event pump is synchronous and
bounded, and holds no locks shared with application threads.

### Testing

I want to be straight about this: **there are no unit tests in this PR**, and I
don't think there is an honest way to add meaningful ones. The code under test
is a driver-registered hardware transform — there is nothing to assert against
without a GPU, and a test that mocked the MFT away would only be asserting that
the mock behaves like the mock. CI has no GPU on the `windows-latest` runners,
so anything I added would either be skipped there or would emulate exactly the
happy path the contributing guidelines ask us not to emulate. This matches the
existing NVENC, VAAPI and Jetson backends, which likewise ship without unit
tests.

What I did instead was validate on real hardware, deliberately choosing a
worst-case old machine — a Dell OptiPlex 7010: i5-3470, **Ivy Bridge HD 2500**,
driver 10.18.10.5161 (2020, the final Ivy Bridge branch), Windows 10. If it
works there, the driver floor is Ivy Bridge and up.

**Standalone probe** (a small `cl.exe` executable driving the MFTs directly):

| Check | Result |
|---|---|
| QSV encoder MFT enumerates + activates | yes (async MFT, `ICodecAPI` ok) |
| 1080p30 CBR low-latency encode | 60/60 frames |
| Levels accepted at 1080p (`TEST_ONLY`) | 3.1, 4.0, 4.1, 4.2, 5.1 all accepted |
| SPS emitted at 1080p | `profile_idc=66`, `level_idc=40` |
| SPS/PPS inline on IDR | yes (prepend fallback not needed on Intel) |
| `ForceKeyFrame` → IDR | yes |
| Runtime bitrate update | accepted (re-init fallback not needed on Intel) |
| Decode with D3D11 manager | DXVA engaged, 60/60 DXGI-texture samples, **1.3 ms/frame** |
| Decode without manager (software baseline) | 9.4–9.7 ms/frame |

**Build and runtime** (same machine, MSVC 14.44 / SDK 10.0.26100, stable Rust):

- `cargo build -p webrtc-sys` — clean.
- `cargo build -p livekit-ffi` — full `livekit_ffi.dll` cdylib link clean, which
  is what validates the CODECAPI GUID instantiation and all four import libs.
- Runtime smoke through the cxx bridge: `video_encoder_backend_list()` returns
  `[Auto, Software, Hardware]`, i.e. `MFVideoEncoderFactory::IsSupported()`
  enumerated and activated the QSV MFT through the real dispatch path.

**End to end**: a live session between a macOS client and a Windows client, both
built on this SDK with H264 selected, camera video flowing in both directions.
Process-module snapshots confirm the Intel hardware encoder MFT
(`mfx_mft_h264ve_64.dll` + `libmfxhw64.dll`) and the inbox decoder
(`msmpeg2vdec.dll`) are loaded in-process on the Windows side for the duration.

Three hardware behaviours were only discovered by running on a real GPU, and are
now baked into the code:

1. Async MFTs **re-signal `METransformHaveOutput` after
   `MF_E_TRANSFORM_STREAM_CHANGE`** — an inline `ProcessOutput` retry returns
   `E_UNEXPECTED` on QSV. The encoder now waits for the re-signal; synchronous
   MFTs keep the inline retry. Without this the first frame would have dropped
   the whole backend to software.
2. `d3d10.h` before `d3d10_1.h` is a hard error on current SDKs (SAL ordering) —
   include `d3d10_1.h` for `ID3D10Multithread`.
3. `GUID_NULL` requires `cguid.h`; zero-initialization is used instead.

**Not covered, and I'd flag it for review:** CI cross-compiles
`aarch64-pc-windows-msvc`, and the `build.rs` arm is gated on `target_os`, so
these sources will be compiled for ARM64 too. There is no architecture-specific
code in them, but I have no ARM64 Windows machine to run on — this PR's CI run
is the first time that target gets built. Happy to add an architecture guard if
you'd prefer to scope the backend to x86_64 for now.

### Notes for review

A few questions I expect, answered up front:

- **Why no `LIVEKIT_PREFERRED_HW_ENCODER` support?** It parses `nvenc|vaapi`
  only, and MF registers as the generic `Hardware` backend and is the sole
  Windows backend, so there is nothing to disambiguate. Worth extending if a
  second Windows backend ever appears.
- **Why advertise Baseline only?** It matches the current OpenH264/NVENC interop
  posture. High profile is a straightforward follow-up — the
  `eAVEncH264VProfile_High` mapping already exists in the implementation.
- **Why does the decoder factory require D3D11?** Without DXVA the inbox MFT
  decodes on the CPU, which is strictly worse than the built-in decoder path, so
  registering unconditionally would be a silent regression.
- **Rebase**: the branch is rebased onto current `main` and applies cleanly.
