### PR TITLE
Set TfStereo when publishing stereo audio sources

### DIFF
--- a/.changeset/advertise-stereo-audio-sources.md
+++ b/.changeset/advertise-stereo-audio-sources.md
@@ -3,4 +3,4 @@ livekit: patch
 livekit-ffi: patch
 ---
 
-Advertise stereo audio sources when publishing tracks so the server configures stereo encoding.
+Advertise two-channel stereo audio sources when publishing tracks so the server configures stereo encoding.

--- a/.changeset/advertise-stereo-audio-sources.md
+++ b/.changeset/advertise-stereo-audio-sources.md
@@ -1,0 +1,6 @@
+---
+livekit: patch
+livekit-ffi: patch
+---
+
+Advertise stereo audio sources when publishing tracks so the server configures stereo encoding.

--- a/livekit/src/room/participant/local_participant.rs
+++ b/livekit/src/room/participant/local_participant.rs
@@ -1181,7 +1181,8 @@ fn set_audio_track_features(
         request.audio_features.push(proto::AudioTrackFeature::TfPreconnectBuffer as i32);
     }
 
-    if source.is_some_and(|source| source.num_channels() >= 2) {
+    // TfStereo configures Opus stereo; higher channel counts do not imply a stereo layout.
+    if source.is_some_and(|source| source.num_channels() == 2) {
         request.audio_features.push(proto::AudioTrackFeature::TfStereo as i32);
     }
 }
@@ -1250,6 +1251,13 @@ mod tests {
     }
 
     #[test]
+    fn audio_sources_with_more_than_two_channels_do_not_request_stereo_encoding() {
+        let request = audio_publish_request(3, false);
+
+        assert!(request.audio_features.is_empty());
+    }
+
+    #[test]
     fn audio_track_features_include_preconnect_buffer_and_stereo() {
         let request = audio_publish_request(2, true);
 
@@ -1259,6 +1267,18 @@ mod tests {
                 proto::AudioTrackFeature::TfPreconnectBuffer as i32,
                 proto::AudioTrackFeature::TfStereo as i32,
             ]
+        );
+    }
+
+    #[test]
+    fn non_audio_tracks_preserve_preconnect_buffer_feature() {
+        let mut request = proto::AddTrackRequest::default();
+
+        set_audio_track_features(&mut request, true, None);
+
+        assert_eq!(
+            request.audio_features,
+            vec![proto::AudioTrackFeature::TfPreconnectBuffer as i32]
         );
     }
 }

--- a/livekit/src/room/participant/local_participant.rs
+++ b/livekit/src/room/participant/local_participant.rs
@@ -381,8 +381,8 @@ impl LocalParticipant {
         video_send_encodings: Option<Vec<RtpEncodingParameters>>,
     ) -> RoomResult<LocalTrackPublication> {
         let disable_red = self.local.encryption_type != EncryptionType::None || !options.red;
-        let audio_source_channels = match &track {
-            LocalTrack::Audio(audio_track) => Some(audio_track.rtc_source().num_channels()),
+        let audio_source = match &track {
+            LocalTrack::Audio(audio_track) => Some(audio_track.rtc_source()),
             LocalTrack::Video(_) => None,
         };
 
@@ -396,10 +396,10 @@ impl LocalParticipant {
             disable_red,
             encryption: proto::encryption::Type::from(self.local.encryption_type) as i32,
             stream: options.stream.clone(),
-            audio_features: audio_track_features(options.preconnect_buffer, audio_source_channels),
             ..Default::default()
         };
 
+        set_audio_track_features(&mut req, options.preconnect_buffer, audio_source.as_ref());
         req.packet_trailer_features =
             options.frame_metadata_features.to_proto().into_iter().map(|f| f as i32).collect();
 
@@ -1172,24 +1172,34 @@ impl LocalParticipant {
     }
 }
 
-fn audio_track_features(preconnect_buffer: bool, source_channels: Option<u32>) -> Vec<i32> {
-    let mut features = Vec::new();
-
+fn set_audio_track_features(
+    request: &mut proto::AddTrackRequest,
+    preconnect_buffer: bool,
+    source: Option<&RtcAudioSource>,
+) {
     if preconnect_buffer {
-        features.push(proto::AudioTrackFeature::TfPreconnectBuffer as i32);
+        request.audio_features.push(proto::AudioTrackFeature::TfPreconnectBuffer as i32);
     }
 
-    if source_channels.is_some_and(|channels| channels >= 2) {
-        features.push(proto::AudioTrackFeature::TfStereo as i32);
+    if source.is_some_and(|source| source.num_channels() >= 2) {
+        request.audio_features.push(proto::AudioTrackFeature::TfStereo as i32);
     }
-
-    features
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::options::FrameMetadataFeatures;
+    use libwebrtc::audio_source::{native::NativeAudioSource, AudioSourceOptions};
+
+    fn audio_publish_request(channels: u32, preconnect_buffer: bool) -> proto::AddTrackRequest {
+        let source = NativeAudioSource::new(AudioSourceOptions::default(), 48_000, channels, 100);
+        let source = RtcAudioSource::Native(source);
+        let mut request = proto::AddTrackRequest::default();
+
+        set_audio_track_features(&mut request, preconnect_buffer, Some(&source));
+        request
+    }
 
     #[test]
     fn timing_subscribers_request_video_sender_transformer_without_frame_metadata() {
@@ -1227,21 +1237,24 @@ mod tests {
 
     #[test]
     fn stereo_audio_sources_request_stereo_encoding() {
-        assert_eq!(
-            audio_track_features(false, Some(2)),
-            vec![proto::AudioTrackFeature::TfStereo as i32]
-        );
+        let request = audio_publish_request(2, false);
+
+        assert_eq!(request.audio_features, vec![proto::AudioTrackFeature::TfStereo as i32]);
     }
 
     #[test]
     fn mono_audio_sources_do_not_request_stereo_encoding() {
-        assert!(audio_track_features(false, Some(1)).is_empty());
+        let request = audio_publish_request(1, false);
+
+        assert!(request.audio_features.is_empty());
     }
 
     #[test]
     fn audio_track_features_include_preconnect_buffer_and_stereo() {
+        let request = audio_publish_request(2, true);
+
         assert_eq!(
-            audio_track_features(true, Some(2)),
+            request.audio_features,
             vec![
                 proto::AudioTrackFeature::TfPreconnectBuffer as i32,
                 proto::AudioTrackFeature::TfStereo as i32,

--- a/livekit/src/room/participant/local_participant.rs
+++ b/livekit/src/room/participant/local_participant.rs
@@ -381,6 +381,10 @@ impl LocalParticipant {
         video_send_encodings: Option<Vec<RtpEncodingParameters>>,
     ) -> RoomResult<LocalTrackPublication> {
         let disable_red = self.local.encryption_type != EncryptionType::None || !options.red;
+        let audio_source_channels = match &track {
+            LocalTrack::Audio(audio_track) => Some(audio_track.rtc_source().num_channels()),
+            LocalTrack::Video(_) => None,
+        };
 
         let mut req = proto::AddTrackRequest {
             cid: track.rtc_track().id(),
@@ -392,12 +396,9 @@ impl LocalParticipant {
             disable_red,
             encryption: proto::encryption::Type::from(self.local.encryption_type) as i32,
             stream: options.stream.clone(),
+            audio_features: audio_track_features(options.preconnect_buffer, audio_source_channels),
             ..Default::default()
         };
-
-        if options.preconnect_buffer {
-            req.audio_features.push(proto::AudioTrackFeature::TfPreconnectBuffer as i32);
-        }
 
         req.packet_trailer_features =
             options.frame_metadata_features.to_proto().into_iter().map(|f| f as i32).collect();
@@ -1171,6 +1172,20 @@ impl LocalParticipant {
     }
 }
 
+fn audio_track_features(preconnect_buffer: bool, source_channels: Option<u32>) -> Vec<i32> {
+    let mut features = Vec::new();
+
+    if preconnect_buffer {
+        features.push(proto::AudioTrackFeature::TfPreconnectBuffer as i32);
+    }
+
+    if source_channels.is_some_and(|channels| channels >= 2) {
+        features.push(proto::AudioTrackFeature::TfStereo as i32);
+    }
+
+    features
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1208,5 +1223,29 @@ mod tests {
         };
 
         assert!(!needs_video_sender_transformer(&options, false));
+    }
+
+    #[test]
+    fn stereo_audio_sources_request_stereo_encoding() {
+        assert_eq!(
+            audio_track_features(false, Some(2)),
+            vec![proto::AudioTrackFeature::TfStereo as i32]
+        );
+    }
+
+    #[test]
+    fn mono_audio_sources_do_not_request_stereo_encoding() {
+        assert!(audio_track_features(false, Some(1)).is_empty());
+    }
+
+    #[test]
+    fn audio_track_features_include_preconnect_buffer_and_stereo() {
+        assert_eq!(
+            audio_track_features(true, Some(2)),
+            vec![
+                proto::AudioTrackFeature::TfPreconnectBuffer as i32,
+                proto::AudioTrackFeature::TfStereo as i32,
+            ]
+        );
     }
 }


### PR DESCRIPTION
### Before you submit your PR

* [x] I have read the contributing guidelines.
* [x] I have read and followed the principles regarding breaking changes, testing, and code quality.

### PR description

Fixes #1018.

When a `LocalAudioTrack` is created from a two-channel `AudioSource`, the publication path does not currently include `AudioTrackFeature::TfStereo` in `AddTrackRequest.audio_features`.

As a result, the server is not told that the source is stereo.

This PR:

* advertises `TfStereo` for two-channel native audio sources;
* leaves mono sources unchanged;
* does not infer stereo from arbitrary multichannel sources;
* preserves `TfPreconnectBuffer` behavior and composes it with `TfStereo`;
* leaves non-audio publication behavior unchanged;
* adds focused regression coverage using real `NativeAudioSource` values;
* adds the required patch changeset for `livekit` and `livekit-ffi`.

`NativeAudioSource` can represent more than two channels, but `TfStereo` is a stereo flag rather than a multichannel layout. Automatic stereo advertisement is therefore limited to exactly two channels.

### Breaking changes

None.

### MSRV

No change.

### Testing

Tests cover:

* one-channel sources do not advertise `TfStereo`;
* two-channel sources advertise `TfStereo`;
* three-channel sources do not automatically advertise `TfStereo`;
* `TfStereo` and `TfPreconnectBuffer` compose correctly;
* non-audio publication behavior remains unchanged;
* the complete `livekit` package test suite;
* workspace formatting.

### Verification

The exact submitted commit was independently verified with [FalseGreen](https://falsegreen.com/) against a frozen verification contract.

* exactly two channels advertise `TfStereo`;
* mono does not advertise `TfStereo`;
* more than two channels do not imply stereo;
* stereo composes with preconnect buffering;
* non-audio publication behavior remains unchanged;
* the complete `livekit` package test suite and workspace formatting pass;
* the required changeset retains patch bumps for `livekit` and `livekit-ffi`;
* 7/7 verification criteria passed;
* verified source: `1f76ed000a2d65749c4008a24e7715c1eeca29a7`.

The verification is scoped to these criteria and does not claim broader correctness of the LiveKit Rust SDK.

### Async

No runtime or async behavior changes.

Assisted-by: Codex