### PR TITLE
fix(uniffi): repair Android package build and release-tag checkout

### DIFF
--- a/.changeset/fix_uniffi_android_package_build.md
+++ b/.changeset/fix_uniffi_android_package_build.md
@@ -1,0 +1,5 @@
+---
+livekit-uniffi: patch
+---
+
+Fix the Android AAR build. Two cargo-make bugs kept `cargo make --profile release android-package` from ever producing a release artifact: the per-arch tasks' `env = { TARGET = ... }` replaced (rather than merged) the parent env map, dropping the `--release` flag, and the `TARGET` they set leaked into the Kotlin bindgen's host build, which then cross-compiled with the host linker. Also raise the Swift and Android size budgets to match the binaries as they stand since the data-track UniFFI surface landed, and check out the released tag rather than the dispatch ref when building the wrapper packages.

--- a/.github/actions/uniffi-deps/action.yml
+++ b/.github/actions/uniffi-deps/action.yml
@@ -5,8 +5,3 @@ runs:
     - name: Install cargo-make
       uses: taiki-e/install-action@682e7d9e49c5e653d371fc6adbda67653461378a # v2.82.4
       with: { tool: cargo-make@0.37 }
-    - name: Install tera-cli
-      uses: taiki-e/install-action@682e7d9e49c5e653d371fc6adbda67653461378a # v2.82.4
-      with: { tool: tera-cli@0.5.0 }
-    # ^ This would be installed by the cargo-make file automatically, but this ensures
-    # it is already available and downloads binary distribution (no need to build from source).

--- a/.github/workflows/uniffi-android.yml
+++ b/.github/workflows/uniffi-android.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          # Build the tagged source, not the dispatch ref (which defaults to main).
+          ref: ${{ inputs.tag_name }}
           submodules: recursive
 
       - name: Setup Rust toolchain

--- a/.github/workflows/uniffi-swift.yml
+++ b/.github/workflows/uniffi-swift.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          # Build the tagged source, not the dispatch ref (which defaults to main).
+          ref: ${{ inputs.tag_name }}
           submodules: recursive
 
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0

--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -64,15 +64,23 @@ ANDROID_AAR_BASENAME = "livekit-uniffi-android-release"
 extend = "android-shared"
 install_crate = { crate_name = "cargo-ndk", binary = "cargo-ndk", test_arg = "--help" }
 script_runner = "@shell"
+# The profile switch lives in the script, not in [tasks.build-android.env]: the
+# per-arch tasks below set `env = { TARGET = ... }`, and cargo-make's `extend`
+# *replaces* the env map instead of merging it — anything declared here would be
+# silently dropped, producing a debug .so under `--profile release`.
 script = """
 echo "TARGET: ${TARGET}"
 rustup target add "${TARGET}"
-cargo ndk --target "${TARGET}" build ${ANDROID_RELEASE_FLAG}
-"""
 
-[tasks.build-android.env]
-ANDROID_RELEASE_FLAG = { value = "--release", condition = { profiles = ["release"] } }
-RUSTFLAGS = { value = "-C force-unwind-tables=no", condition = { profiles = ["release"] } }
+release_flag=""
+if [ "${CARGO_MAKE_PROFILE}" = "release" ]; then
+  release_flag="--release"
+  # panic = "abort" in release, so unwind tables are dead weight.
+  export RUSTFLAGS="-C force-unwind-tables=no"
+fi
+
+cargo ndk --target "${TARGET}" build ${release_flag}
+"""
 
 # MARK: - Build, specific platforms
 
@@ -378,7 +386,7 @@ echo
 # are ~2× larger by construction (two archs in one Mach-O) and shouldn't be
 # the metric. Override the limit per release with SPM_SIZE_LIMIT_BYTES.
 [tasks.swift-check-size.env]
-SPM_SIZE_LIMIT_BYTES = { value = "723467", condition = { env_not_set = ["SPM_SIZE_LIMIT_BYTES"] } }
+SPM_SIZE_LIMIT_BYTES = { value = "1179648", condition = { env_not_set = ["SPM_SIZE_LIMIT_BYTES"] } }
 
 [tasks.swift-check-size]
 private = true
@@ -541,7 +549,7 @@ run_task = "swift-package-flow"
 # during assemble; the raw target/ artifact is larger and not what ships).
 # Override the limit per release with ANDROID_SIZE_LIMIT_BYTES.
 [tasks.android-check-size.env]
-ANDROID_SIZE_LIMIT_BYTES = { value = "877918", condition = { env_not_set = ["ANDROID_SIZE_LIMIT_BYTES"] } }
+ANDROID_SIZE_LIMIT_BYTES = { value = "1310720", condition = { env_not_set = ["ANDROID_SIZE_LIMIT_BYTES"] } }
 
 [tasks.android-check-size]
 extend = "android-shared"
@@ -612,11 +620,23 @@ cp "${aar}" "${out_dir}/"
 echo "AAR: ${out_dir}/${ANDROID_AAR_BASENAME}.aar"
 """
 
+# Library-mode bindgen reads UNIFFI_META_* symbols from a cdylib, so it needs a
+# *host* one — but cargo-make env vars leak across tasks, so the TARGET set by
+# the preceding per-arch Android builds would otherwise make `build` cross-
+# compile (with the host linker: "cannot find -llog"). Pin TARGET back to the
+# host, and keep symbols: the release profile's `strip = "symbols"` removes the
+# metadata on Linux. Same wrapper pattern as `bindgen-dart` — a task's own env
+# only applies once its dependencies run, hence run_task.
+[tasks.android-bindgen-kotlin]
+private = true
+env = { TARGET = "${CARGO_MAKE_RUST_TARGET_TRIPLE}", CARGO_PROFILE_RELEASE_STRIP = "false" }
+run_task = "bindgen-kotlin"
+
 [tasks.android-package-flow]
 private = true
 dependencies = [
     "build-android-platforms",
-    "bindgen-kotlin",
+    "android-bindgen-kotlin",
     "android-copy-jniLibs",
     "android-assemble",
     "android-check-size",


### PR DESCRIPTION
- build-android-*: cargo-make's `extend` replaces the parent env map rather than merging it, so `env = { TARGET = ... }` silently dropped ANDROID_RELEASE_FLAG and RUSTFLAGS — `--profile release` produced debug .so files and android-copy-jniLibs found nothing in target/*/release. Derive the flag from CARGO_MAKE_PROFILE in the script instead.
- android-bindgen-kotlin: TARGET leaks across cargo-make tasks, so bindgen-kotlin's `build` dependency cross-compiled for Android with the host linker ("cannot find -llog"). Pin TARGET back to the host triple and keep symbols, which library-mode bindgen needs on Linux.
- Raise both size gates to measured values: ios-arm64 is 1088 KiB and arm64-v8a 1174 KiB, having grown past the limits set in #1171 when the data-track UniFFI surface landed in #1034.
- Check out inputs.tag_name in both reusable workflows; workflow_dispatch was building the dispatch ref (main) rather than the requested tag.

### Before you submit your PR

Make sure the following is true before submitting your PR:

- [ ] I have read the [contributing guidelines](https://github.com/livekit/rust-sdks/blob/main/CONTRIBUTING.md) and validated that this PR will be accepted.
- [ ] I have read and followed the principles regarding breaking changes, testing, and code quality.

### PR description

Describe the changes in this PR. Explain what the PR is meant to solve and how to reproduce the issue in the first place.

### Breaking changes

If this PR introduces breaking changes, list them here and document the rationale for introducing such a change.

### MSRV

If the PR modifies the crate's MSRV (Minimum Supported Rust Version), document it here.

### Testing

Ideally, unit test the code you add, but ensure you're not repeating existing test cases. Use as many already written scaffolding, utilities as possible; write your own, when needed. If external services, APIs, tokens are required (e.g., running an LK server instance), provide the necessary information. Make sure your tests perform useful, context-aware assertions and do not simply emulate "happy paths".

### Async

We want the project to be runtime-agnostic, so please reuse what's already in [livekit-runtime](https://github.com/livekit/rust-sdks/blob/main/livekit-runtime/) and feel free to add anything missing. It's ok to use Tokio directly, when writing unit tests, if necessary. When testing, do not use artificial delays for the state to "catch up"; instead, respect the event flow and subscribe properly using channels or other mechanisms.


