### PR TITLE
livekit-ffi migration, phase 0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,6 +763,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgens"
+version = "0.1.0"
+dependencies = [
+ "uniffi",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4056,6 +4063,7 @@ dependencies = [
  "soxr-sys",
  "thiserror 2.0.19",
  "tokio",
+ "uniffi",
  "webrtc-sys",
  "webrtc-sys-build",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "livekit-net",
     "livekit-runtime",
     "livekit-wakeword",
+    "tools/bindgens",
     "libwebrtc",
     "soxr-sys",
     "yuv-sys",

--- a/livekit-ffi/Cargo.toml
+++ b/livekit-ffi/Cargo.toml
@@ -38,6 +38,7 @@ downcast-rs = "1.2"
 console-subscriber = { workspace = true, features = ["parking_lot"], optional = true }
 bytes = { workspace = true }
 from_variants = "1.0.2"
+uniffi = { workspace = true, features = ["scaffolding-ffi-buffer-fns"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.21.1"

--- a/livekit-ffi/src/build_info.rs
+++ b/livekit-ffi/src/build_info.rs
@@ -1,0 +1,34 @@
+// Copyright 2025 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Returns the version specified in the crate's Cargo.toml.
+///
+/// This is the first function exposed over UniFFI from `livekit-ffi`. It carries
+/// no server state and touches no handle store, so downstream SDKs can call it to
+/// prove the UniFFI bindgen toolchain is wired up end-to-end.
+#[uniffi::export]
+pub fn build_version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_version;
+
+    #[test]
+    fn build_version_matches_cargo_pkg_version() {
+        assert_eq!(build_version(), env!("CARGO_PKG_VERSION"));
+        assert!(!build_version().is_empty());
+    }
+}

--- a/livekit-ffi/src/lib.rs
+++ b/livekit-ffi/src/lib.rs
@@ -20,9 +20,12 @@ use thiserror::Error;
 
 mod conversion;
 
+pub mod build_info;
 pub mod cabi;
 pub mod proto;
 pub mod server;
+
+uniffi::setup_scaffolding!();
 
 #[derive(Error, Debug)]
 pub enum FfiError {

--- a/tools/bindgens/Cargo.toml
+++ b/tools/bindgens/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "bindgens"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Foreign-binding generator CLIs for the LiveKit Rust crates"
+publish = false
+
+# Tooling crate: each bin is a code-generation CLI shared across the workspace's
+# uniffi-exposing crates (livekit-ffi, livekit-uniffi, ...). It has no library
+# target — the bindgens read metadata from an already-compiled cdylib via
+# `--library`, so they never depend on the crates they generate for.
+[dependencies]
+uniffi = { workspace = true, features = ["cli"] }

--- a/tools/bindgens/src/bin/uniffi-bindgen.rs
+++ b/tools/bindgens/src/bin/uniffi-bindgen.rs
@@ -1,0 +1,22 @@
+// Copyright 2025 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The UniFFI bindgen CLI, shared across the workspace.
+//!
+//! Generate bindings from any compiled uniffi cdylib, e.g.:
+//! `cargo run -p bindgens --bin uniffi-bindgen -- generate \
+//!     --library target/debug/liblivekit_ffi.dylib --language python --out-dir <dir>`
+fn main() {
+    uniffi::uniffi_bindgen_main()
+}


### PR DESCRIPTION
This PR introduces uniffi to the `livekit-ffi` crate, and the smallest possible additional functionality.

This corresponds to Phase 0 of the plan documented [here](https://app.notion.com/p/livekit/Livekit-FFI-C-ABI-Uniffi-migration-3ac3c4901a4280b8bbddd67b4ae0db20).

### Before you submit your PR

Make sure the following is true before submitting your PR:

- [ ] I have read the [contributing guidelines](https://github.com/livekit/rust-sdks/blob/main/CONTRIBUTING.md) and validated that this PR will be accepted.
- [ ] I have read and followed the principles regarding breaking changes, testing, and code quality.

### PR description

Describe the changes in this PR. Explain what the PR is meant to solve and how to reproduce the issue in the first place.

### Breaking changes

If this PR introduces breaking changes, list them here and document the rationale for introducing such a change.

### MSRV

If the PR modifies the crate's MSRV (Minimum Supported Rust Version), document it here.

### Testing

Ideally, unit test the code you add, but ensure you're not repeating existing test cases. Use as many already written scaffolding, utilities as possible; write your own, when needed. If external services, APIs, tokens are required (e.g., running an LK server instance), provide the necessary information. Make sure your tests perform useful, context-aware assertions and do not simply emulate "happy paths".

### Async

We want the project to be runtime-agnostic, so please reuse what's already in [livekit-runtime](https://github.com/livekit/rust-sdks/blob/main/livekit-runtime/) and feel free to add anything missing. It's ok to use Tokio directly, when writing unit tests, if necessary. When testing, do not use artificial delays for the state to "catch up"; instead, respect the event flow and subscribe properly using channels or other mechanisms.


