### PR TITLE
fix(CI): gate changeset action on unmanaged crates

### DIFF
--- a/.github/scripts/changeset_detect.py
+++ b/.github/scripts/changeset_detect.py
@@ -35,6 +35,8 @@ Output (JSON on stdout):
     "present":           [[pkg, bump], ...], # bumps already in the changeset
     "missing":           [pkg, ...],         # required packages not yet covered
     "invalid":           [{...}, ...],       # bump lines in a format knope would ignore
+    "unmanaged":         [pkg, ...],         # publishable crates missing from knope.toml
+    "stale":             [pkg, ...],         # knope.toml entries with no workspace crate
     "changeset_content": str,               # a changeset prefilled with `missing`
   }
 """
@@ -204,6 +206,38 @@ def detect(meta, knope_packages, changed_files, present):
     }
 
 
+def is_publishable(pkg):
+    """True unless the crate opts out of publishing with `publish = false`.
+
+    `cargo metadata` encodes the manifest's `publish` field as: `null` (default,
+    publishable to any registry), `[]` (`publish = false`), or a list of allowed
+    registry names. Only the empty list means "never published".
+    """
+    return pkg.get("publish") != []
+
+
+def reconcile_knope_config(meta, knope_packages):
+    """Find drift between the Cargo workspace and knope.toml.
+
+    Returns (unmanaged, stale):
+      unmanaged  publishable workspace crates absent from knope.toml. These
+                 silently escape changeset enforcement and are never released.
+                 Fix by adding a `[packages.<name>]` block, or by setting
+                 `publish = false` if the crate isn't meant to ship.
+      stale      knope.toml package names with no matching workspace crate
+                 (e.g. a renamed or removed crate leaving a dangling entry).
+
+    Note the rule is one-directional: publishable implies knope-managed, but a
+    knope-managed crate may set `publish = false` (e.g. livekit-ffi / livekit-
+    uniffi, which CI publishes via wrapper packages rather than `cargo publish`).
+    """
+    workspace_names = {pkg["name"] for pkg in meta["packages"]}
+    publishable = {pkg["name"] for pkg in meta["packages"] if is_publishable(pkg)}
+    unmanaged = sorted(publishable - knope_packages)
+    stale = sorted(knope_packages - workspace_names)
+    return unmanaged, stale
+
+
 def load_cargo_metadata():
     """Fetch workspace metadata (--no-deps avoids network access)."""
     return json.loads(subprocess.check_output(
@@ -227,12 +261,14 @@ def main():
             "direct": [], "downstream": [], "required": [],
             "present": sorted(present.items()), "missing": [],
             "invalid": invalid,
+            "unmanaged": [], "stale": [],
             "changeset_content": "",
         })
         return  # emit calls sys.exit, but guard against falling through
 
     result = detect(meta, knope_packages, changed_files, present)
     result["invalid"] = invalid
+    result["unmanaged"], result["stale"] = reconcile_knope_config(meta, knope_packages)
     emit(result)
 
 

--- a/.github/scripts/test_changeset_detect.py
+++ b/.github/scripts/test_changeset_detect.py
@@ -29,23 +29,28 @@ import unittest
 import changeset_detect as cd
 
 
-def make_meta(packages, deps, workspace_root="/ws"):
+def make_meta(packages, deps, workspace_root="/ws", publish=None):
     """Build a fake `cargo metadata` document.
 
     packages: {name -> relative dir}
     deps:     {name -> [dependency names]}
+    publish:  {name -> publish value}, mirroring cargo metadata's `publish`
+              field (`[]` for `publish = false`, a list for restricted
+              registries). Names omitted here get no `publish` key, i.e. the
+              default publishable-to-any-registry state.
     """
-    return {
-        "workspace_root": workspace_root,
-        "packages": [
-            {
-                "name": name,
-                "manifest_path": f"{workspace_root}/{rel}/Cargo.toml",
-                "dependencies": [{"name": d} for d in deps.get(name, [])],
-            }
-            for name, rel in packages.items()
-        ],
-    }
+    publish = publish or {}
+    pkgs = []
+    for name, rel in packages.items():
+        entry = {
+            "name": name,
+            "manifest_path": f"{workspace_root}/{rel}/Cargo.toml",
+            "dependencies": [{"name": d} for d in deps.get(name, [])],
+        }
+        if name in publish:
+            entry["publish"] = publish[name]
+        pkgs.append(entry)
+    return {"workspace_root": workspace_root, "packages": pkgs}
 
 
 # A small synthetic workspace:
@@ -218,6 +223,48 @@ class TestDetect(unittest.TestCase):
         self.assertIn("b: patch", r["changeset_content"])
         self.assertIn("c: patch", r["changeset_content"])
         self.assertNotIn("a-sys", r["changeset_content"])
+
+
+class TestReconcile(unittest.TestCase):
+    def test_publishable_crate_missing_from_knope_is_unmanaged(self):
+        # Both crates are publishable (no `publish` key); only `a` is in knope.
+        meta = make_meta({"a": "a", "b": "b"}, {})
+        unmanaged, stale = cd.reconcile_knope_config(meta, {"a"})
+        self.assertEqual(unmanaged, ["b"])
+        self.assertEqual(stale, [])
+
+    def test_publish_false_crate_not_required_in_knope(self):
+        # An example crate (publish = false) need not be knope-managed.
+        meta = make_meta({"a": "a", "ex": "examples/ex"}, {}, publish={"ex": []})
+        unmanaged, stale = cd.reconcile_knope_config(meta, {"a"})
+        self.assertEqual(unmanaged, [])
+        self.assertEqual(stale, [])
+
+    def test_publish_false_crate_may_still_be_knope_managed(self):
+        # e.g. livekit-ffi: publish = false but released via CI, so it's in
+        # knope. This must not be flagged as stale.
+        meta = make_meta({"ffi": "ffi"}, {}, publish={"ffi": []})
+        unmanaged, stale = cd.reconcile_knope_config(meta, {"ffi"})
+        self.assertEqual(unmanaged, [])
+        self.assertEqual(stale, [])
+
+    def test_restricted_registry_is_still_publishable(self):
+        meta = make_meta({"a": "a"}, {}, publish={"a": ["crates-io"]})
+        unmanaged, stale = cd.reconcile_knope_config(meta, set())
+        self.assertEqual(unmanaged, ["a"])
+        self.assertEqual(stale, [])
+
+    def test_stale_knope_entry_with_no_matching_crate(self):
+        meta = make_meta({"a": "a"}, {})
+        unmanaged, stale = cd.reconcile_knope_config(meta, {"a", "ghost"})
+        self.assertEqual(unmanaged, [])
+        self.assertEqual(stale, ["ghost"])
+
+    def test_both_directions_at_once(self):
+        meta = make_meta({"a": "a", "b": "b"}, {})
+        unmanaged, stale = cd.reconcile_knope_config(meta, {"a", "ghost"})
+        self.assertEqual(unmanaged, ["b"])
+        self.assertEqual(stale, ["ghost"])
 
 
 class TestBuildChangesetContent(unittest.TestCase):

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -126,6 +126,46 @@ jobs:
             exit 1
           fi
 
+          # --- Gate: knope.toml must stay in sync with the workspace ---
+          # A publishable crate missing from knope.toml silently escapes changeset
+          # enforcement and is never released; a knope entry with no matching crate
+          # is dangling config. Either is a release-pipeline bug, so fail hard until
+          # the config is reconciled. This runs before the "no versioned packages"
+          # early-out below because a brand-new unmanaged crate maps to no knope
+          # package and would otherwise slip through as "nothing affected".
+          NUM_UNMANAGED=$(echo "$DETECTION" | jq '.unmanaged | length')
+          NUM_STALE=$(echo "$DETECTION" | jq '.stale | length')
+          if [ "$NUM_UNMANAGED" != "0" ] || [ "$NUM_STALE" != "0" ]; then
+            COMMENT_BODY=$(
+              echo "$COMMENT_MARKER"
+              echo "### knope.toml is out of sync with the workspace"
+              echo ""
+              if [ "$NUM_UNMANAGED" != "0" ]; then
+                UNMANAGED_LIST=$(echo "$DETECTION" | jq -r '.unmanaged[] | "- `\(.)`"')
+                echo "These publishable crates are **not** managed by knope, so they would never get a changeset requirement or a release:"
+                echo ""
+                echo "$UNMANAGED_LIST"
+                echo ""
+                echo "Fix each one by **either**:"
+                echo "- adding a \`[packages.<name>]\` block to \`knope.toml\` (if it should be released), **or**"
+                echo "- setting \`publish = false\` in its \`Cargo.toml\` (if it should not)."
+                echo ""
+              fi
+              if [ "$NUM_STALE" != "0" ]; then
+                STALE_LIST=$(echo "$DETECTION" | jq -r '.stale[] | "- `\(.)`"')
+                echo "These \`knope.toml\` packages have no matching workspace crate (renamed or removed?):"
+                echo ""
+                echo "$STALE_LIST"
+                echo ""
+                echo "Remove the stale \`[packages.<name>]\` block(s) from \`knope.toml\`."
+                echo ""
+              fi
+            )
+            upsert_comment "$COMMENT_BODY" || echo "::warning::Could not post PR comment (this can happen for fork PRs with limited permissions)"
+            echo "::error::knope.toml is out of sync with the workspace (unmanaged: ${NUM_UNMANAGED}, stale: ${NUM_STALE}). See the PR comment for details."
+            exit 1
+          fi
+
           # --- If no versioned packages are affected, no changeset is required ---
           NUM_REQUIRED=$(echo "$DETECTION" | jq '.required | length')
           if [ "$NUM_REQUIRED" = "0" ]; then

--- a/knope.toml
+++ b/knope.toml
@@ -173,3 +173,11 @@ versioned_files = [
   { path = "Cargo.toml", dependency = "device-info" },
 ]
 changelog = "device-info/CHANGELOG.md"
+
+[packages.livekit-runtime]
+versioned_files = [
+  "livekit-runtime/Cargo.toml",
+  "Cargo.lock",
+  { path = "Cargo.toml", dependency = "livekit-runtime" },
+]
+changelog = "livekit-runtime/CHANGELOG.md"


### PR DESCRIPTION
The changeset check derived its list of packages from `knope.toml` alone. A
crate that wasn't listed there was invisible to the whole release pipeline: no
changeset was ever required for it, and knope never released it. Nothing noticed
when a new publishable crate was added to the workspace but not wired into
`knope.toml`.

This adds a reconciliation gate between the Cargo workspace and `knope.toml`,
using the `publish` field from `cargo metadata` as the source of truth.

### Changes

- **`changeset_detect.py`**: new `reconcile_knope_config()` that reports two
  lists:
  - `unmanaged` — publishable crates (not `publish = false`) missing from
    `knope.toml`.
  - `stale` — `knope.toml` entries with no matching workspace crate (e.g. a
    renamed or removed crate).

  The rule is one-directional: a publishable crate must be knope-managed, but a
  knope-managed crate may set `publish = false` (e.g. `livekit-ffi` /
  `livekit-uniffi`, which CI publishes via wrapper packages).
- **`changeset-check.yml`**: fails the check with an explanatory PR comment when
  either list is non-empty. Each unmanaged crate must be fixed by adding a
  `[packages.<name>]` block, or by setting `publish = false`. Runs before the
  "no versioned packages affected" early-out so a brand-new crate can't slip
  through as "nothing affected".
- **`knope.toml`**: registers `livekit-runtime`, which the new gate surfaced as
  a pre-existing gap — it is publishable but was never knope-managed.
- **`test_changeset_detect.py`**: tests covering unmanaged, stale,
  `publish = false` exclusion, knope-managed `publish = false`, and restricted
  registries.

