### PR TITLE
add option to add simuclcast layers in trackpublishoptions

### DIFF
--- a/livekit-ffi/protocol/room.proto
+++ b/livekit-ffi/protocol/room.proto
@@ -305,6 +305,13 @@ message AudioEncoding {
   required uint64 max_bitrate = 1;
 }
 
+// A video preset describing a simulcast layer.
+message VideoPreset {
+  required uint32 width = 1;
+  required uint32 height = 2;
+  required VideoEncoding encoding = 3;
+} 
+
 message TrackPublishOptions {
   // encodings are optional
   optional VideoEncoding video_encoding = 1;

--- a/livekit-ffi/src/conversion/room.rs
+++ b/livekit-ffi/src/conversion/room.rs
@@ -20,7 +20,7 @@ use livekit::{
     },
     options::{
         AudioEncoding, DegradationPreference, FrameMetadataFeatures, TrackPublishOptions,
-        VideoEncoderBackend, VideoEncoding,
+        VideoEncoderBackend, VideoEncoding, VideoPreset,
     },
     prelude::*,
     webrtc::{
@@ -354,7 +354,11 @@ impl From<proto::TrackPublishOptions> for TrackPublishOptions {
             red: opts.red.unwrap_or(default_publish_options.red),
             simulcast: opts.simulcast.unwrap_or(default_publish_options.simulcast),
             stream: opts.stream.unwrap_or(default_publish_options.stream),
-            simulcast_layers: default_publish_options.simulcast_layers,
+            simulcast_layers: if opts.simulcast_layers.is_empty() {
+                opts.default_publish_options.simulcast_layers
+            } else {
+                Some(opts.simulcast_layers.into_iter().map(Into::into).collect())
+            },
             preconnect_buffer: opts
                 .preconnect_buffer
                 .unwrap_or(default_publish_options.preconnect_buffer),
@@ -378,6 +382,12 @@ impl From<proto::VideoEncoding> for VideoEncoding {
 impl From<proto::AudioEncoding> for AudioEncoding {
     fn from(opts: proto::AudioEncoding) -> Self {
         Self { max_bitrate: opts.max_bitrate }
+    }
+}
+
+impl From<proto::VideoPreset> for VideoPreset {
+    fn from(preset: proto::VideoPreset) -> Self {
+        Self { width: preset.width, height: preset.height, encoding: preset.encoding.into() }
     }
 }
 


### PR DESCRIPTION
### Before you submit your PR

Make sure the following is true before submitting your PR:

- [x] I have read the [contributing guidelines](https://github.com/livekit/rust-sdks/blob/main/CONTRIBUTING.md) and validated that this PR will be accepted.
- [x] I have read and followed the principles regarding breaking changes, testing, and code quality.

### PR description

Helps to add simulcast layers in livkit-ffi in trackpublishoptions during publishing of track, Fixes livekit/client-sdk-unity#176
### Breaking changes

no breaking change

### MSRV

no






