### PR TITLE
Bump libwebrtc to webrtc-b9233c3-2

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,12 +10,16 @@ rustflags = ["-C", "target-feature=+crt-static"]
 
 [target.x86_64-apple-darwin]
 rustflags = ["-C", "link-args=-ObjC"]
+rustdocflags = ["-C", "link-args=-ObjC"]
 
 [target.aarch64-apple-darwin]
 rustflags = ["-C", "link-args=-ObjC"]
+rustdocflags = ["-C", "link-args=-ObjC"]
 
 [target.aarch64-apple-ios]
 rustflags = ["-C", "link-args=-ObjC"]
+rustdocflags = ["-C", "link-args=-ObjC"]
 
 [target.aarch64-apple-ios-sim]
 rustflags = ["-C", "link-args=-ObjC"]
+rustdocflags = ["-C", "link-args=-ObjC"]

--- a/.changeset/bump_libwebrtc_to_webrtc_b9233c3_2.md
+++ b/.changeset/bump_libwebrtc_to_webrtc_b9233c3_2.md
@@ -1,0 +1,19 @@
+---
+webrtc-sys: patch
+libwebrtc: patch
+livekit: patch
+livekit-ffi: patch
+---
+
+fix: bump libwebrtc to webrtc-b9233c3-2 so TURN/TLS can use the OS trust store
+
+WebRTC validates TURN/TLS against a small set of anchors compiled into
+`rtc_base/ssl_roots.h`, generated in 2023 from Google's own PKI list. It has no
+Amazon, Starfield Services or ISRG roots, so a relay-only connection to a TURN
+server fronted by AWS ACM or Let's Encrypt times out with `unknown_ca` even
+though the host OS trusts the chain.
+
+This build picks up webrtc-sdk/webrtc#277, which falls back to the operating
+system's trust store when the built-in anchors yield no path. It sits in
+`rtc_base` below every SDK, so the C++ API that webrtc-sys binds is covered
+without any Rust-side change.

--- a/.changeset/bump_libwebrtc_to_webrtc_b9233c3_2.md
+++ b/.changeset/bump_libwebrtc_to_webrtc_b9233c3_2.md
@@ -1,5 +1,6 @@
 ---
 webrtc-sys: patch
+webrtc-sys-build: patch
 libwebrtc: patch
 livekit: patch
 livekit-ffi: patch

--- a/webrtc-sys/build.rs
+++ b/webrtc-sys/build.rs
@@ -316,6 +316,8 @@ fn main() {
         "macos" => {
             println!("cargo:rustc-link-lib=framework=Foundation");
             println!("cargo:rustc-link-lib=framework=AVFoundation");
+            // rtc_base's platform certificate verifier calls SecTrust.
+            println!("cargo:rustc-link-lib=framework=Security");
             println!("cargo:rustc-link-lib=framework=CoreAudio");
             println!("cargo:rustc-link-lib=framework=AudioToolbox");
             println!("cargo:rustc-link-lib=framework=Appkit");
@@ -344,6 +346,8 @@ fn main() {
             println!("cargo:rustc-link-lib=framework=Foundation");
             println!("cargo:rustc-link-lib=framework=CoreFoundation");
             println!("cargo:rustc-link-lib=framework=AVFoundation");
+            // rtc_base's platform certificate verifier calls SecTrust.
+            println!("cargo:rustc-link-lib=framework=Security");
             println!("cargo:rustc-link-lib=framework=CoreAudio");
             println!("cargo:rustc-link-lib=framework=UIKit");
             println!("cargo:rustc-link-lib=framework=CoreVideo");

--- a/webrtc-sys/build/src/lib.rs
+++ b/webrtc-sys/build/src/lib.rs
@@ -28,7 +28,7 @@ use regex::Regex;
 use reqwest::StatusCode;
 
 pub const SCRATH_PATH: &str = "livekit_webrtc";
-pub const WEBRTC_TAG: &str = "webrtc-51ef663";
+pub const WEBRTC_TAG: &str = "webrtc-b9233c3-2";
 pub const IGNORE_DEFINES: [&str; 2] = ["CR_CLANG_REVISION", "CR_XCODE_VERSION"];
 
 pub fn target_os() -> String {


### PR DESCRIPTION
Fixes #1301 — picks up webrtc-sdk/webrtc#277, which falls back to the operating system's trust store when the anchors compiled into `rtc_base/ssl_roots.h` yield no path for a TURN/TLS chain.

### Why it was broken

WebRTC validates TURN/TLS solely against the anchors in `rtc_base/ssl_roots.h` — 36 roots generated in 2023 from `https://pki.goog/roots.pem`, Google's own PKI list rather than a general CA store. It contains no Amazon Root CA, no Starfield Services Root G2 and no ISRG Root X1, so a relay-only connection to a TURN server fronted by AWS ACM or Let's Encrypt fails with `unknown_ca` even though the host OS trusts the chain and the server sent a complete one.

### Why no Rust-side change is needed

The fix lives in `rtc_base/openssl_adapter.cc`, below every SDK, and `webrtc-sys` binds the C++ API directly — so it is covered without touching this repo beyond the tag. Verified locally on macOS by driving `rtc_base`'s `SSLAdapter` with no ObjC and no PeerConnection in the picture, against a local coturn whose CA is outside the built-in set:

```
(openssl_adapter.cc:924): Invoking SSL Verify Callback.
(platform_certificate_verifier_apple.cc): rejected by the system trust store: ...
```

### Build

[webrtc-b9233c3-2](https://github.com/livekit/rust-sdks/releases/tag/webrtc-b9233c3-2) — all 11 platform jobs green, 11 assets published. Built from `9e3b4f8`, so it includes the patch repairs from #1329; confirmed in the job logs that `external_audio_source.patch` applied cleanly rather than being skipped by `|| true`.