### PR TITLE
Caching of tokio backend reqwest http client

### DIFF
--- a/.changeset/caching_of_tokio_backend_reqwest_http_client.md
+++ b/.changeset/caching_of_tokio_backend_reqwest_http_client.md
@@ -1,0 +1,9 @@
+---
+livekit: patch
+livekit-api: patch
+livekit-ffi: patch
+livekit-net: patch
+livekit-uniffi: patch
+---
+
+Caching of tokio backend reqwest http client - #1285 (@MaxHeimbrock)

--- a/livekit-net/src/lib.rs
+++ b/livekit-net/src/lib.rs
@@ -97,11 +97,11 @@ pub mod testing {
     use std::sync::Arc;
     /// A fresh native WebSocket client for tests (bypasses the global registry).
     pub fn native_ws_client() -> Arc<dyn WsClient> {
-        Arc::new(crate::native::NativeTransport)
+        Arc::new(crate::native::NativeTransport::new())
     }
     /// A fresh native HTTP client for tests (bypasses the global registry).
     pub fn native_http_client() -> Arc<dyn HttpClient> {
-        Arc::new(crate::native::NativeTransport)
+        Arc::new(crate::native::NativeTransport::new())
     }
 }
 

--- a/livekit-net/src/native/mod.rs
+++ b/livekit-net/src/native/mod.rs
@@ -109,7 +109,12 @@ impl HttpClient for NativeTransport {
     ) -> Result<HttpResponse, TransportError> {
         #[cfg(feature = "__native-tokio")]
         {
-            let client = reqwest::Client::new();
+            // One process-wide client: reqwest pools connections per client, so a
+            // per-request client would redo TCP/TLS setup (and root-store loading)
+            // on every call.
+            static CLIENT: std::sync::LazyLock<reqwest::Client> =
+                std::sync::LazyLock::new(reqwest::Client::new);
+            let client = &*CLIENT;
             let mut req = match method {
                 HttpMethod::Get => client.get(&url),
                 HttpMethod::Post => client.post(&url),

--- a/livekit-net/src/native/mod.rs
+++ b/livekit-net/src/native/mod.rs
@@ -31,16 +31,40 @@ fn error_chain(e: &dyn std::error::Error) -> String {
     msg
 }
 
-/// The built-in native transport. One stateless type implements both [`WsClient`]
-/// and [`HttpClient`]; the registry hands out a fresh `Arc` per trait.
-pub struct NativeTransport;
+/// The built-in native transport. One type implements both [`WsClient`] and
+/// [`HttpClient`]. On the tokio backend it owns the reqwest client, so the
+/// connection pool lives and dies with the transport object.
+pub struct NativeTransport {
+    // reqwest pools connections per client, so a per-request client would redo
+    // TCP/TLS setup (and root-store loading) on every call.
+    #[cfg(feature = "__native-tokio")]
+    http: reqwest::Client,
+}
+
+impl NativeTransport {
+    pub(crate) fn new() -> Self {
+        Self {
+            #[cfg(feature = "__native-tokio")]
+            http: reqwest::Client::new(),
+        }
+    }
+}
+
+/// The shared default transport behind the registry fallback. Memoized because
+/// consumers resolve a client per request: a fresh transport per resolution
+/// would defeat its connection pooling.
+fn default_transport() -> Arc<NativeTransport> {
+    use std::sync::OnceLock;
+    static DEFAULT: OnceLock<Arc<NativeTransport>> = OnceLock::new();
+    Arc::clone(DEFAULT.get_or_init(|| Arc::new(NativeTransport::new())))
+}
 
 pub(crate) fn native_ws_client() -> Arc<dyn WsClient> {
-    Arc::new(NativeTransport)
+    default_transport()
 }
 
 pub(crate) fn native_http_client() -> Arc<dyn HttpClient> {
-    Arc::new(NativeTransport)
+    default_transport()
 }
 
 #[async_trait::async_trait]
@@ -109,12 +133,7 @@ impl HttpClient for NativeTransport {
     ) -> Result<HttpResponse, TransportError> {
         #[cfg(feature = "__native-tokio")]
         {
-            // One process-wide client: reqwest pools connections per client, so a
-            // per-request client would redo TCP/TLS setup (and root-store loading)
-            // on every call.
-            static CLIENT: std::sync::LazyLock<reqwest::Client> =
-                std::sync::LazyLock::new(reqwest::Client::new);
-            let client = &*CLIENT;
+            let client = &self.http;
             let mut req = match method {
                 HttpMethod::Get => client.get(&url),
                 HttpMethod::Post => client.post(&url),


### PR DESCRIPTION
### Summary

With the native-tokio feature (enabled via livekit-api/signal-client-tokio → livekit-net/native-tokio → internal __native-tokio marker), NativeTransport::request in livekit-net/src/native/mod.rs:110 uses reqwest for HTTP. Before this branch, it built a reqwest::Client::new() inside every request; This PR replaces that with a process-wide static LazyLock<reqwest::Client>, so all requests share one client — and with it reqwest's internal hyper connection pool (keep-alive TCP/TLS connections). The async backend (isahc) is untouched.

### Proof by benchmark

I built a throwaway bench crate (in the session scratchpad, not your repo) that runs N sequential GETs two ways: cached goes through the real livekit_net::testing::native_http_client() code path, fresh replicates the old code verbatim. A local server counts accepted TCP connections; a second scenario hits a real HTTPS endpoint so a genuine TLS handshake is in play.

  ```
┌─────────────────────────────────────────────┬──────────────┬─────────────────────────────┐
  │                  Scenario                   │ Cached (new) │   Fresh per-request (old)   │
  ├─────────────────────────────────────────────┼──────────────┼─────────────────────────────┤
  │ Local plaintext, 1000 reqs — time/req       │ 58 µs        │ 95 µs (~1.6× slower)        │
  ├─────────────────────────────────────────────┼──────────────┼─────────────────────────────┤
  │ Local plaintext — TCP connections opened    │ 1            │ 1000                        │
  ├─────────────────────────────────────────────┼──────────────┼─────────────────────────────┤
  │ Real HTTPS (Cloudflare), 50 reqs — time/req │ 7.0–9.8 ms   │ 36.5–41.4 ms (~4–5× slower) │
  ├─────────────────────────────────────────────┼──────────────┼─────────────────────────────┤
  │ Peak RSS (local run)                        │ 8.3 MB       │ 8.5 MB                      │
  └─────────────────────────────────────────────┴──────────────┴─────────────────────────────┘
```

The connection count is the smoking gun: the old code opened a brand-new TCP connection for every single request, the cached client opened exactly one and reused it. On loopback that only costs ~40 µs per request, but against a real HTTPS server — which is what token endpoints are — every fresh connection pays DNS + TCP + TLS handshake, making the cached client 4–5× faster per request (I ran it in both orders to rule out warm-up bias).

### Alternative

The alternative is storing the Client on NativeTransport instead of in a static — same pooling benefit per registered transport, but scoped to the object's lifetime rather than the process.