### PR TITLE
Setup trusted publishing

### DIFF
--- a/.github/scripts/check_crates_published.sh
+++ b/.github/scripts/check_crates_published.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright 2026 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Make sure that every publishable crate in the workspace exists on crates.io.
+# Trusted publishing cannot create a new crate. A new crate needs one manual
+# publish before the release runs.
+set -uo pipefail
+
+CRATES=$(cargo metadata --no-deps --format-version 1 \
+  | jq -r '.packages[] | select(.publish != []) | .name' | sort) || CRATES=""
+if [ -z "$CRATES" ]; then
+  echo "::error::Could not get the publishable crates from cargo metadata."
+  exit 1
+fi
+
+MISSING=()
+for crate in $CRATES; do
+  CODE=$(curl -sS --retry 2 -o /dev/null -w '%{http_code}' \
+    -A "livekit-rust-sdks-ci (github.com/livekit/rust-sdks)" \
+    "https://crates.io/api/v1/crates/${crate}")
+  case "$CODE" in
+    200) ;;
+    404) MISSING+=("$crate") ;;
+    *) echo "::error::crates.io returned HTTP ${CODE:-none} for '${crate}'."; exit 1 ;;
+  esac
+done
+
+if [ ${#MISSING[@]} -ne 0 ]; then
+  echo "::error::These crates are not on crates.io and need one manual publish before the release: ${MISSING[*]}"
+  exit 1
+fi
+
+echo "Every publishable crate exists on crates.io."

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -24,6 +24,16 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Trusted publishing cannot create a new crate (see release.yml). This check
+  # runs on the release PR, which is the last gate before publication.
+  check-crates-published:
+    name: Check crates exist on crates.io
+    if: github.head_ref == 'knope/release'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - run: .github/scripts/check_crates_published.sh
+
   check-changeset:
     name: Check for changeset
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,11 @@ jobs:
           cache: false
           rustflags: ""
 
+      # The release PR check (release-pr-check.yml) is the primary gate. This
+      # step also covers a workflow_dispatch run, which has no release PR.
+      - name: Check crates exist on crates.io
+        run: .github/scripts/check_crates_published.sh
+
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@30b5ca8b54e1dcffd9548bc87ede1531310fdc67 # v1.20.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,10 +37,14 @@ jobs:
       - name: Install cargo-release
         run: cargo binstall cargo-release@1.1.2 --no-confirm
 
+      - name: Authenticate with crates.io
+        id: crates-auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
       - name: Publish to crates.io
         run: cargo release publish --workspace --no-confirm --no-verify ${{ inputs.dry_run != true && '--execute' || '' }}
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-auth.outputs.token }}
 
   call-node-ffi:
     name: Call Node FFI Builds


### PR DESCRIPTION
The following crates are currently published to crates.io and have had [trusted publishing](https://crates.io/docs/trusted-publishing) configured:
- device-info
- imgproc 
- libwebrtc 
- livekit
- livekit-api 
- livekit-common
- livekit-data-stream 
- livekit-datatrack 
- livekit-net 
- livekit-protocol 
- livekit-runtime
- livekit-wakeword
- soxr-sys 
- webrtc-sys
- webrtc-sys-build 
- yuv-sys 

Note: when a new crate is added, it must also manually have trusted publishing enabled and published manually; subsequent releases will be handled by CI automatically.

Follow up: after the first successful release using trusted publishing, remove the `CARGO_TOKEN` from repo secrets and enable "Require trusted publishing for all new versions" for all crates.

Closes CLT-3231