### PR TITLE
Only advertise internal H264 decode formats if the decoder works

### DIFF
--- a/.changeset/only_advertise_internal_h264_decode_formats_if_the_decoder_w.md
+++ b/.changeset/only_advertise_internal_h264_decode_formats_if_the_decoder_w.md
@@ -1,0 +1,8 @@
+---
+libwebrtc: patch
+livekit: patch
+livekit-ffi: patch
+webrtc-sys: patch
+---
+
+Only advertise internal H264 decode formats if the decoder works - #1313 (@MaxHeimbrock)

--- a/webrtc-sys/include/livekit/video_decoder_factory.h
+++ b/webrtc-sys/include/livekit/video_decoder_factory.h
@@ -35,5 +35,6 @@ class VideoDecoderFactory : public webrtc::VideoDecoderFactory {
 
  private:
   std::vector<std::unique_ptr<webrtc::VideoDecoderFactory>> factories_;
+  bool internal_h264_decoder_works_ = false;
 };
 }  // namespace livekit_ffi

--- a/webrtc-sys/include/livekit/video_decoder_factory.h
+++ b/webrtc-sys/include/livekit/video_decoder_factory.h
@@ -35,6 +35,6 @@ class VideoDecoderFactory : public webrtc::VideoDecoderFactory {
 
  private:
   std::vector<std::unique_ptr<webrtc::VideoDecoderFactory>> factories_;
-  bool internal_h264_decoder_works_ = false;
+  const bool internal_h264_decoder_works_;
 };
 }  // namespace livekit_ffi

--- a/webrtc-sys/src/video_decoder_factory.cpp
+++ b/webrtc-sys/src/video_decoder_factory.cpp
@@ -41,6 +41,24 @@
 
 namespace livekit_ffi {
 
+namespace {
+// H264Decoder::IsSupported() only reflects the WEBRTC_USE_H264 build flag;
+// desktop prebuilts link an FFmpeg without the H.264 codec, which only
+// surfaces when Configure() fails at runtime ("FFmpeg H.264 decoder not
+// found"). Probe once so the SDP does not advertise decode support the
+// internal decoder cannot deliver.
+bool InternalH264DecoderWorks() {
+  if (!webrtc::H264Decoder::IsSupported())
+    return false;
+  auto decoder = webrtc::H264Decoder::Create();
+  if (!decoder)
+    return false;
+  webrtc::VideoDecoder::Settings settings;
+  settings.set_codec_type(webrtc::kVideoCodecH264);
+  return decoder->Configure(settings);
+}
+}  // namespace
+
 VideoDecoderFactory::VideoDecoderFactory() {
 #ifdef __APPLE__
   factories_.push_back(livekit_ffi::CreateObjCVideoDecoderFactory());
@@ -55,6 +73,12 @@ VideoDecoderFactory::VideoDecoderFactory() {
     factories_.push_back(std::make_unique<webrtc::NvidiaVideoDecoderFactory>());
   }
 #endif
+
+  internal_h264_decoder_works_ = InternalH264DecoderWorks();
+  if (!internal_h264_decoder_works_) {
+    RTC_LOG(LS_WARNING) << "Internal H264 decoder is unavailable, "
+                           "not advertising its formats";
+  }
 }
 
 std::vector<webrtc::SdpVideoFormat> VideoDecoderFactory::GetSupportedFormats()
@@ -71,9 +95,11 @@ std::vector<webrtc::SdpVideoFormat> VideoDecoderFactory::GetSupportedFormats()
   for (const webrtc::SdpVideoFormat& format :
        webrtc::SupportedVP9DecoderCodecs())
     formats.push_back(format);
-  for (const webrtc::SdpVideoFormat& h264_format :
-       webrtc::SupportedH264DecoderCodecs())
-    formats.push_back(h264_format);
+  if (internal_h264_decoder_works_) {
+    for (const webrtc::SdpVideoFormat& h264_format :
+         webrtc::SupportedH264DecoderCodecs())
+      formats.push_back(h264_format);
+  }
 
   formats.push_back(webrtc::SdpVideoFormat(
       webrtc::SdpVideoFormat::AV1Profile0(),

--- a/webrtc-sys/src/video_decoder_factory.cpp
+++ b/webrtc-sys/src/video_decoder_factory.cpp
@@ -47,19 +47,30 @@ namespace {
 // surfaces when Configure() fails at runtime ("FFmpeg H.264 decoder not
 // found"). Probe once so the SDP does not advertise decode support the
 // internal decoder cannot deliver.
-bool InternalH264DecoderWorks() {
-  if (!webrtc::H264Decoder::IsSupported())
+bool IsInternalH264DecoderAvailable() {
+  if (!webrtc::H264Decoder::IsSupported()) {
+    RTC_LOG(LS_WARNING) << "Internal H264 decoder not compiled in "
+                           "(WEBRTC_USE_H264 off)";
     return false;
+  }
   auto decoder = webrtc::H264Decoder::Create();
-  if (!decoder)
+  if (!decoder) {
+    RTC_LOG(LS_WARNING) << "H264Decoder::Create() returned null";
     return false;
+  }
   webrtc::VideoDecoder::Settings settings;
   settings.set_codec_type(webrtc::kVideoCodecH264);
-  return decoder->Configure(settings);
+  if (!decoder->Configure(settings)) {
+    RTC_LOG(LS_WARNING) << "Internal H264 decoder failed to configure; "
+                           "FFmpeg likely lacks the H.264 codec";
+    return false;
+  }
+  return true;
 }
 }  // namespace
 
-VideoDecoderFactory::VideoDecoderFactory() {
+VideoDecoderFactory::VideoDecoderFactory()
+    : internal_h264_decoder_works_(IsInternalH264DecoderAvailable()) {
 #ifdef __APPLE__
   factories_.push_back(livekit_ffi::CreateObjCVideoDecoderFactory());
 #endif
@@ -74,7 +85,6 @@ VideoDecoderFactory::VideoDecoderFactory() {
   }
 #endif
 
-  internal_h264_decoder_works_ = InternalH264DecoderWorks();
   if (!internal_h264_decoder_works_) {
     RTC_LOG(LS_WARNING) << "Internal H264 decoder is unavailable, "
                            "not advertising its formats";
@@ -97,8 +107,9 @@ std::vector<webrtc::SdpVideoFormat> VideoDecoderFactory::GetSupportedFormats()
     formats.push_back(format);
   if (internal_h264_decoder_works_) {
     for (const webrtc::SdpVideoFormat& h264_format :
-         webrtc::SupportedH264DecoderCodecs())
+         webrtc::SupportedH264DecoderCodecs()) {
       formats.push_back(h264_format);
+    }
   }
 
   formats.push_back(webrtc::SdpVideoFormat(

--- a/webrtc-sys/src/video_decoder_factory.cpp
+++ b/webrtc-sys/src/video_decoder_factory.cpp
@@ -157,7 +157,8 @@ std::unique_ptr<webrtc::VideoDecoder> VideoDecoderFactory::Create(
     return webrtc::CreateVp8Decoder(env);
   if (absl::EqualsIgnoreCase(format.name, webrtc::kVp9CodecName))
     return webrtc::VP9Decoder::Create();
-  if (absl::EqualsIgnoreCase(format.name, webrtc::kH264CodecName))
+  if (absl::EqualsIgnoreCase(format.name, webrtc::kH264CodecName) &&
+      internal_h264_decoder_works_)
     return webrtc::H264Decoder::Create();
 
 


### PR DESCRIPTION
GetSupportedFormats() unconditionally appended SupportedH264DecoderCodecs(), so desktop clients claimed 42001f/42e01f decode support in their SDP even though the internal FFmpeg decoder cannot initialize on desktop prebuilts (H.264 codec not compiled in). The SFU then selected Baseline for those subscribers, producing undecodable streams.

H264Decoder::IsSupported() only reflects the WEBRTC_USE_H264 build flag — the missing FFmpeg codec surfaces first when Configure() fails at runtime. Probe Create()+Configure() once at factory construction and advertise the internal formats only when the probe succeeds. Platform-factory formats (VideoToolbox, MediaCodec, NVDEC) are unaffected.

Also gate the internal H264Decoder::Create() fallback in Create() on the same probe, so a format the platform factories reject yields a clear "No VideoDecoder found" error instead of a decoder that fails Configure() at runtime.

Solving [issue description](https://claude.ai/code/artifact/b7ae7e12-a6ff-4c5f-9856-62c0ee962070?via=auto_preview) client side