### PR TITLE
fix nvenc SetRate

### DIFF
--- a/.changeset/fix_nvenc_dynamic_bitrate_updates.md
+++ b/.changeset/fix_nvenc_dynamic_bitrate_updates.md
@@ -1,0 +1,9 @@
+---
+webrtc-sys: patch
+libwebrtc: patch
+livekit: patch
+livekit-ffi: patch
+---
+
+Fix H.264, H.265, and AV1 NVENC sessions so live bitrate and frame rate updates
+reconfigure the hardware without restarting the encoder.

--- a/webrtc-sys/src/nvidia/NvCodec/NvCodec/NvEncoder/NvEncoder.cpp
+++ b/webrtc-sys/src/nvidia/NvCodec/NvCodec/NvEncoder/NvEncoder.cpp
@@ -11,6 +11,9 @@
 
 #include "NvEncoder.h"
 
+#include <algorithm>
+#include <limits>
+
 #if defined(WIN32)
 #include <windows.h>
 #else
@@ -668,12 +671,15 @@ bool NvEncoder::Reconfigure(
   NVENC_API_CALL(m_nvenc.nvEncReconfigureEncoder(
       m_hEncoder, const_cast<NV_ENC_RECONFIGURE_PARAMS*>(pReconfigureParams)));
 
-  memcpy(&m_initializeParams, &(pReconfigureParams->reInitEncodeParams),
-         sizeof(m_initializeParams));
   if (pReconfigureParams->reInitEncodeParams.encodeConfig) {
     memcpy(&m_encodeConfig, pReconfigureParams->reInitEncodeParams.encodeConfig,
            sizeof(m_encodeConfig));
   }
+  memcpy(&m_initializeParams, &(pReconfigureParams->reInitEncodeParams),
+         sizeof(m_initializeParams));
+  m_initializeParams.encodeConfig =
+      pReconfigureParams->reInitEncodeParams.encodeConfig ? &m_encodeConfig
+                                                          : nullptr;
 
   m_nWidth = m_initializeParams.encodeWidth;
   m_nHeight = m_initializeParams.encodeHeight;
@@ -693,6 +699,8 @@ bool NvEncoder::SetRates(uint32_t frameRate, uint32_t averageBitrate) {
 
   NV_ENC_RECONFIGURE_PARAMS reconfigureParams = {};
   reconfigureParams.version = NV_ENC_RECONFIGURE_PARAMS_VER;
+  reconfigureParams.resetEncoder = 0;
+  reconfigureParams.forceIDR = 0;
 
   NV_ENC_CONFIG encodeConfig = {};
   encodeConfig.version = NV_ENC_CONFIG_VER;
@@ -705,14 +713,15 @@ bool NvEncoder::SetRates(uint32_t frameRate, uint32_t averageBitrate) {
   reconfigureParams.reInitEncodeParams.frameRateDen = 1;
 
   encodeConfig.rcParams.averageBitRate = averageBitrate;
-  encodeConfig.rcParams.vbvBufferSize = (averageBitrate / frameRate) * 5;
+  encodeConfig.rcParams.maxBitRate = averageBitrate;
+  const uint64_t vbvBufferSize =
+      static_cast<uint64_t>(averageBitrate) * 5 / frameRate;
+  encodeConfig.rcParams.vbvBufferSize = static_cast<uint32_t>(
+      std::min<uint64_t>(vbvBufferSize,
+                         std::numeric_limits<uint32_t>::max()));
   encodeConfig.rcParams.vbvInitialDelay = encodeConfig.rcParams.vbvBufferSize;
 
-  try {
-    return Reconfigure(&reconfigureParams);
-  } catch (const NVENCException&) {
-    return false;
-  }
+  return Reconfigure(&reconfigureParams);
 }
 
 NV_ENC_REGISTERED_PTR NvEncoder::RegisterResource(

--- a/webrtc-sys/src/nvidia/NvCodec/NvCodec/NvEncoder/NvEncoder.h
+++ b/webrtc-sys/src/nvidia/NvCodec/NvCodec/NvEncoder/NvEncoder.h
@@ -116,8 +116,8 @@ class NvEncoder {
 
   /**
    *  @brief  Dynamically updates the encode bitrate and framerate on the live
-   *  session. Returns false if the encoder is not initialized or reconfigure
-   *  fails.
+   *  session. Returns false if the encoder is not initialized and throws
+   *  NVENCException if reconfiguration fails.
    */
   bool SetRates(uint32_t frameRate, uint32_t averageBitrate);
 

--- a/webrtc-sys/src/nvidia/av1_encoder_impl.cpp
+++ b/webrtc-sys/src/nvidia/av1_encoder_impl.cpp
@@ -438,31 +438,39 @@ void NvidiaAV1EncoderImpl::SetRates(
     return;
   }
 
-  if (parameters.framerate_fps < 1.0) {
+  if (!std::isfinite(parameters.framerate_fps) ||
+      parameters.framerate_fps < 1.0) {
     RTC_LOG(LS_WARNING) << "Invalid frame rate: " << parameters.framerate_fps;
     return;
   }
 
-  if (parameters.bitrate.get_sum_bps() == 0) {
+  const uint32_t target_bps = parameters.bitrate.get_sum_bps();
+  if (target_bps == 0) {
     configuration_.SetStreamState(false);
     return;
   }
 
-  codec_.maxFramerate = static_cast<uint32_t>(parameters.framerate_fps);
-  codec_.maxBitrate = parameters.bitrate.GetSpatialLayerSum(0);
-
-  configuration_.target_bps = parameters.bitrate.GetSpatialLayerSum(0);
-  configuration_.max_frame_rate = parameters.framerate_fps;
-
-  if (!encoder_->SetRates(codec_.maxFramerate, configuration_.target_bps)) {
-    RTC_LOG(LS_WARNING) << "Failed to reconfigure NVENC rates.";
+  const uint32_t frame_rate = static_cast<uint32_t>(std::clamp(
+      std::round(parameters.framerate_fps), 1.0,
+      static_cast<double>(std::numeric_limits<uint32_t>::max())));
+  try {
+    if (!encoder_->SetRates(frame_rate, target_bps)) {
+      RTC_LOG(LS_WARNING) << "Failed to reconfigure NVENC rates: encoder is "
+                             "not initialized.";
+      return;
+    }
+  } catch (const NVENCException& e) {
+    RTC_LOG(LS_WARNING) << "Failed to reconfigure NVENC rates to "
+                        << target_bps << " bps @ " << frame_rate
+                        << " fps: " << e.what();
+    return;
   }
 
-  if (configuration_.target_bps) {
-    configuration_.SetStreamState(true);
-  } else {
-    configuration_.SetStreamState(false);
-  }
+  codec_.maxFramerate = frame_rate;
+  codec_.maxBitrate = target_bps / 1000;
+  configuration_.target_bps = target_bps;
+  configuration_.max_frame_rate = frame_rate;
+  configuration_.SetStreamState(true);
 }
 
 void NvidiaAV1EncoderImpl::LayerConfig::SetStreamState(bool send_stream) {

--- a/webrtc-sys/src/nvidia/h264_encoder_impl.cpp
+++ b/webrtc-sys/src/nvidia/h264_encoder_impl.cpp
@@ -423,31 +423,39 @@ void NvidiaH264EncoderImpl::SetRates(
     return;
   }
 
-  if (parameters.framerate_fps < 1.0) {
+  if (!std::isfinite(parameters.framerate_fps) ||
+      parameters.framerate_fps < 1.0) {
     RTC_LOG(LS_WARNING) << "Invalid frame rate: " << parameters.framerate_fps;
     return;
   }
 
-  if (parameters.bitrate.get_sum_bps() == 0) {
+  const uint32_t target_bps = parameters.bitrate.get_sum_bps();
+  if (target_bps == 0) {
     configuration_.SetStreamState(false);
     return;
   }
 
-  codec_.maxFramerate = static_cast<uint32_t>(parameters.framerate_fps);
-  codec_.maxBitrate = parameters.bitrate.GetSpatialLayerSum(0);
-
-  configuration_.target_bps = parameters.bitrate.GetSpatialLayerSum(0);
-  configuration_.max_frame_rate = parameters.framerate_fps;
-
-  if (!encoder_->SetRates(codec_.maxFramerate, configuration_.target_bps)) {
-    RTC_LOG(LS_WARNING) << "Failed to reconfigure NVENC rates.";
+  const uint32_t frame_rate = static_cast<uint32_t>(std::clamp(
+      std::round(parameters.framerate_fps), 1.0,
+      static_cast<double>(std::numeric_limits<uint32_t>::max())));
+  try {
+    if (!encoder_->SetRates(frame_rate, target_bps)) {
+      RTC_LOG(LS_WARNING) << "Failed to reconfigure NVENC rates: encoder is "
+                             "not initialized.";
+      return;
+    }
+  } catch (const NVENCException& e) {
+    RTC_LOG(LS_WARNING) << "Failed to reconfigure NVENC rates to "
+                        << target_bps << " bps @ " << frame_rate
+                        << " fps: " << e.what();
+    return;
   }
 
-  if (configuration_.target_bps) {
-    configuration_.SetStreamState(true);
-  } else {
-    configuration_.SetStreamState(false);
-  }
+  codec_.maxFramerate = frame_rate;
+  codec_.maxBitrate = target_bps / 1000;
+  configuration_.target_bps = target_bps;
+  configuration_.max_frame_rate = frame_rate;
+  configuration_.SetStreamState(true);
 }
 
 void NvidiaH264EncoderImpl::LayerConfig::SetStreamState(bool send_stream) {

--- a/webrtc-sys/src/nvidia/h265_encoder_impl.cpp
+++ b/webrtc-sys/src/nvidia/h265_encoder_impl.cpp
@@ -344,31 +344,39 @@ void NvidiaH265EncoderImpl::SetRates(
     return;
   }
 
-  if (parameters.framerate_fps < 1.0) {
+  if (!std::isfinite(parameters.framerate_fps) ||
+      parameters.framerate_fps < 1.0) {
     RTC_LOG(LS_WARNING) << "Invalid frame rate: " << parameters.framerate_fps;
     return;
   }
 
-  if (parameters.bitrate.get_sum_bps() == 0) {
+  const uint32_t target_bps = parameters.bitrate.get_sum_bps();
+  if (target_bps == 0) {
     configuration_.SetStreamState(false);
     return;
   }
 
-  codec_.maxFramerate = static_cast<uint32_t>(parameters.framerate_fps);
-  codec_.maxBitrate = parameters.bitrate.GetSpatialLayerSum(0);
-
-  configuration_.target_bps = parameters.bitrate.GetSpatialLayerSum(0);
-  configuration_.max_frame_rate = parameters.framerate_fps;
-
-  if (!encoder_->SetRates(codec_.maxFramerate, configuration_.target_bps)) {
-    RTC_LOG(LS_WARNING) << "Failed to reconfigure NVENC rates.";
+  const uint32_t frame_rate = static_cast<uint32_t>(std::clamp(
+      std::round(parameters.framerate_fps), 1.0,
+      static_cast<double>(std::numeric_limits<uint32_t>::max())));
+  try {
+    if (!encoder_->SetRates(frame_rate, target_bps)) {
+      RTC_LOG(LS_WARNING) << "Failed to reconfigure NVENC rates: encoder is "
+                             "not initialized.";
+      return;
+    }
+  } catch (const NVENCException& e) {
+    RTC_LOG(LS_WARNING) << "Failed to reconfigure NVENC rates to "
+                        << target_bps << " bps @ " << frame_rate
+                        << " fps: " << e.what();
+    return;
   }
 
-  if (configuration_.target_bps) {
-    configuration_.SetStreamState(true);
-  } else {
-    configuration_.SetStreamState(false);
-  }
+  codec_.maxFramerate = frame_rate;
+  codec_.maxBitrate = target_bps / 1000;
+  configuration_.target_bps = target_bps;
+  configuration_.max_frame_rate = frame_rate;
+  configuration_.SetStreamState(true);
 }
 
 void NvidiaH265EncoderImpl::LayerConfig::SetStreamState(bool send_stream) {
@@ -379,4 +387,3 @@ void NvidiaH265EncoderImpl::LayerConfig::SetStreamState(bool send_stream) {
 }
 
 }  // namespace webrtc
-


### PR DESCRIPTION
NVENC SetRate was not properly updating encoder bitrate.  Fix H.264, H.265, and AV1 NVENC sessions so live bitrate and frame rate updates reconfigure the hardware without restarting the encoder.

Tested on Linux/Nvidia GPU