### PR TITLE
[CI experiment — do not merge] e2e test rooms use dual peer connections

### DIFF
--- a/livekit/tests/common/e2e/mod.rs
+++ b/livekit/tests/common/e2e/mod.rs
@@ -55,10 +55,10 @@ pub struct TestRoomOptions {
 
 impl Default for TestRoomOptions {
     fn default() -> Self {
-        Self {
-            grants: VideoGrants { room_join: true, ..Default::default() },
-            room: Default::default(),
-        }
+        // CI experiment: revert to dual peer connections to test whether the
+        // test_audio flake correlates with the single-PC default (#1206).
+        let room = RoomOptions { single_peer_connection: false, ..Default::default() };
+        Self { grants: VideoGrants { room_join: true, ..Default::default() }, room }
     }
 }
 

--- a/livekit/tests/common/e2e/mod.rs
+++ b/livekit/tests/common/e2e/mod.rs
@@ -57,7 +57,10 @@ impl Default for TestRoomOptions {
     fn default() -> Self {
         // CI experiment: revert to dual peer connections to test whether the
         // test_audio flake correlates with the single-PC default (#1206).
-        let room = RoomOptions { single_peer_connection: false, ..Default::default() };
+        // RoomOptions is #[non_exhaustive], so mutate instead of using a
+        // struct expression.
+        let mut room = RoomOptions::default();
+        room.single_peer_connection = false;
         Self { grants: VideoGrants { room_join: true, ..Default::default() }, room }
     }
 }


### PR DESCRIPTION
Part of a CI bisect for the flaky `test_audio` sine-frequency failure (see #1293 for the investigation). This PR exists only to measure the flake rate under a controlled condition — **do not merge**. It will be closed once enough runs have accumulated.

**Condition:** `TestRoomOptions::default()` sets `single_peer_connection: false`, reverting e2e tests to the pre-#1206 connection topology (single PC became the default on 2026-07-01, shortly before the flake appeared).