### PR TITLE
fix(uniffi): publish livekit_datatrack.swift with the Swift package

### DIFF
--- a/.github/workflows/uniffi-swift.yml
+++ b/.github/workflows/uniffi-swift.yml
@@ -97,6 +97,7 @@ jobs:
             ${{ env.OUTPUT_DIR }}/LICENSE:LICENSE
             ${{ env.OUTPUT_DIR }}/PrivacyInfo.xcprivacy:PrivacyInfo.xcprivacy
             ${{ env.OUTPUT_DIR }}/Sources/${{ env.SPM_NAME }}/livekit_uniffi.swift:Sources/${{ env.SPM_NAME }}/livekit_uniffi.swift
+            ${{ env.OUTPUT_DIR }}/Sources/${{ env.SPM_NAME }}/livekit_datatrack.swift:Sources/${{ env.SPM_NAME }}/livekit_datatrack.swift
           token: ${{ secrets.UNIFFI_XCFRAMEWORK_PAT }}
           pr-body: |
             Source tag: `${{ inputs.tag_name }}`


### PR DESCRIPTION
The Swift package build generates one bindings file per UniFFI component, but the publish step's hardcoded file list only carried `livekit_uniffi.swift` — `livekit_datatrack.swift` was silently dropped. The published package (v0.1.8, livekit-uniffi-xcframework#14) references data-track types that are never defined and fails to compile; verified by building the `release/0.1.8` package against the draft xcframework (fails), then adding the bindings file generated at the same tag (builds clean). The Android AAR is unaffected — Kotlin sources are compiled as a directory, and the 0.1.8 AAR on Maven Central already contains both components. The v0.1.8 release itself was repaired by hand-adding the tag-generated bindings to livekit-uniffi-xcframework#14; this fix keeps future releases from regressing.