### PR TITLE
Option for webrtc WARP

### DIFF
--- a/.changeset/enable_warp_by_default.md
+++ b/.changeset/enable_warp_by_default.md
@@ -1,0 +1,18 @@
+---
+libwebrtc: minor
+livekit: minor
+webrtc-sys: patch
+livekit-ffi: patch
+---
+
+feat: enable WARP (SPED + SNAP) by default, gated by the server
+
+WARP is now always enabled on the client and negotiated with the SFU: SPED
+(DTLS-in-STUN) via the `WebRTC-IceHandshakeDtls` field trial, and SNAP
+(SCTP-INIT-in-SDP) via the `RtcConfiguration.enable_sctp_snap` field. When the
+server does not enable WARP it is not advertised and the connection falls back to
+plain DTLS/SCTP, so there is no client-side toggle.
+
+BREAKING CHANGE: `libwebrtc::RtcConfiguration` is now `#[non_exhaustive]` and has a
+new `enable_sctp_snap` field. Construct it from `RtcConfiguration::default()` and set
+the fields you need instead of a struct literal.

--- a/libwebrtc/CHANGELOG.md
+++ b/libwebrtc/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Breaking
-
-- `RtcConfiguration` is now `#[non_exhaustive]` and gained an `enable_sctp_snap` field
-  (WARP / SNAP — SCTP-INIT-in-SDP). Construct it from `RtcConfiguration::default()` and
-  set the fields you need instead of a struct literal; future fields can then be added
-  without a breaking change.
-
 ## [0.3.26](https://github.com/livekit/rust-sdks/compare/rust-sdks/libwebrtc@0.3.25...rust-sdks/libwebrtc@0.3.26) - 2026-02-16
 
 ### Other

--- a/libwebrtc/CHANGELOG.md
+++ b/libwebrtc/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+
+- `RtcConfiguration` is now `#[non_exhaustive]` and gained an `enable_sctp_snap` field
+  (WARP / SNAP — SCTP-INIT-in-SDP). Construct it from `RtcConfiguration::default()` and
+  set the fields you need instead of a struct literal; future fields can then be added
+  without a breaking change.
+
 ## [0.3.26](https://github.com/livekit/rust-sdks/compare/rust-sdks/libwebrtc@0.3.25...rust-sdks/libwebrtc@0.3.26) - 2026-02-16
 
 ### Other

--- a/libwebrtc/src/native/peer_connection.rs
+++ b/libwebrtc/src/native/peer_connection.rs
@@ -166,6 +166,7 @@ impl From<RtcConfiguration> for sys_pc::ffi::RtcConfiguration {
             ice_servers: value.ice_servers.into_iter().map(Into::into).collect(),
             continual_gathering_policy: value.continual_gathering_policy.into(),
             ice_transport_type: value.ice_transport_type.into(),
+            enable_sctp_snap: value.enable_sctp_snap,
         }
     }
 }

--- a/libwebrtc/src/native/peer_connection_factory.rs
+++ b/libwebrtc/src/native/peer_connection_factory.rs
@@ -66,6 +66,20 @@ impl PeerConnectionFactory {
         Self { sys_handle }
     }
 
+    /// Creates a [`PeerConnectionFactory`] with the given runtime options.
+    /// `zero_playout_delay` enables the WebRTC-ForcePlayoutDelay field trial;
+    /// `enable_warp` enables WARP (SPED via the WebRTC-IceHandshakeDtls field
+    /// trial; SNAP is carried on the RtcConfiguration, not a field trial). The
+    /// two are independent and may be combined.
+    pub fn with_options(zero_playout_delay: bool, enable_warp: bool) -> Self {
+        ensure_log_sink();
+        let sys_handle = sys_pcf::ffi::create_peer_connection_factory_with_options(
+            zero_playout_delay,
+            enable_warp,
+        );
+        Self { sys_handle }
+    }
+
     #[cfg(test)]
     pub(crate) fn zero_playout_delay_enabled(&self) -> bool {
         self.sys_handle.zero_playout_delay_enabled()

--- a/libwebrtc/src/peer_connection.rs
+++ b/libwebrtc/src/peer_connection.rs
@@ -291,6 +291,7 @@ mod tests {
             }],
             continual_gathering_policy: ContinualGatheringPolicy::GatherOnce,
             ice_transport_type: IceTransportsType::All,
+            enable_sctp_snap: false,
         };
 
         let bob = factory.create_peer_connection(config.clone()).unwrap();

--- a/libwebrtc/src/peer_connection_factory.rs
+++ b/libwebrtc/src/peer_connection_factory.rs
@@ -44,6 +44,10 @@ pub struct RtcConfiguration {
     pub ice_servers: Vec<IceServer>,
     pub continual_gathering_policy: ContinualGatheringPolicy,
     pub ice_transport_type: IceTransportsType,
+    /// WARP: enable SNAP (SCTP-INIT-in-SDP). Maps to the immutable
+    /// `enable_sctp_snap` RTCConfiguration field, so it must be set the same at
+    /// PeerConnection creation and every set_configuration.
+    pub enable_sctp_snap: bool,
 }
 
 impl Default for RtcConfiguration {
@@ -52,6 +56,7 @@ impl Default for RtcConfiguration {
             ice_servers: vec![],
             continual_gathering_policy: ContinualGatheringPolicy::GatherContinually,
             ice_transport_type: IceTransportsType::All,
+            enable_sctp_snap: false,
         }
     }
 }
@@ -72,6 +77,14 @@ impl PeerConnectionFactory {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn with_zero_playout_delay() -> Self {
         Self { handle: imp_pcf::PeerConnectionFactory::with_zero_playout_delay() }
+    }
+
+    /// Creates a native peer connection factory with the given runtime options.
+    /// `zero_playout_delay` and `enable_warp` (SPED + SNAP) are independent and
+    /// may be combined.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn with_options(zero_playout_delay: bool, enable_warp: bool) -> Self {
+        Self { handle: imp_pcf::PeerConnectionFactory::with_options(zero_playout_delay, enable_warp) }
     }
 
     pub fn create_peer_connection(

--- a/libwebrtc/src/peer_connection_factory.rs
+++ b/libwebrtc/src/peer_connection_factory.rs
@@ -84,7 +84,9 @@ impl PeerConnectionFactory {
     /// may be combined.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn with_options(zero_playout_delay: bool, enable_warp: bool) -> Self {
-        Self { handle: imp_pcf::PeerConnectionFactory::with_options(zero_playout_delay, enable_warp) }
+        Self {
+            handle: imp_pcf::PeerConnectionFactory::with_options(zero_playout_delay, enable_warp),
+        }
     }
 
     pub fn create_peer_connection(

--- a/libwebrtc/src/peer_connection_factory.rs
+++ b/libwebrtc/src/peer_connection_factory.rs
@@ -39,7 +39,17 @@ pub enum IceTransportsType {
     All,
 }
 
+/// Configuration for a [`PeerConnection`].
+///
+/// This type is `#[non_exhaustive]`: construct it from [`RtcConfiguration::default`]
+/// and set the fields you need, e.g.
+/// ```ignore
+/// let mut cfg = RtcConfiguration::default();
+/// cfg.ice_transport_type = IceTransportsType::Relay;
+/// ```
+/// New fields may be added in future releases without a breaking change.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct RtcConfiguration {
     pub ice_servers: Vec<IceServer>,
     pub continual_gathering_policy: ContinualGatheringPolicy,

--- a/libwebrtc/src/peer_connection_factory.rs
+++ b/libwebrtc/src/peer_connection_factory.rs
@@ -43,7 +43,8 @@ pub enum IceTransportsType {
 ///
 /// This type is `#[non_exhaustive]`: construct it from [`RtcConfiguration::default`]
 /// and set the fields you need, e.g.
-/// ```ignore
+/// ```
+/// # use libwebrtc::peer_connection_factory::{IceTransportsType, RtcConfiguration};
 /// let mut cfg = RtcConfiguration::default();
 /// cfg.ice_transport_type = IceTransportsType::Relay;
 /// ```

--- a/livekit-ffi/src/conversion/room.rs
+++ b/livekit-ffi/src/conversion/room.rs
@@ -249,6 +249,7 @@ impl From<proto::RtcConfig> for RtcConfiguration {
                     proto::ContinualGatheringPolicy::try_from(x).unwrap().into()
                 }),
             ice_servers: value.ice_servers.into_iter().map(Into::into).collect(),
+            enable_sctp_snap: default.enable_sctp_snap,
         }
     }
 }

--- a/livekit-ffi/src/conversion/room.rs
+++ b/livekit-ffi/src/conversion/room.rs
@@ -241,9 +241,10 @@ impl From<proto::RtcConfig> for RtcConfiguration {
         // so it must be built from Default rather than a struct literal.
         let mut config = RoomOptions::default().rtc_config;
 
-        config.ice_transport_type = value.ice_transport_type.map_or(config.ice_transport_type, |x| {
-            proto::IceTransportType::try_from(x).unwrap().into()
-        });
+        config.ice_transport_type =
+            value.ice_transport_type.map_or(config.ice_transport_type, |x| {
+                proto::IceTransportType::try_from(x).unwrap().into()
+            });
         config.continual_gathering_policy =
             value.continual_gathering_policy.map_or(config.continual_gathering_policy, |x| {
                 proto::ContinualGatheringPolicy::try_from(x).unwrap().into()

--- a/livekit-ffi/src/conversion/room.rs
+++ b/livekit-ffi/src/conversion/room.rs
@@ -237,20 +237,19 @@ impl From<proto::IceServer> for IceServer {
 
 impl From<proto::RtcConfig> for RtcConfiguration {
     fn from(value: proto::RtcConfig) -> Self {
-        let default = RoomOptions::default().rtc_config; // Always use RoomOptions as the default reference
+        // Start from RoomOptions defaults; RtcConfiguration is #[non_exhaustive]
+        // so it must be built from Default rather than a struct literal.
+        let mut config = RoomOptions::default().rtc_config;
 
-        Self {
-            ice_transport_type: value.ice_transport_type.map_or(default.ice_transport_type, |x| {
-                proto::IceTransportType::try_from(x).unwrap().into()
-            }),
-            continual_gathering_policy: value
-                .continual_gathering_policy
-                .map_or(default.continual_gathering_policy, |x| {
-                    proto::ContinualGatheringPolicy::try_from(x).unwrap().into()
-                }),
-            ice_servers: value.ice_servers.into_iter().map(Into::into).collect(),
-            enable_sctp_snap: default.enable_sctp_snap,
-        }
+        config.ice_transport_type = value.ice_transport_type.map_or(config.ice_transport_type, |x| {
+            proto::IceTransportType::try_from(x).unwrap().into()
+        });
+        config.continual_gathering_policy =
+            value.continual_gathering_policy.map_or(config.continual_gathering_policy, |x| {
+                proto::ContinualGatheringPolicy::try_from(x).unwrap().into()
+            });
+        config.ice_servers = value.ice_servers.into_iter().map(Into::into).collect();
+        config
     }
 }
 

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -473,6 +473,7 @@ impl Default for RoomOptions {
                                       * JoinResponse */
                 continual_gathering_policy: ContinualGatheringPolicy::GatherContinually,
                 ice_transport_type: IceTransportsType::All,
+                enable_sctp_snap: false,
             },
             join_retries: 3,
             sdk_options: RoomSdkOptions::default(),

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -18,8 +18,7 @@ use futures_util::StreamExt;
 use libwebrtc::{
     native::frame_cryptor::EncryptionState,
     prelude::{
-        ContinualGatheringPolicy, IceTransportsType, MediaStream, MediaStreamTrack,
-        RtcConfiguration,
+        MediaStream, MediaStreamTrack, RtcConfiguration,
     },
     rtp_transceiver::RtpTransceiver,
     RtcError,
@@ -467,14 +466,8 @@ impl Default for RoomOptions {
             e2ee: None,
             encryption: None,
 
-            // Explicitly set the default values
-            rtc_config: RtcConfiguration {
-                ice_servers: vec![], /* When empty, this will automatically be filled by the
-                                      * JoinResponse */
-                continual_gathering_policy: ContinualGatheringPolicy::GatherContinually,
-                ice_transport_type: IceTransportsType::All,
-                enable_sctp_snap: false,
-            },
+            // Defaults; ice_servers is empty here and filled from the JoinResponse.
+            rtc_config: RtcConfiguration::default(),
             join_retries: 3,
             sdk_options: RoomSdkOptions::default(),
             single_peer_connection: true,

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -17,9 +17,7 @@ use bmrng::unbounded::UnboundedRequestReceiver;
 use futures_util::StreamExt;
 use libwebrtc::{
     native::frame_cryptor::EncryptionState,
-    prelude::{
-        MediaStream, MediaStreamTrack, RtcConfiguration,
-    },
+    prelude::{MediaStream, MediaStreamTrack, RtcConfiguration},
     rtp_transceiver::RtpTransceiver,
     RtcError,
 };

--- a/livekit/src/rtc_engine/lk_runtime.rs
+++ b/livekit/src/rtc_engine/lk_runtime.rs
@@ -80,12 +80,13 @@ impl LkRuntime {
         } else {
             log::debug!("LkRuntime::new()");
             let zero_playout_delay = state.zero_playout_delay;
+            // WARP (SPED + SNAP) is always enabled. SPED is the factory field
+            // trial enabled here; SNAP is carried on the RtcConfiguration (set
+            // in RtcSession). zero_playout_delay is independent and composed
+            // alongside WARP. Whether WARP actually engages is negotiated with
+            // the server — it degrades to plain DTLS/SCTP if the peer opts out.
             #[cfg(not(target_arch = "wasm32"))]
-            let pc_factory = if zero_playout_delay {
-                PeerConnectionFactory::with_zero_playout_delay()
-            } else {
-                PeerConnectionFactory::default()
-            };
+            let pc_factory = PeerConnectionFactory::with_options(zero_playout_delay, true);
             #[cfg(target_arch = "wasm32")]
             let pc_factory = PeerConnectionFactory::default();
             let new_runtime = Arc::new(Self { pc_factory, zero_playout_delay });

--- a/livekit/src/rtc_engine/peer_transport.rs
+++ b/livekit/src/rtc_engine/peer_transport.rs
@@ -586,12 +586,9 @@ mod tests {
         use livekit_protocol as proto;
 
         let factory = PeerConnectionFactory::default();
-        let config = RtcConfiguration {
-            ice_servers: vec![],
-            continual_gathering_policy: ContinualGatheringPolicy::GatherOnce,
-            ice_transport_type: IceTransportsType::All,
-            enable_sctp_snap: true,
-        };
+        let mut config = RtcConfiguration::default();
+        config.continual_gathering_policy = ContinualGatheringPolicy::GatherOnce;
+        config.enable_sctp_snap = true;
 
         let alice_pc = factory.create_peer_connection(config.clone()).unwrap();
         let bob_pc = factory.create_peer_connection(config).unwrap();

--- a/livekit/src/rtc_engine/peer_transport.rs
+++ b/livekit/src/rtc_engine/peer_transport.rs
@@ -590,6 +590,7 @@ mod tests {
             ice_servers: vec![],
             continual_gathering_policy: ContinualGatheringPolicy::GatherOnce,
             ice_transport_type: IceTransportsType::All,
+            enable_sctp_snap: true,
         };
 
         let alice_pc = factory.create_peer_connection(config.clone()).unwrap();

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -501,6 +501,16 @@ impl RtcSession {
         let (emitter, session_events) = mpsc::unbounded_channel();
 
         let lk_runtime = LkRuntime::instance();
+
+        // WARP is always on. SNAP is an immutable RTCConfiguration field
+        // (enable_sctp_snap), so it must be carried by every config this session
+        // builds (creation + set_configuration + reconnect all derive from
+        // options.rtc_config). Set it once here; whether SNAP actually engages
+        // is negotiated with the server (the answer/offer omits a=sctp-init if
+        // the peer opts out, falling back to plain SCTP).
+        let mut options = options;
+        options.rtc_config.enable_sctp_snap = true;
+
         let use_single_pc = options.signal_options.single_peer_connection;
 
         let mut publisher_offer = None;

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -502,12 +502,6 @@ impl RtcSession {
 
         let lk_runtime = LkRuntime::instance();
 
-        // WARP is always on. SNAP is an immutable RTCConfiguration field
-        // (enable_sctp_snap), so it must be carried by every config this session
-        // builds (creation + set_configuration + reconnect all derive from
-        // options.rtc_config). Set it once here; whether SNAP actually engages
-        // is negotiated with the server (the answer/offer omits a=sctp-init if
-        // the peer opts out, falling back to plain SCTP).
         let mut options = options;
         options.rtc_config.enable_sctp_snap = true;
 

--- a/webrtc-sys/include/livekit/peer_connection_factory.h
+++ b/webrtc-sys/include/livekit/peer_connection_factory.h
@@ -47,6 +47,9 @@ class PeerConnectionFactory {
   explicit PeerConnectionFactory(std::shared_ptr<RtcRuntime> rtc_runtime);
   PeerConnectionFactory(std::shared_ptr<RtcRuntime> rtc_runtime,
                         bool zero_playout_delay);
+  PeerConnectionFactory(std::shared_ptr<RtcRuntime> rtc_runtime,
+                        bool zero_playout_delay,
+                        bool enable_warp);
   ~PeerConnectionFactory();
 
   std::shared_ptr<PeerConnection> create_peer_connection(
@@ -85,4 +88,7 @@ class PeerConnectionFactory {
 std::shared_ptr<PeerConnectionFactory> create_peer_connection_factory();
 std::shared_ptr<PeerConnectionFactory>
 create_peer_connection_factory_with_zero_playout_delay();
+std::shared_ptr<PeerConnectionFactory>
+create_peer_connection_factory_with_options(bool zero_playout_delay,
+                                            bool enable_warp);
 }  // namespace livekit_ffi

--- a/webrtc-sys/src/peer_connection.cpp
+++ b/webrtc-sys/src/peer_connection.cpp
@@ -55,6 +55,8 @@ webrtc::PeerConnectionInterface::RTCConfiguration to_native_rtc_configuration(
       static_cast<webrtc::PeerConnectionInterface::IceTransportsType>(
           config.ice_transport_type);
 
+  rtc_config.enable_sctp_snap = config.enable_sctp_snap;
+
   return rtc_config;
 }
 

--- a/webrtc-sys/src/peer_connection.rs
+++ b/webrtc-sys/src/peer_connection.rs
@@ -92,6 +92,9 @@ pub mod ffi {
         pub ice_servers: Vec<IceServer>,
         pub continual_gathering_policy: ContinualGatheringPolicy,
         pub ice_transport_type: IceTransportsType,
+        // WARP/SNAP: enable SCTP-INIT-in-SDP. Must be carried consistently across
+        // create + set_configuration (it is an immutable RTCConfiguration field).
+        pub enable_sctp_snap: bool,
     }
 
     extern "C++" {

--- a/webrtc-sys/src/peer_connection_factory.cpp
+++ b/webrtc-sys/src/peer_connection_factory.cpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "api/audio_codecs/builtin_audio_decoder_factory.h"
 #include "api/audio_codecs/builtin_audio_encoder_factory.h"
@@ -64,12 +65,77 @@ class ZeroPlayoutDelayFieldTrials final : public webrtc::FieldTrialsView {
   }
 };
 
-webrtc::Environment CreateEnvironment(bool zero_playout_delay) {
-  if (zero_playout_delay) {
-    return webrtc::CreateEnvironment(
-        std::make_unique<ZeroPlayoutDelayFieldTrials>());
+// Enables SPED (DTLS-in-STUN) via the WebRTC-IceHandshakeDtls field trial.
+// SNAP (SCTP-INIT-in-SDP) is intentionally NOT set here: it maps to the
+// immutable enable_sctp_snap RTCConfiguration field, so it must be carried on
+// the RtcConfiguration (see RtcConfiguration.enable_sctp_snap) to stay
+// consistent across create + set_configuration. Enabling it via a field trial
+// makes set_configuration fail ("Modifying the configuration in an unsupported
+// way").
+class EnableWarpFieldTrials final : public webrtc::FieldTrialsView {
+ public:
+  std::string Lookup(absl::string_view key) const override {
+    if (key == "WebRTC-IceHandshakeDtls") {
+      return "Enabled";
+    }
+    return "";
   }
-  return webrtc::CreateEnvironment();
+
+  std::unique_ptr<webrtc::FieldTrialsView> CreateCopy() const override {
+    return std::make_unique<EnableWarpFieldTrials>();
+  }
+};
+
+// An Environment accepts a single FieldTrialsView, so to enable several
+// independent trial groups (e.g. zero-playout-delay AND WARP) we combine their
+// views into one: Lookup delegates to each sub-view and returns the first
+// non-empty result. The groups' keys are disjoint, so ordering is irrelevant.
+class CompositeFieldTrials final : public webrtc::FieldTrialsView {
+ public:
+  explicit CompositeFieldTrials(
+      std::vector<std::unique_ptr<webrtc::FieldTrialsView>> views)
+      : views_(std::move(views)) {}
+
+  std::string Lookup(absl::string_view key) const override {
+    for (const auto& view : views_) {
+      std::string value = view->Lookup(key);
+      if (!value.empty()) {
+        return value;
+      }
+    }
+    return "";
+  }
+
+  std::unique_ptr<webrtc::FieldTrialsView> CreateCopy() const override {
+    std::vector<std::unique_ptr<webrtc::FieldTrialsView>> copies;
+    copies.reserve(views_.size());
+    for (const auto& view : views_) {
+      copies.push_back(view->CreateCopy());
+    }
+    return std::make_unique<CompositeFieldTrials>(std::move(copies));
+  }
+
+ private:
+  std::vector<std::unique_ptr<webrtc::FieldTrialsView>> views_;
+};
+
+// zero_playout_delay and enable_warp are independent and may both be enabled;
+// their field-trial views are composed into one.
+webrtc::Environment CreateEnvironment(bool zero_playout_delay,
+                                      bool enable_warp) {
+  std::vector<std::unique_ptr<webrtc::FieldTrialsView>> views;
+  if (zero_playout_delay) {
+    views.push_back(std::make_unique<ZeroPlayoutDelayFieldTrials>());
+  }
+  if (enable_warp) {
+    views.push_back(std::make_unique<EnableWarpFieldTrials>());
+  }
+
+  if (views.empty()) {
+    return webrtc::CreateEnvironment();
+  }
+  return webrtc::CreateEnvironment(
+      std::make_unique<CompositeFieldTrials>(std::move(views)));
 }
 
 }  // namespace
@@ -78,13 +144,19 @@ class PeerConnectionObserver;
 
 PeerConnectionFactory::PeerConnectionFactory(
     std::shared_ptr<RtcRuntime> rtc_runtime)
-    : PeerConnectionFactory(std::move(rtc_runtime), false) {}
+    : PeerConnectionFactory(std::move(rtc_runtime), false, false) {}
 
 PeerConnectionFactory::PeerConnectionFactory(
     std::shared_ptr<RtcRuntime> rtc_runtime,
     bool zero_playout_delay)
+    : PeerConnectionFactory(std::move(rtc_runtime), zero_playout_delay, false) {}
+
+PeerConnectionFactory::PeerConnectionFactory(
+    std::shared_ptr<RtcRuntime> rtc_runtime,
+    bool zero_playout_delay,
+    bool enable_warp)
     : rtc_runtime_(rtc_runtime),
-      env_(CreateEnvironment(zero_playout_delay)) {
+      env_(CreateEnvironment(zero_playout_delay, enable_warp)) {
   webrtc::PeerConnectionFactoryDependencies dependencies;
   dependencies.network_thread = rtc_runtime_->network_thread();
   dependencies.worker_thread = rtc_runtime_->worker_thread();
@@ -96,6 +168,12 @@ PeerConnectionFactory::PeerConnectionFactory(
   if (zero_playout_delay) {
     RTC_LOG(LS_INFO) << "WebRTC zero playout delay enabled with field trial: "
                      << kForcePlayoutDelayFieldTrial;
+  }
+
+  if (enable_warp) {
+    RTC_LOG(LS_INFO) << "WebRTC WARP: SPED enabled via field trial "
+                        "WebRTC-IceHandshakeDtls/Enabled/ (SNAP via "
+                        "RtcConfiguration.enable_sctp_snap)";
   }
 
   // Create AdmProxy - it creates and initializes Platform ADM internally
@@ -213,6 +291,14 @@ std::shared_ptr<PeerConnectionFactory> create_peer_connection_factory() {
 std::shared_ptr<PeerConnectionFactory>
 create_peer_connection_factory_with_zero_playout_delay() {
   return std::make_shared<PeerConnectionFactory>(RtcRuntime::create(), true);
+}
+
+std::shared_ptr<PeerConnectionFactory>
+create_peer_connection_factory_with_options(bool zero_playout_delay,
+                                            bool enable_warp) {
+  return std::make_shared<PeerConnectionFactory>(RtcRuntime::create(),
+                                                 zero_playout_delay,
+                                                 enable_warp);
 }
 
 }  // namespace livekit_ffi

--- a/webrtc-sys/src/peer_connection_factory.rs
+++ b/webrtc-sys/src/peer_connection_factory.rs
@@ -90,6 +90,10 @@ pub mod ffi {
         fn create_peer_connection_factory() -> SharedPtr<PeerConnectionFactory>;
         fn create_peer_connection_factory_with_zero_playout_delay(
         ) -> SharedPtr<PeerConnectionFactory>;
+        fn create_peer_connection_factory_with_options(
+            zero_playout_delay: bool,
+            enable_warp: bool,
+        ) -> SharedPtr<PeerConnectionFactory>;
 
         fn zero_playout_delay_enabled(self: &PeerConnectionFactory) -> bool;
 


### PR DESCRIPTION
### Before you submit your PR

Make sure the following is true before submitting your PR:

- [x] I have read the [contributing guidelines](https://github.com/livekit/rust-sdks/blob/main/CONTRIBUTING.md) and validated that this PR will be accepted.
- [x] I have read and followed the principles regarding breaking changes, testing, and code quality.

### PR description

Option for webrtc WARP, turned on by default in livekit runtime. The SFU will control it by sdp negotiation and ice attr.

### Breaking changes


### MSRV

If the PR modifies the crate's MSRV (Minimum Supported Rust Version), document it here.

### Testing

Ideally, unit test the code you add, but ensure you're not repeating existing test cases. Use as many already written scaffolding, utilities as possible; write your own, when needed. If external services, APIs, tokens are required (e.g., running an LK server instance), provide the necessary information. Make sure your tests perform useful, context-aware assertions and do not simply emulate "happy paths".

### Async

We want the project to be runtime-agnostic, so please reuse what's already in [livekit-runtime](https://github.com/livekit/rust-sdks/blob/main/livekit-runtime/) and feel free to add anything missing. It's ok to use Tokio directly, when writing unit tests, if necessary. When testing, do not use artificial delays for the state to "catch up"; instead, respect the event flow and subscribe properly using channels or other mechanisms.


