### PR TITLE
Fix buffered AudioSource.capture_frame hanging when the source drain stalls

### DIFF
--- a/.changeset/fix-audiosource-capture-frame-drain-stall.md
+++ b/.changeset/fix-audiosource-capture-frame-drain-stall.md
@@ -1,0 +1,8 @@
+---
+libwebrtc: patch
+livekit: patch
+livekit-ffi: patch
+webrtc-sys: patch
+---
+
+Bound the buffered `AudioSource::capture_frame` completion wait and split the drain lock so a stalled or wedged source drain returns a recoverable error instead of hanging the producer (and the session) forever (#408, #420, #497) - #1289 (@sam-hark)

--- a/libwebrtc/Cargo.toml
+++ b/libwebrtc/Cargo.toml
@@ -33,7 +33,7 @@ webrtc-sys = { workspace = true }
 livekit-runtime = { workspace = true, features = ["tokio"] }
 lazy_static = { workspace = true }
 parking_lot = { workspace = true }
-tokio = { workspace = true, default-features = false, features = ["sync", "macros"] }
+tokio = { workspace = true, default-features = false, features = ["sync", "macros", "time"] }
 cxx = "1.0"
 rtrb = "0.3.3"
 
@@ -59,3 +59,4 @@ web-sys = { version = "0.3", features = [
 
 [dev-dependencies]
 env_logger = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "sync"] }

--- a/libwebrtc/Cargo.toml
+++ b/libwebrtc/Cargo.toml
@@ -33,7 +33,7 @@ webrtc-sys = { workspace = true }
 livekit-runtime = { workspace = true, features = ["tokio"] }
 lazy_static = { workspace = true }
 parking_lot = { workspace = true }
-tokio = { workspace = true, default-features = false, features = ["sync", "macros", "time"] }
+tokio = { workspace = true, default-features = false, features = ["sync", "macros"] }
 cxx = "1.0"
 rtrb = "0.3.3"
 

--- a/libwebrtc/src/native/audio_source.rs
+++ b/libwebrtc/src/native/audio_source.rs
@@ -204,7 +204,9 @@ impl NativeAudioSource {
 
             // Bound the wait for the drain's completion (timeout rationale above). On a stall,
             // clear_buffer() releases the pending completion so the source stays usable afterward.
-            match tokio::time::timeout(capture_timeout, rx).await {
+            // Route through livekit_runtime so capture_frame stays runtime-neutral (tokio::time
+            // would panic when awaited off a Tokio runtime).
+            match livekit_runtime::timeout(capture_timeout, rx).await {
                 Ok(_) => {}
                 Err(_) => {
                     self.clear_buffer();

--- a/libwebrtc/src/native/audio_source.rs
+++ b/libwebrtc/src/native/audio_source.rs
@@ -18,6 +18,14 @@ use webrtc_sys::audio_track as sys_at;
 
 use crate::{audio_frame::AudioFrame, audio_source::AudioSourceOptions, RtcError, RtcErrorType};
 
+/// Floor for the per-chunk completion wait, for very small queues.
+const CAPTURE_COMPLETE_TIMEOUT_FLOOR: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// Headroom multiple applied to the queue duration when bounding the completion wait: a healthy
+/// drain acknowledges a chunk within one queue-duration, so this leaves margin before the wait is
+/// treated as a stall.
+const CAPTURE_COMPLETE_TIMEOUT_QUEUE_MULTIPLE: u64 = 5;
+
 #[derive(Clone)]
 pub struct NativeAudioSource {
     sys_handle: SharedPtr<sys_at::ffi::AudioTrackSource>,
@@ -153,6 +161,20 @@ impl NativeAudioSource {
             let _ = tx.send(());
         }
 
+        // Bound the per-chunk completion wait on a multiple of the queue duration. The C++
+        // drain acknowledges a chunk from a 10ms RepeatingTask; legitimate backpressure clears
+        // within one queue-duration. A wait beyond that means the drain stalled (CPU-starved,
+        // or a sink blocked in OnData), so surface a recoverable error rather than hang the
+        // caller — and the whole session — forever (see rust-sdks #408 / #420 / #497).
+        let queue_ms = (self.queue_size_samples as u64)
+            .saturating_mul(1000)
+            .checked_div((self.sample_rate as u64) * (self.num_channels as u64))
+            .unwrap_or(0);
+        let capture_timeout = std::time::Duration::from_millis(
+            queue_ms.saturating_mul(CAPTURE_COMPLETE_TIMEOUT_QUEUE_MULTIPLE),
+        )
+        .max(CAPTURE_COMPLETE_TIMEOUT_FLOOR);
+
         // iterate over chunks of self._queue_size_samples
         for chunk in frame.data.chunks(self.queue_size_samples as usize) {
             let nb_frames = chunk.len() / self.num_channels as usize;
@@ -161,7 +183,9 @@ impl NativeAudioSource {
             let ctx_ptr = Box::into_raw(ctx) as *const sys_at::SourceContext;
 
             unsafe {
-                // In the fast path, C++ never store / invoke on_complete / ctx.
+                // C++ only takes ownership of `ctx` when capture_frame returns true; on a false
+                // return (buffer full, or a prior completion still pending) it has not, so reclaim
+                // the Box here to avoid leaking the Sender.
                 if !self.sys_handle.capture_frame(
                     chunk,
                     self.sample_rate,
@@ -170,6 +194,7 @@ impl NativeAudioSource {
                     ctx_ptr,
                     sys_at::CompleteCallback(lk_audio_source_complete),
                 ) {
+                    drop(Box::from_raw(ctx_ptr as *mut oneshot::Sender<()>));
                     return Err(RtcError {
                         error_type: RtcErrorType::InvalidState,
                         message: "failed to capture frame".to_owned(),
@@ -177,7 +202,18 @@ impl NativeAudioSource {
                 }
             }
 
-            let _ = rx.await;
+            // Bound the wait for the drain's completion (timeout rationale above). On a stall,
+            // clear_buffer() releases the pending completion so the source stays usable afterward.
+            match tokio::time::timeout(capture_timeout, rx).await {
+                Ok(_) => {}
+                Err(_) => {
+                    self.clear_buffer();
+                    return Err(RtcError {
+                        error_type: RtcErrorType::InvalidState,
+                        message: "audio capture timed out: source drain stalled".to_owned(),
+                    });
+                }
+            }
         }
 
         Ok(())

--- a/libwebrtc/src/native/audio_source.rs
+++ b/libwebrtc/src/native/audio_source.rs
@@ -183,9 +183,9 @@ impl NativeAudioSource {
             let ctx_ptr = Box::into_raw(ctx) as *const sys_at::SourceContext;
 
             unsafe {
-                // C++ only takes ownership of `ctx` when capture_frame returns true; on a false
-                // return (buffer full, or a prior completion still pending) it has not, so reclaim
-                // the Box here to avoid leaking the Sender.
+                // SAFETY: `ctx_ptr` comes from `Box::into_raw` above and is non-null and uniquely
+                // owned here. C++ only takes ownership of `ctx` when capture_frame returns true;
+                // on a false return it has not, so reclaiming the Box exactly once is sound.
                 if !self.sys_handle.capture_frame(
                     chunk,
                     self.sample_rate,

--- a/libwebrtc/src/native/drain_stall_tests.rs
+++ b/libwebrtc/src/native/drain_stall_tests.rs
@@ -118,6 +118,8 @@ mod stall {
             SAMPLE_RATE as i32,
             1,
         );
+        // SAFETY: `track` is an audio track created by `create_audio_track`, so downcasting its
+        // media-stream-track handle back to an `AudioTrack` is valid.
         let audio = unsafe { sys_at::ffi::media_to_audio(track.sys_handle()) };
         audio.add_sink(&native_sink);
 

--- a/libwebrtc/src/native/drain_stall_tests.rs
+++ b/libwebrtc/src/native/drain_stall_tests.rs
@@ -1,0 +1,167 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Regression tests for the buffered `NativeAudioSource::capture_frame` drain stall
+//! (rust-sdks #408 / #420 / #497): the C++ `AudioTrackSource` drain fires the per-chunk completion
+//! that `capture_frame` awaits. If the drain stops progressing — a sink blocked in `OnData`, or the
+//! drain TaskQueue CPU-starved — an unbounded await would wedge the producer (and any session built
+//! on it) forever.
+
+use crate::audio_frame::AudioFrame;
+use crate::audio_source::native::NativeAudioSource;
+use crate::audio_source::AudioSourceOptions;
+
+const SAMPLE_RATE: u32 = 48000;
+
+fn silent_frame<'a>(samples: usize) -> AudioFrame<'a> {
+    AudioFrame {
+        data: vec![0i16; samples].into(),
+        sample_rate: SAMPLE_RATE,
+        num_channels: 1,
+        samples_per_channel: samples as u32,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn capture_frame_completes_under_normal_backpressure() {
+    // The fix must not regress the healthy path. A large queue keeps the derived timeout far above
+    // the ~one-queue-duration a healthy deferral needs, so this asserts "no false-trip on legitimate
+    // backpressure" without coupling to the production floor (which would make it flaky on a loaded
+    // CI runner). No sink/track is created, so this is safe on every platform.
+    const QUEUE_MS: u32 = 1000;
+    let q = (SAMPLE_RATE / 1000 * QUEUE_MS) as usize;
+    let source = NativeAudioSource::new(AudioSourceOptions::default(), SAMPLE_RATE, 1, QUEUE_MS);
+
+    for i in 0..3u32 {
+        // q + q/2 forces a deferral (completion routed through the drain) every call.
+        source
+            .capture_frame(&silent_frame(q + q / 2))
+            .await
+            .unwrap_or_else(|e| panic!("healthy capture {i} failed: {e:?}"));
+    }
+}
+
+// The stall reproducer needs a real audio track, which requires a `PeerConnectionFactory`. On
+// macOS/Windows that brings up the platform AudioDeviceModule, whose real-time audio thread aborts
+// the process when the test's blocking sink stalls it. The Linux CI webrtc build has no such device
+// backend, so the reproducer runs there and is deterministic. The fix itself is platform-independent
+// and the healthy-path test above runs everywhere. This test also creates a factory, so — like the
+// sibling factory tests — it relies on serial execution (CI runs `--test-threads=1`).
+#[cfg(target_os = "linux")]
+mod stall {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::mpsc;
+    use webrtc_sys::audio_track as sys_at;
+
+    use super::{silent_frame, SAMPLE_RATE};
+    use crate::audio_source::native::NativeAudioSource;
+    use crate::audio_source::AudioSourceOptions;
+    use crate::peer_connection_factory::native::PeerConnectionFactoryExt;
+    use crate::peer_connection_factory::PeerConnectionFactory;
+    use crate::RtcErrorType;
+
+    /// A sink whose `on_data` blocks the C++ 10ms drain task, modelling a wedged/starved consumer.
+    /// It signals `entered` on its first call (so the test awaits the stall instead of sleeping for
+    /// it) and unblocks when `released` is set.
+    struct BlockingSink {
+        entered: mpsc::UnboundedSender<()>,
+        released: Arc<AtomicBool>,
+    }
+
+    impl sys_at::AudioSink for BlockingSink {
+        fn on_data(
+            &self,
+            _data: &[i16],
+            _sample_rate: i32,
+            _num_channels: usize,
+            _num_frames: usize,
+        ) {
+            let _ = self.entered.send(());
+            while !self.released.load(Ordering::Acquire) {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+        }
+    }
+
+    // worker_threads = 2: one for the (on a revert, possibly-wedged) capture task, one for the timeout.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn capture_frame_recovers_when_drain_stalls() {
+        const QUEUE_MS: u32 = 200;
+        let q = (SAMPLE_RATE / 1000 * QUEUE_MS) as usize;
+
+        let factory = PeerConnectionFactory::default();
+        let source =
+            NativeAudioSource::new(AudioSourceOptions::default(), SAMPLE_RATE, 1, QUEUE_MS);
+        let track = factory.create_audio_track("drain-stall", source.clone());
+
+        let (entered_tx, mut entered_rx) = mpsc::unbounded_channel();
+        let released = Arc::new(AtomicBool::new(false));
+        let native_sink = sys_at::ffi::new_native_audio_sink(
+            Box::new(sys_at::AudioSinkWrapper::new(Arc::new(BlockingSink {
+                entered: entered_tx,
+                released: released.clone(),
+            }))),
+            SAMPLE_RATE as i32,
+            1,
+        );
+        let audio = unsafe { sys_at::ffi::media_to_audio(track.sys_handle()) };
+        audio.add_sink(&native_sink);
+
+        // Wait until the drain is actually stalled inside the sink (bounded, so a wiring regression
+        // fails the test cleanly instead of hanging the CI job).
+        tokio::time::timeout(Duration::from_secs(5), entered_rx.recv())
+            .await
+            .expect("drain never entered the sink within 5s")
+            .expect("sink signal channel closed");
+
+        // Feed 2x the queue so the second chunk must wait on the (now stalled) drain.
+        let src = source.clone();
+        let mut handle = tokio::spawn(async move { src.capture_frame(&silent_frame(q * 2)).await });
+
+        // Outer bound distinguishes "returned" from "hung", well above the fix's own timeout.
+        let res = tokio::time::timeout(Duration::from_secs(8), &mut handle).await;
+
+        // Release the drain regardless, so teardown and the recovery check below can proceed.
+        released.store(true, Ordering::Release);
+        if res.is_err() {
+            let _ = handle.await;
+        }
+
+        match res {
+            Ok(Ok(Err(e))) => {
+                assert_eq!(e.error_type, RtcErrorType::InvalidState);
+                assert!(
+                    e.message.contains("source drain stalled"),
+                    "unexpected error: {}",
+                    e.message
+                );
+            }
+            other => {
+                panic!("capture_frame should return an error on a stalled drain, got: {other:?}")
+            }
+        }
+
+        // The stall must leave the source usable: the timeout path releases the pending completion
+        // rather than poisoning the slot, so a fresh capture succeeds once the drain is unstuck.
+        tokio::time::timeout(Duration::from_secs(5), source.capture_frame(&silent_frame(q)))
+            .await
+            .expect("recovery capture hung")
+            .expect("source did not recover after the stall cleared");
+
+        audio.remove_sink(&native_sink);
+    }
+}

--- a/libwebrtc/src/native/mod.rs
+++ b/libwebrtc/src/native/mod.rs
@@ -23,6 +23,8 @@ pub mod audio_track;
 pub mod data_channel;
 #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 pub mod desktop_capturer;
+#[cfg(test)]
+mod drain_stall_tests;
 pub mod frame_cryptor;
 pub mod ice_candidate;
 pub mod media_stream;

--- a/webrtc-sys/include/livekit/audio_track.h
+++ b/webrtc-sys/include/livekit/audio_track.h
@@ -133,17 +133,24 @@ class AudioTrackSource {
     bool is_external_source() const { return true; }
 
    private:
-    mutable webrtc::Mutex mutex_;
+    // Split lock. `sink_mutex_` guards `sinks_` and is held across the drain's OnData loop, so a
+    // wedged or slow sink blocks only AddSink/RemoveSink — never the producer — while still
+    // preventing a sink from being freed mid-OnData. `buffer_mutex_` guards the producer and
+    // completion state, so capture_frame never contends with a sink.
+    mutable webrtc::Mutex sink_mutex_;
+    mutable webrtc::Mutex buffer_mutex_;
     std::unique_ptr<webrtc::TaskQueueBase, webrtc::TaskQueueDeleter> audio_queue_;
     webrtc::RepeatingTaskHandle audio_task_;
 
-    std::vector<webrtc::AudioTrackSinkInterface*> sinks_ RTC_GUARDED_BY(mutex_);
-    std::vector<int16_t> buffer_ RTC_GUARDED_BY(mutex_);
+    std::vector<webrtc::AudioTrackSinkInterface*> sinks_ RTC_GUARDED_BY(sink_mutex_);
+    std::vector<int16_t> buffer_ RTC_GUARDED_BY(buffer_mutex_);
 
-    const SourceContext* capture_userdata_ RTC_GUARDED_BY(mutex_);
-    void (*on_complete_)(const SourceContext*) RTC_GUARDED_BY(mutex_);
+    const SourceContext* capture_userdata_ RTC_GUARDED_BY(buffer_mutex_);
+    void (*on_complete_)(const SourceContext*) RTC_GUARDED_BY(buffer_mutex_);
 
     std::vector<int16_t> silence_buffer_;
+    // Reusable 10ms scratch owned solely by the single-threaded drain task (no lock needed).
+    std::vector<int16_t> scratch_;
 
     int sample_rate_ = 0;
     int num_channels_ = 0;

--- a/webrtc-sys/src/audio_track.cpp
+++ b/webrtc-sys/src/audio_track.cpp
@@ -154,34 +154,49 @@ AudioTrackSource::InternalSource::InternalSource(
                                                     // using x2 the queue size
   buffer_.reserve(queue_size_samples_ + notify_threshold_samples_);
 
-  audio_queue_ =
-      task_queue_factory->CreateTaskQueue(
-          "AudioSourceCapture", webrtc::TaskQueueFactory::Priority::NORMAL);
+  audio_queue_ = task_queue_factory->CreateTaskQueue(
+      "AudioSourceCapture", webrtc::TaskQueueFactory::Priority::NORMAL);
 
   audio_task_ = webrtc::RepeatingTaskHandle::Start(
       audio_queue_.get(),
       [this, samples10ms]() {
-        webrtc::MutexLock lock(&mutex_);
         constexpr int kBitsPerSample = sizeof(int16_t) * 8;
 
-        if (buffer_.size() >= samples10ms) {
-          for (auto sink : sinks_)
-            sink->OnData(buffer_.data(), kBitsPerSample, sample_rate_,
-                         num_channels_, samples10ms / num_channels_);
-
-          buffer_.erase(buffer_.begin(), buffer_.begin() + samples10ms);
-        } else {
-          // Always provide a 10ms frame to avoid playout underruns.
-          for (auto sink : sinks_)
-            sink->OnData(silence_buffer_.data(), kBitsPerSample, sample_rate_,
-                         num_channels_, samples10ms / num_channels_);
+        // Take the 10ms frame and any pending completion under buffer_mutex_, then run
+        // sink->OnData() under sink_mutex_ and fire the completion with no lock held. Keeping
+        // OnData off buffer_mutex_ means a wedged or slow sink can never block capture_frame;
+        // keeping it under sink_mutex_ means a sink cannot be freed (via RemoveSink) mid-call.
+        // scratch_ is reused across ticks (this task is the only thread that touches it) to avoid
+        // a per-10ms allocation on the audio path.
+        void (*complete)(const SourceContext*) = nullptr;
+        const SourceContext* complete_ctx = nullptr;
+        {
+          webrtc::MutexLock lock(&buffer_mutex_);
+          scratch_.resize(samples10ms);
+          if (buffer_.size() >= static_cast<size_t>(samples10ms)) {
+            std::copy(buffer_.begin(), buffer_.begin() + samples10ms, scratch_.begin());
+            buffer_.erase(buffer_.begin(), buffer_.begin() + samples10ms);
+          } else {
+            // Always provide a 10ms frame to avoid playout underruns.
+            std::copy(silence_buffer_.begin(), silence_buffer_.end(), scratch_.begin());
+          }
+          if (on_complete_ && buffer_.size() <= notify_threshold_samples_) {
+            complete = on_complete_;
+            complete_ctx = capture_userdata_;
+            on_complete_ = nullptr;
+            capture_userdata_ = nullptr;
+          }
         }
 
-        if (on_complete_ && buffer_.size() <= notify_threshold_samples_) {
-          on_complete_(capture_userdata_);
-          on_complete_ = nullptr;
-          capture_userdata_ = nullptr;
+        {
+          webrtc::MutexLock lock(&sink_mutex_);
+          for (auto sink : sinks_)
+            sink->OnData(scratch_.data(), kBitsPerSample, sample_rate_, num_channels_,
+                         samples10ms / num_channels_);
         }
+
+        if (complete)
+          complete(complete_ctx);
 
         return webrtc::TimeDelta::Millis(10);
       },
@@ -198,9 +213,8 @@ bool AudioTrackSource::InternalSource::capture_frame(
     size_t number_of_frames,
     const SourceContext* ctx,
     void (*on_complete)(const SourceContext*)) {
-  webrtc::MutexLock lock(&mutex_);
-
   if (queue_size_samples_) {
+    webrtc::MutexLock lock(&buffer_mutex_);
     int available =
         (queue_size_samples_ + notify_threshold_samples_) - buffer_.size();
     if (available < data.size())
@@ -217,9 +231,9 @@ bool AudioTrackSource::InternalSource::capture_frame(
       on_complete_ = on_complete;
       capture_userdata_ = ctx;
     }
-
   } else {
     // Fast path: capture directly when the queue buffer is 0 (frame size must be 10ms)
+    webrtc::MutexLock lock(&sink_mutex_);
     for (auto sink : sinks_)
       sink->OnData(data.data(), sizeof(int16_t) * 8, sample_rate,
                    number_of_channels, number_of_frames);
@@ -229,8 +243,16 @@ bool AudioTrackSource::InternalSource::capture_frame(
 }
 
 void AudioTrackSource::InternalSource::clear_buffer() {
-  webrtc::MutexLock lock(&mutex_);
+  webrtc::MutexLock lock(&buffer_mutex_);
   buffer_.clear();
+  // Release any chunk still awaiting completion so the source is immediately reusable and its
+  // context is freed rather than leaked. Serialized with the drain via buffer_mutex_, so the
+  // completion fires at most once.
+  if (on_complete_) {
+    on_complete_(capture_userdata_);
+    on_complete_ = nullptr;
+    capture_userdata_ = nullptr;
+  }
 }
 
 webrtc::MediaSourceInterface::SourceState
@@ -243,25 +265,25 @@ bool AudioTrackSource::InternalSource::remote() const {
 }
 
 const webrtc::AudioOptions AudioTrackSource::InternalSource::options() const {
-  webrtc::MutexLock lock(&mutex_);
+  webrtc::MutexLock lock(&buffer_mutex_);
   return options_;
 }
 
 void AudioTrackSource::InternalSource::set_options(
     const webrtc::AudioOptions& options) {
-  webrtc::MutexLock lock(&mutex_);
+  webrtc::MutexLock lock(&buffer_mutex_);
   options_ = options;
 }
 
 void AudioTrackSource::InternalSource::AddSink(
     webrtc::AudioTrackSinkInterface* sink) {
-  webrtc::MutexLock lock(&mutex_);
+  webrtc::MutexLock lock(&sink_mutex_);
   sinks_.push_back(sink);
 }
 
 void AudioTrackSource::InternalSource::RemoveSink(
     webrtc::AudioTrackSinkInterface* sink) {
-  webrtc::MutexLock lock(&mutex_);
+  webrtc::MutexLock lock(&sink_mutex_);
   sinks_.erase(std::remove(sinks_.begin(), sinks_.end(), sink), sinks_.end());
 }
 

--- a/webrtc-sys/src/audio_track.cpp
+++ b/webrtc-sys/src/audio_track.cpp
@@ -149,6 +149,8 @@ AudioTrackSource::InternalSource::InternalSource(
   int samples10ms = sample_rate / 100 * num_channels;
 
   silence_buffer_.assign(samples10ms, 0);
+  // Sized once here; the drain reuses it every tick without reallocating.
+  scratch_.resize(samples10ms);
   queue_size_samples_ = queue_size_ms / 10 * samples10ms;
   notify_threshold_samples_ = queue_size_samples_;  // TODO: this is currently
                                                     // using x2 the queue size
@@ -166,13 +168,12 @@ AudioTrackSource::InternalSource::InternalSource(
         // sink->OnData() under sink_mutex_ and fire the completion with no lock held. Keeping
         // OnData off buffer_mutex_ means a wedged or slow sink can never block capture_frame;
         // keeping it under sink_mutex_ means a sink cannot be freed (via RemoveSink) mid-call.
-        // scratch_ is reused across ticks (this task is the only thread that touches it) to avoid
-        // a per-10ms allocation on the audio path.
+        // scratch_ is reused across ticks (this task is the only thread that touches it, and it is
+        // sized once in the constructor) to avoid a per-10ms allocation on the audio path.
         void (*complete)(const SourceContext*) = nullptr;
         const SourceContext* complete_ctx = nullptr;
         {
           webrtc::MutexLock lock(&buffer_mutex_);
-          scratch_.resize(samples10ms);
           if (buffer_.size() >= static_cast<size_t>(samples10ms)) {
             std::copy(buffer_.begin(), buffer_.begin() + samples10ms, scratch_.begin());
             buffer_.erase(buffer_.begin(), buffer_.begin() + samples10ms);
@@ -243,16 +244,23 @@ bool AudioTrackSource::InternalSource::capture_frame(
 }
 
 void AudioTrackSource::InternalSource::clear_buffer() {
-  webrtc::MutexLock lock(&buffer_mutex_);
-  buffer_.clear();
-  // Release any chunk still awaiting completion so the source is immediately reusable and its
-  // context is freed rather than leaked. Serialized with the drain via buffer_mutex_, so the
-  // completion fires at most once.
-  if (on_complete_) {
-    on_complete_(capture_userdata_);
+  // Snapshot any chunk still awaiting completion under buffer_mutex_ (serialized with the drain,
+  // so it fires at most once), then run it with no lock held — matching the drain path and
+  // avoiding a callback under the lock.
+  void (*complete)(const SourceContext*) = nullptr;
+  const SourceContext* complete_ctx = nullptr;
+  {
+    webrtc::MutexLock lock(&buffer_mutex_);
+    buffer_.clear();
+    complete = on_complete_;
+    complete_ctx = capture_userdata_;
     on_complete_ = nullptr;
     capture_userdata_ = nullptr;
   }
+  // Release the pending completion so the source is immediately reusable and its context is
+  // freed rather than leaked.
+  if (complete)
+    complete(complete_ctx);
 }
 
 webrtc::MediaSourceInterface::SourceState


### PR DESCRIPTION
### Before you submit your PR

- [x] I have read the [contributing guidelines](https://github.com/livekit/rust-sdks/blob/main/CONTRIBUTING.md) and validated that this PR will be accepted.
- [x] I have read and followed the principles regarding breaking changes, testing, and code quality.

### PR description

**Summary**

- Bound the buffered `NativeAudioSource::capture_frame` completion wait (scaled to the queue duration) so a stalled source drain returns a recoverable `RtcError` instead of hanging forever.
- Split the `AudioTrackSource::InternalSource` lock so the drain's `sink->OnData()` no longer runs under the same mutex as the producer — a wedged/slow sink can no longer block `capture_frame`, while a sink still cannot be freed mid-`OnData`.
- On a stall/`clear_buffer`, release the pending completion so the source stays usable; reclaim the completion context on the `false` return path (previously leaked).

**Problem**

A buffered native audio source (`queue_size_ms > 0`, the default used by `livekit-agents`' `_ParticipantAudioOutput`) can hang `capture_frame` forever, silently killing outbound audio while the room still reports `Connected`. Reported repeatedly and worked around locally, never fixed upstream:

- **#408** "capture_frame never completes" — reporter pinpointed it: *"the buffer never becomes un-full and thus we block forever"*.
- **#420** "Capture Frame Consistently Hang Audio Output" — *"highly temperamental to load … the multi-threaded, task-switching nature … GC playing a role"*.
- **#497** "Capture frame failed" — Python agents: *"TTS is lost … on long stories voice just stops"*.

**Root cause**

The buffered source is a producer/consumer pair across the FFI:

- **Consumer** — `webrtc-sys/src/audio_track.cpp`, `AudioTrackSource::InternalSource`: a 10 ms `RepeatingTask` drains the buffer, pushes 10 ms to each sink via `sink->OnData(...)`, and — only when it runs — fires the deferred completion for the chunk that filled the buffer past the notify threshold.
- **Producer** — `libwebrtc/src/native/audio_source.rs`, `NativeAudioSource::capture_frame`: for each chunk it hands C++ a `oneshot::Sender` and `rx.await`s that completion **with no timeout**.

The drain held `mutex_` across the entire `OnData` loop. So when the drain is slow or CPU-starved, it is almost always holding the lock, and the producer's synchronous FFI `capture_frame` blocks acquiring that same mutex — often before it even reaches the awaited completion. Either way, `capture_frame` never returns: `_wait_for_playout` never completes, generation tasks pile up, and the session goes permanently mute while ICE stays connected.

**Fix**

- **`audio_track.cpp` / `audio_track.h` — split the lock.** `sink_mutex_` guards `sinks_` and is held across the `OnData` loop; `buffer_mutex_` guards the buffer and completion state. The producer (`capture_frame`) only ever takes `buffer_mutex_`, so a wedged/slow sink can no longer block it — while `RemoveSink` still serializes against an in-flight `OnData`, so a sink cannot be freed mid-call. The drain copies the 10 ms frame into a reused scratch buffer (no per-tick allocation).
- **`audio_source.rs` — bound the wait.** `rx.await` → `tokio::time::timeout(...)`, scaled to the queue duration (`5 × queue_ms`, floored at 1 s) so legitimate backpressure never trips it. On timeout, `clear_buffer()` and return `RtcError { InvalidState }`.
- **Keep the source usable + no leak.** `clear_buffer()` now also releases any pending completion (freeing its context and clearing the slot), so a fresh `capture_frame` succeeds after a stall clears rather than erroring forever. The `false`-return path now reclaims the boxed `Sender` it previously leaked.

The timeout and the lock split are coupled: with the drain holding the mutex across `OnData`, the producer blocks in the FFI before the await, so bounding the await alone would be dead code in exactly the scenario it targets.

### Breaking changes

None. `capture_frame` gains a recoverable `RtcError` for the stall case, replacing an unobservable permanent hang; callers already handle `capture_frame` errors.

### MSRV

Unchanged.

### Testing

`libwebrtc/src/native/drain_stall_tests.rs`, exercised by the standard `cargo test`:

- **`capture_frame_recovers_when_drain_stalls`** — attaches a sink whose `OnData` blocks (a deterministic stalled consumer) to a real `AudioTrackSource`, feeds `capture_frame`, asserts it returns the drain-stall `RtcError` (bounded so a wiring regression fails cleanly rather than hanging CI), then — after the stall clears — asserts a fresh `capture_frame` succeeds (the source is not poisoned). Gated to Linux: it needs a real audio track, and on macOS/Windows that brings up the platform AudioDeviceModule, whose real-time thread aborts the process when the blocking sink stalls it. The fix is platform-independent.
- **`capture_frame_completes_under_normal_backpressure`** — runs on every platform (no track/sink); with the drain running, deferred captures complete `Ok`, confirming the timeout does not false-trip on legitimate backpressure. Uses a large queue so the assertion is not coupled to the production floor.

Verified on a real webrtc build: stock hangs; timeout-without-lock-split still hangs (producer wedged on the mutex); the combined fix returns an error in ~1 s and the source recovers; the full `libwebrtc` lib suite passes.

### Async

The bounded wait is the fix itself; the test also uses `tokio::time::timeout` to detect a hang, mirroring the existing `renegotiation_does_not_deadlock` test, and subscribes to a channel signalled the instant the drain enters the sink rather than sleeping for it.

### Out of scope (deferred)

`capture_frame` remains a synchronous FFI call that can block its caller's task while the drain catches up; a fuller change might make the enqueue non-blocking (or run it off the async runtime). This PR keeps that shape and only ensures the wait is bounded and the lock no longer couples the producer to a wedged sink.
