### PR TITLE
Expose remote data track pipeline options over UniFFI

### DIFF
--- a/.changeset/expose_remote_data_track_pipeline_options.md
+++ b/.changeset/expose_remote_data_track_pipeline_options.md
@@ -1,0 +1,5 @@
+---
+livekit-uniffi: patch
+---
+
+Expose `RemoteDataTrack.set_pipeline_options` and `RemoteDataTrackPipelineOptions` (`max_partial_frames`) over UniFFI, matching the JS and Rust SDKs

--- a/livekit-uniffi/src/data_track/local.rs
+++ b/livekit-uniffi/src/data_track/local.rs
@@ -54,8 +54,9 @@ impl LocalDataTrack {
 
     /// Try pushing a frame to subscribers of the track.
     pub fn try_push(&self, frame: DataTrackFrame) -> Result<(), PushFrameErrorReason> {
-        // `PushFrameError` returns ownership of the unpublished frame to the caller;
-        // since this isn't applicable in an FFI context, just provide the reason.
+        // `PushFrameError` returns ownership of the unpublished frame to the caller because Rust's
+        // `try_push` moves it. Across the FFI boundary the frame is lowered by copy, so the caller
+        // still holds its own value and can retry with it directly; just provide the reason.
         self.0.try_push(frame.into()).map_err(|err| err.reason())
     }
 

--- a/livekit-uniffi/src/data_track/remote.rs
+++ b/livekit-uniffi/src/data_track/remote.rs
@@ -72,10 +72,21 @@ impl RemoteDataTrack {
             .await
             .map(|stream| DataTrackStream(Mutex::new(stream)))
     }
+
+    /// Configures options for the pipeline handling incoming packets for this track.
+    ///
+    /// These options apply to all current and future subscriptions of this track, and may be
+    /// set at any time. New options take affect with the next received packet.
+    ///
+    pub fn set_pipeline_options(&self, options: RemoteDataTrackPipelineOptions) {
+        self.0.set_pipeline_options(options.into())
+    }
 }
 
 #[derive(uniffi::Record)]
 pub struct DataTrackSubscribeOptions {
+    /// Maximum number of received frames buffered internally. Zero is clamped to one.
+    #[uniffi(default = 16)]
     pub buffer_size: u32,
 }
 
@@ -83,6 +94,29 @@ impl From<DataTrackSubscribeOptions> for livekit_datatrack::api::DataTrackSubscr
     fn from(options: DataTrackSubscribeOptions) -> Self {
         livekit_datatrack::api::DataTrackSubscribeOptions::default()
             .with_buffer_size(options.buffer_size as usize)
+    }
+}
+
+/// FFI wrapper around [`livekit_datatrack::api::RemoteDataTrackPipelineOptions`]. The underlying
+/// type uses the builder pattern with private fields.
+///
+#[derive(uniffi::Record)]
+pub struct RemoteDataTrackPipelineOptions {
+    /// Maximum number of partial frames the depacketizer will track concurrently for this track.
+    ///
+    /// Higher values give more out-of-order tolerance for high-frequency senders at the cost of
+    /// additional buffering. Zero is clamped to one.
+    ///
+    #[uniffi(default = 1)]
+    pub max_partial_frames: u32,
+}
+
+impl From<RemoteDataTrackPipelineOptions>
+    for livekit_datatrack::api::RemoteDataTrackPipelineOptions
+{
+    fn from(options: RemoteDataTrackPipelineOptions) -> Self {
+        livekit_datatrack::api::RemoteDataTrackPipelineOptions::default()
+            .with_max_partial_frames(options.max_partial_frames as usize)
     }
 }
 


### PR DESCRIPTION
Exposes `RemoteDataTrack.set_pipeline_options` and a `RemoteDataTrackPipelineOptions` record (`max_partial_frames`, default 1) so Swift reaches parity with the JS, Python, and Rust SDKs, which all document this as the lever for reassembling large or high-frequency frames under packet reordering. Also defaults `DataTrackSubscribeOptions.buffer_size` to 16 to match the documented default.