### PR TITLE
[CI experiment — do not merge] baseline flake-rate measurement

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -10,3 +10,5 @@ max_width = 100
 use_small_heuristics = "Max"
 # Workaround for https://github.com/rust-lang/rust.vim/issues/464
 edition = "2021"
+
+# CI experiment: baseline flake-rate measurement (no functional change)


### PR DESCRIPTION
Part of a CI bisect for the flaky `test_audio` sine-frequency failure (see #1293 for the investigation). This PR exists only to measure the flake rate under a controlled condition — **do not merge**. It will be closed once enough runs have accumulated.

**Condition:** unmodified main (control group).