### PR TITLE
rust server SDK: add unified start_egress convenience method

### DIFF
--- a/.changeset/add_unified_start_egress.md
+++ b/.changeset/add_unified_start_egress.md
@@ -1,0 +1,8 @@
+---
+livekit-api: minor
+livekit: patch
+livekit-ffi: patch
+livekit-uniffi: patch
+---
+
+Add a unified `EgressClient::start_egress` that calls the v2 `Egress.StartEgress` RPC with a `StartEgressRequest`, alongside the existing per-type helpers.

--- a/livekit-api/src/services/api_test.rs
+++ b/livekit-api/src/services/api_test.rs
@@ -359,6 +359,25 @@ async fn egress_smoke() {
         )
         .await
         .expect("start_track_egress");
+    egress
+        .start_egress(proto::StartEgressRequest {
+            room_name: "test-room".to_owned(),
+            source: Some(proto::start_egress_request::Source::Web(proto::WebSource {
+                url: "https://example.com/scene".to_owned(),
+                ..Default::default()
+            })),
+            outputs: vec![proto::Output {
+                config: Some(proto::output::Config::File(proto::FileOutput {
+                    file_type: proto::EncodedFileType::Mp4 as i32,
+                    filepath: "unified.mp4".to_owned(),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            }],
+            ..Default::default()
+        })
+        .await
+        .expect("start_egress");
     egress.update_layout("EG_abc123", "speaker").await.expect("update_layout");
     egress
         .update_stream("EG_abc123", vec!["rtmps://b.example.com/live/key".to_owned()], vec![])

--- a/livekit-api/src/services/egress.rs
+++ b/livekit-api/src/services/egress.rs
@@ -317,6 +317,25 @@ impl EgressClient {
             .map_err(Into::into)
     }
 
+    /// Starts an egress using the unified v2 [`StartEgressRequest`](proto::StartEgressRequest),
+    /// which supersedes the per-source `start_*_egress` helpers. Calls the
+    /// `Egress.StartEgress` RPC and returns the created [`EgressInfo`](proto::EgressInfo).
+    pub async fn start_egress(
+        &self,
+        request: proto::StartEgressRequest,
+    ) -> ServiceResult<proto::EgressInfo> {
+        self.client
+            .request(
+                SVC,
+                "StartEgress",
+                request,
+                self.base
+                    .auth_header(VideoGrants { room_record: true, ..Default::default() }, None)?,
+            )
+            .await
+            .map_err(Into::into)
+    }
+
     pub async fn update_layout(
         &self,
         egress_id: &str,


### PR DESCRIPTION
livekit-api (rust) egress service exposes a unified start_egress that calls the Egress.StartEgress RPC with the v2 StartEgressRequest.
