### PR TITLE
Close peer connections before awaiting signal teardown

### DIFF
--- a/.changeset/close_peer_connections_before_signal_teardown.md
+++ b/.changeset/close_peer_connections_before_signal_teardown.md
@@ -1,0 +1,12 @@
+---
+livekit: patch
+livekit-ffi: patch
+---
+
+# Close peer connections before awaiting signal teardown
+
+`SessionInner::close` released the peer connections only after two awaits that can block
+indefinitely, so cancelling `close()` — for example by wrapping it in a timeout — left the
+transports open and their ICE UDP sockets bound for the lifetime of the process. Long-lived
+clients eventually exhausted their file descriptors. The transports are now closed before
+the first await, which makes the teardown safe to cancel.

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -908,6 +908,14 @@ impl Room {
         self.inner.rtc_engine.drop_disconnected_updates(enabled);
     }
 
+    /// Test-only: the publisher transport's current connection state. Lets a test assert
+    /// that teardown really closed the transport, rather than inferring it from room-level
+    /// state that can reach `Disconnected` while the transport is still open.
+    #[cfg(feature = "__lk-e2e-test")]
+    pub fn publisher_connection_state(&self) -> libwebrtc::prelude::PeerConnectionState {
+        self.inner.rtc_engine.session().publisher_connection_state()
+    }
+
     pub async fn get_stats(&self) -> EngineResult<SessionStats> {
         self.inner.rtc_engine.get_stats().await
     }

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -845,6 +845,13 @@ impl RtcSession {
         self.inner.drop_disconnected_updates.store(enabled, Ordering::Release);
     }
 
+    /// Test-only: the publisher transport's current connection state, so tests can assert
+    /// that teardown actually closed it rather than inferring it from room-level state.
+    #[cfg(feature = "__lk-e2e-test")]
+    pub fn publisher_connection_state(&self) -> PeerConnectionState {
+        self.inner.publisher_pc.peer_connection().connection_state()
+    }
+
     pub async fn wait_pc_connection(&self) -> EngineResult<()> {
         self.inner.wait_pc_connection().await
     }
@@ -1981,6 +1988,15 @@ impl SessionInner {
         self.closed.store(true, Ordering::Release);
         self.pc_state_notify.notify_waiters();
 
+        // Both awaits below are unbounded, and `PeerTransport::close` is synchronous, so
+        // closing here — before the future can suspend — is what stops a cancelled
+        // `close()` leaving the ICE sockets bound for the process's lifetime. The
+        // signalling socket is unaffected, so the Leave below still goes out.
+        self.publisher_pc.close();
+        if let Some(ref sub_pc) = self.subscriber_pc {
+            sub_pc.close();
+        }
+
         self.signal_client
             .send(proto::signal_request::Message::Leave(proto::LeaveRequest {
                 action: proto::leave_request::Action::Disconnect.into(),
@@ -1990,10 +2006,6 @@ impl SessionInner {
             .await;
 
         self.signal_client.close().await;
-        self.publisher_pc.close();
-        if let Some(ref sub_pc) = self.subscriber_pc {
-            sub_pc.close();
-        }
     }
 
     async fn simulate_scenario(self: &Arc<Self>, scenario: SimulateScenario) -> EngineResult<()> {

--- a/livekit/tests/room_test.rs
+++ b/livekit/tests/room_test.rs
@@ -17,6 +17,7 @@ use {
     anyhow::{Ok, Result},
     chrono::{TimeDelta, TimeZone, Utc},
     common::test_rooms,
+    libwebrtc::prelude::PeerConnectionState,
     livekit::{ConnectionState, ParticipantKind, RoomEvent},
     std::time::Duration,
     tokio::time::{self, timeout},
@@ -87,5 +88,37 @@ async fn test_participant_disconnect() -> Result<()> {
         Ok(())
     };
     timeout(Duration::from_secs(15), wait_for_disconnected).await??;
+    Ok(())
+}
+
+/// A cancelled `close()` must still have closed the peer connections.
+///
+/// `SessionInner::close` ends with two unbounded awaits, so a caller bounding it with a
+/// timeout used to drop the future before the transports were closed — and nothing else
+/// closes them, so their ICE sockets stayed bound for the process's lifetime. Cancelling at
+/// the first `.await` makes this deterministic: the assertion holds only if the close ran
+/// before the future suspended.
+#[cfg(feature = "__lk-e2e-test")]
+#[test_log::test(tokio::test)]
+async fn test_cancelled_close_still_closes_peer_connections() -> Result<()> {
+    let (room, _) = test_rooms(1).await?.pop().unwrap();
+    assert_eq!(
+        room.publisher_connection_state(),
+        PeerConnectionState::Connected,
+        "publisher should be connected before teardown, or the assertion below proves nothing"
+    );
+
+    // Poll the close exactly once, then drop it. `Duration::ZERO` elapses on the first poll,
+    // so `timeout` yields `Err` the moment the inner future suspends — cancelling it at the
+    // earliest possible point rather than at some arbitrary later one.
+    let cancelled = timeout(Duration::ZERO, room.close()).await;
+    assert!(cancelled.is_err(), "close should have been cancelled at its first suspension point");
+
+    assert_eq!(
+        room.publisher_connection_state(),
+        PeerConnectionState::Closed,
+        "a cancelled close must not leave the publisher transport open: its ICE sockets are \
+         only released by PeerConnection::close, so anything else leaks them permanently"
+    );
     Ok(())
 }


### PR DESCRIPTION
### Before you submit your PR

Make sure the following is true before submitting your PR:

- [x] I have read the [contributing guidelines](https://github.com/livekit/rust-sdks/blob/main/CONTRIBUTING.md) and validated that this PR will be accepted.
- [x] I have read and followed the principles regarding breaking changes, testing, and code quality.

### PR description

Fixes https://github.com/livekit/rust-sdks/issues/1334

`SessionInner::close` closed the peer connections after two awaits that can block indefinitely:

```rust
self.signal_client.send(Leave { .. }).await;
self.signal_client.close().await;
self.publisher_pc.close();
```

`PeerConnection::close` is the only thing that releases a room's ICE UDP sockets, so a caller bounding `close()` with a timeout — a natural response to an unbounded API — dropped the future before it ran, and the sockets stayed bound for the process's lifetime. Nothing else releases them: `engine_task` and `room_task` own `Arc`s of the inner state and exit only on `close_rx`, so an un-closed room keeps the graph alive and the `PeerConnection` destructor never runs.

Both awaits really can park. `SignalStream::send` waits on the writer task, which does `conn.send(data).await` with no timeout, so a half-open socket blocks it until TCP gives up. `SignalStream::close` then joins that same task, and the `InternalMessage::Close` it queues sits behind the stuck message in a capacity-8 channel. Every timeout in `signal_client` is on the connect path.

This moves the peer-connection close above both awaits. `PeerTransport::close` is synchronous, so it has already run by the time the future first suspends. The signalling socket is unaffected, so the `Leave` still goes out.

Measured on aarch64 with a bare connect/close loop, counting `/proc/self/fd` socket inodes against `/proc/self/net/udp{,6}`:

| teardown | before | after |
| --- | --- | --- |
| `close()` cancelled | ~13 UDP/cycle | **0** |
| `close()` awaited | 0 | 0 |
| `Room` dropped, never closed | ~13 UDP/cycle | ~12 (unchanged) |

`Room`-dropped is deliberately untouched: that needs the spawned tasks stopped so the graph can drop, which is a larger change.

`client-sdk-js` already orders it this way — `RTCEngine.close()` closes the peer connections before the signal client.

### Breaking changes

None. Statement reorder inside a private `async fn`; no public API or behaviour change.

### MSRV

Unchanged.

### Testing

Adds `test_cancelled_close_still_closes_peer_connections` to `livekit/tests/room_test.rs`, using the existing `common::test_rooms` harness.

It cancels `close()` at its earliest suspension point (`timeout(Duration::ZERO, ..)` — tokio polls the inner future once before the elapsed timer fires) and asserts the publisher transport is `Closed`. That only holds if the transports were closed before the future suspended, so moving the close back below an await fails the test. It also asserts the publisher was `Connected` first, so it cannot pass vacuously.

Reading transport state needed a test-only accessor, following the existing `#[cfg(feature = "__lk-e2e-test")]` pattern on `Room`. Room-level state was not usable — a room can report `Disconnected` while its transport is still open, which is the bug.

Reverting only the reorder, keeping the test:

```
test test_cancelled_close_still_closes_peer_connections ... FAILED
  left: Connected
 right: Closed
```

With it restored, all four `room_test` cases pass. Run with `cargo test -p livekit --features __lk-e2e-test,rustls-tls-webpki-roots --test room_test`; a TLS feature is needed only because this ran against a `wss://` endpoint rather than a local `--dev` server.

I also ran the rest of the suite, each file serially, with and without the change. Nothing regressed: `dynacast_test` 3/0 both, `rpc_test` 6/0 both, `data_track_test` 11 passed/4 failed both, `reconnection_test` 4/1 both (same test), `peer_connection_signaling_test` 20/7 before vs 23/4 after, plus the 76 lib unit tests green. The pre-existing failures look environmental rather than real — `test_published_state` asserts a 20 ms tolerance that a cloud RTT cannot meet, and the `node_failure` / `resume_*` cases want a server they can fault-inject. I did not have a local `livekit-server --dev` to confirm that, so I am reporting the comparison rather than claiming a green suite.

### Async

No new runtime dependencies; the production change introduces no `.await`. The test uses `tokio::time::timeout` directly and contains no artificial delay — it polls once and asserts.
