### PR TITLE
Add livekit-common to knope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "livekit-common"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "livekit-protocol",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ livekit = { version = "0.8.1", path = "livekit" }
 livekit-api = { version = "0.6.1", path = "livekit-api" }
 livekit-ffi = { version = "0.12.73", path = "livekit-ffi" }
 livekit-datatrack = { version = "0.1.13", path = "livekit-datatrack" }
-livekit-common = { version = "0.1.0", path = "livekit-common" }
+livekit-common = { version = "0.1.1", path = "livekit-common" }
 livekit-data-stream = { version = "0.1.1", path = "livekit-data-stream" }
 livekit-net = { version = "0.1.2", path = "livekit-net" }
 livekit-protocol = { version = "0.7.12", path = "livekit-protocol" }

--- a/knope.toml
+++ b/knope.toml
@@ -150,6 +150,14 @@ versioned_files = [
 ]
 changelog = "livekit-datatrack/CHANGELOG.md"
 
+[packages.livekit-common]
+versioned_files = [
+  "livekit-common/Cargo.toml",
+  "Cargo.lock",
+  { path = "Cargo.toml", dependency = "livekit-common" },
+]
+changelog = "livekit-common/CHANGELOG.md"
+
 [packages.livekit-data-stream]
 versioned_files = [
   "livekit-data-stream/Cargo.toml",

--- a/livekit-common/Cargo.toml
+++ b/livekit-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "livekit-common"
 description = "Common foundational types shared across LiveKit crates"
-version = "0.1.0"
+version = "0.1.1"
 readme = "README.md"
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
When adding `livekit-common` in https://github.com/livekit/rust-sdks/pull/1227, I missed adding it to the `knope.toml`. What that looks like it meant in practice is the initial crate publish succeeded, but once the next update occurred to this crate it wasn't tracked properly by knope and further updates weren't pushed.

Caveat: I don't have a super strong grasp on how knope is set up in this repo.

Fixes #1302 