### PR TITLE
feat(livekit): add a stereo option to TrackPublishOptions

### DIFF
--- a/livekit-ffi/protocol/room.proto
+++ b/livekit-ffi/protocol/room.proto
@@ -326,6 +326,9 @@ message TrackPublishOptions {
   // Controls how the encoder trades off between resolution and framerate
   // when bandwidth is constrained. Default is MAINTAIN_RESOLUTION.
   optional DegradationPreference degradation_preference = 13;
+  // Publish an audio track as stereo. Required for the server to signal
+  // stereo=1 to the publisher and sprop-stereo=1 to subscribers.
+  optional bool stereo = 14;
 }
 
 enum VideoEncoderBackend {

--- a/livekit-ffi/src/conversion/room.rs
+++ b/livekit-ffi/src/conversion/room.rs
@@ -359,6 +359,7 @@ impl From<proto::TrackPublishOptions> for TrackPublishOptions {
             preconnect_buffer: opts
                 .preconnect_buffer
                 .unwrap_or(default_publish_options.preconnect_buffer),
+            stereo: opts.stereo.unwrap_or(default_publish_options.stereo),
             frame_metadata_features: frame_metadata_features_from_proto(
                 opts.frame_metadata_features,
             ),

--- a/livekit/src/room/options.rs
+++ b/livekit/src/room/options.rs
@@ -121,6 +121,10 @@ pub struct TrackPublishOptions {
     pub video_codec: VideoCodec,
     pub dtx: bool,
     pub red: bool,
+    /// Publish the audio track as stereo. The server only signals `stereo=1;maxaveragebitrate=510000`
+    /// to the publisher (and `sprop-stereo=1` to subscribers) when the track carries the
+    /// `TF_STEREO` audio feature, so stereo sources are otherwise downmixed to mono by the encoder.
+    pub stereo: bool,
     pub simulcast: bool,
     /// Custom simulcast layer presets (low, mid). When set, these override the
     /// SDK's built-in defaults which reduce fps on lower layers.
@@ -161,6 +165,7 @@ impl Default for TrackPublishOptions {
             video_codec: VideoCodec::VP8,
             dtx: true,
             red: true,
+            stereo: false,
             simulcast: true,
             simulcast_layers: None,
             source: TrackSource::Unknown,

--- a/livekit/src/room/participant/local_participant.rs
+++ b/livekit/src/room/participant/local_participant.rs
@@ -399,6 +399,11 @@ impl LocalParticipant {
             req.audio_features.push(proto::AudioTrackFeature::TfPreconnectBuffer as i32);
         }
 
+        if options.stereo && matches!(track, LocalTrack::Audio(_)) {
+            req.stereo = true;
+            req.audio_features.push(proto::AudioTrackFeature::TfStereo as i32);
+        }
+
         req.packet_trailer_features =
             options.frame_metadata_features.to_proto().into_iter().map(|f| f as i32).collect();
 


### PR DESCRIPTION
## Problem

An audio track published from this SDK is always encoded as mono, in speech mode, regardless of how many channels the `AudioSource` was created with or how high `audio_encoding.max_bitrate` is set.

The server decides stereo on the publisher side in `configurePublisherAnswer` (livekit/livekit, `pkg/rtc/participant_sdp.go`): it appends `stereo=1;maxaveragebitrate=510000` to the Opus `fmtp` line of the answer **only** when the track was published with the `TF_STEREO` audio feature, and strips `stereo=1` otherwise. It also gates `sprop-stereo=1` for subscribers on the same flag (`pkg/rtc/transport.go`, `configureSenderAudio`).

This SDK never sets that flag. `publish_track` fills `AddTrackRequest` with `disable_dtx` and the encodings, but nothing ever pushes `AudioTrackFeature::TfStereo` or sets `AddTrackRequest::stereo` — so the answer comes back without `stereo=1`, libwebrtc's Opus encoder downmixes to mono and selects speech mode, and subscribers negotiate a mono decoder.

The practical effect: a server-side music bot built on `@livekit/rtc-node` (which is this crate through the FFI) cannot publish stereo music at all. Raising `max_bitrate` does not help, because the encoder never learns it is sending stereo.

## Change

- Add `TrackPublishOptions::stereo`, defaulting to `false` so existing behaviour is unchanged.
- When an audio track is published with `stereo: true`, set `AddTrackRequest::stereo` and push `AudioTrackFeature::TfStereo`.
- Add the same `optional bool stereo` field to the FFI `TrackPublishOptions` message and map it in the conversion, so the Node and Python SDKs can opt in without another protocol change.

14 added lines, no behaviour change for callers that do not set the flag.

## Verification

`cargo check -p livekit` is clean on this branch.

I could not build `livekit-ffi` locally: `yuv-sys`'s build script needs the `libyuv` submodule contents, which my environment did not have. The FFI part of this diff is one proto field plus one line in `From<proto::TrackPublishOptions> for TrackPublishOptions` that mirrors the existing `preconnect_buffer` line, so I would appreciate CI confirming that half.

## Notes

Happy to adjust naming (`stereo` vs. mirroring the JS SDK's terminology), or to gate it behind the audio encoding options instead of a top-level flag, if you prefer a different shape.
