### PR TITLE
Route unmatched H264 formats to platform decoder factories

### DIFF
--- a/webrtc-sys/src/video_decoder_factory.cpp
+++ b/webrtc-sys/src/video_decoder_factory.cpp
@@ -125,6 +125,25 @@ std::unique_ptr<webrtc::VideoDecoder> VideoDecoderFactory::Create(
           return factory->Create(env, adjusted);
       }
     }
+
+    // Still no match: the profile-level-id differs from everything the
+    // platform factories advertise (e.g. the SFU sends Baseline 42001f but
+    // VideoToolbox only lists 42e01f/640c1f). Hardware decoders handle
+    // Baseline/Main/High regardless of the exact fmtp they advertise, so
+    // relax the profile too and create from the factory's own advertised
+    // format rather than falling through to the internal FFmpeg decoder,
+    // which desktop builds may not be able to initialize.
+    for (const auto& factory : factories_) {
+      for (const auto& sf : factory->GetSupportedFormats()) {
+        if (!absl::EqualsIgnoreCase(sf.name, webrtc::kH264CodecName))
+          continue;
+        RTC_LOG(LS_INFO) << "No exact H264 decoder match for "
+                         << format.ToString()
+                         << ", creating platform decoder with "
+                         << sf.ToString();
+        return factory->Create(env, sf);
+      }
+    }
   }
 
   if (absl::EqualsIgnoreCase(format.name, webrtc::kVp8CodecName))


### PR DESCRIPTION
The SFU now includes H.264 Baseline (42001f) in its default codec set and selects the forwarded codec from the subscriber's SDP. Create() matched platform factories with IsSameCodec, which is strict on profile-level-id; VideoToolbox only advertises 42e01f/640c1f, so 42001f fell through to the internal FFmpeg decoder, which desktop prebuilts cannot initialize (no H.264 codec compiled in) — every frame failed to decode and subscribers saw black video in a PLI loop.

Hardware decoders handle Baseline/Main/High regardless of the exact fmtp they advertise, so when no exact or packetization-mode-relaxed match exists, create the decoder from the platform factory's own advertised H.264 format instead of falling through.

Solving [issue description](https://claude.ai/code/artifact/b7ae7e12-a6ff-4c5f-9856-62c0ee962070?via=auto_preview) client side