### PR TITLE
fix(uniffi): register the Bytes custom type once, in livekit-common

### DIFF
--- a/.changeset/fix_uniffi_register_the_bytes_custom_type_once_in_livekit_co.md
+++ b/.changeset/fix_uniffi_register_the_bytes_custom_type_once_in_livekit_co.md
@@ -1,0 +1,8 @@
+---
+livekit: patch
+livekit-api: patch
+livekit-data-stream: patch
+livekit-ffi: patch
+---
+
+fix(uniffi): register the Bytes custom type once, in livekit-common - #1343 (@pblazej)

--- a/.changeset/reuse_datatrack_bytes_converter.md
+++ b/.changeset/reuse_datatrack_bytes_converter.md
@@ -1,0 +1,5 @@
+---
+livekit-uniffi: patch
+---
+
+Reuse `livekit-datatrack`'s `Bytes` converter instead of registering a second one, so UniFFI emits it once and the post-generation Swift workaround is no longer needed

--- a/.changeset/reuse_datatrack_bytes_converter.md
+++ b/.changeset/reuse_datatrack_bytes_converter.md
@@ -1,5 +1,7 @@
 ---
 livekit-uniffi: patch
+livekit-datatrack: patch
+livekit-common: patch
 ---
 
-Reuse `livekit-datatrack`'s `Bytes` converter instead of registering a second one, so UniFFI emits it once and the post-generation Swift workaround is no longer needed
+Register the `Bytes` UniFFI custom type once in `livekit-common` and borrow it from each component with `uniffi::use_remote_type!`, so the converter is emitted once and the post-generation Swift workaround is no longer needed

--- a/.github/workflows/uniffi-swift.yml
+++ b/.github/workflows/uniffi-swift.yml
@@ -85,7 +85,8 @@ jobs:
 
       - name: Publish to hosting repo
         if: ${{ !inputs.dry_run }}
-        uses: livekit/publish-xcframework-action@200ee4984ef1b68068c0b3c4e87e798988730c90 # main @ fix: abort on missing source files (#3)
+        # TODO: repin to the merge commit once livekit/publish-xcframework-action#5 lands.
+        uses: livekit/publish-xcframework-action@94cb0ea28a25e18469c4a3e43c7f162a84da2169 # feat/glob-sources @ feat: allow path patterns as file sources (#5)
         with:
           xcframework-zip: ${{ env.OUTPUT_DIR }}/Rust${{ env.SPM_NAME }}.xcframework.zip
           version: ${{ inputs.version }}
@@ -96,12 +97,9 @@ jobs:
             ${{ env.OUTPUT_DIR }}/${{ env.SPM_NAME }}.podspec:${{ env.SPM_NAME }}.podspec
             ${{ env.OUTPUT_DIR }}/LICENSE:LICENSE
             ${{ env.OUTPUT_DIR }}/PrivacyInfo.xcprivacy:PrivacyInfo.xcprivacy
-            # One entry per UniFFI component (each `setup_scaffolding!()` crate gets its own
-            # generated file). Add a line here when a component is added, or the published
-            # package will be missing types and fail to build for consumers.
-            ${{ env.OUTPUT_DIR }}/Sources/${{ env.SPM_NAME }}/livekit_uniffi.swift:Sources/${{ env.SPM_NAME }}/livekit_uniffi.swift
-            ${{ env.OUTPUT_DIR }}/Sources/${{ env.SPM_NAME }}/livekit_common.swift:Sources/${{ env.SPM_NAME }}/livekit_common.swift
-            ${{ env.OUTPUT_DIR }}/Sources/${{ env.SPM_NAME }}/livekit_datatrack.swift:Sources/${{ env.SPM_NAME }}/livekit_datatrack.swift
+            # UniFFI emits one source per component, so match rather than list them:
+            # adding a component must not require a workflow change.
+            ${{ env.OUTPUT_DIR }}/Sources/${{ env.SPM_NAME }}/*.swift:Sources/${{ env.SPM_NAME }}/
           token: ${{ secrets.UNIFFI_XCFRAMEWORK_PAT }}
           pr-body: |
             Source tag: `${{ inputs.tag_name }}`

--- a/.github/workflows/uniffi-swift.yml
+++ b/.github/workflows/uniffi-swift.yml
@@ -96,7 +96,11 @@ jobs:
             ${{ env.OUTPUT_DIR }}/${{ env.SPM_NAME }}.podspec:${{ env.SPM_NAME }}.podspec
             ${{ env.OUTPUT_DIR }}/LICENSE:LICENSE
             ${{ env.OUTPUT_DIR }}/PrivacyInfo.xcprivacy:PrivacyInfo.xcprivacy
+            # One entry per UniFFI component (each `setup_scaffolding!()` crate gets its own
+            # generated file). Add a line here when a component is added, or the published
+            # package will be missing types and fail to build for consumers.
             ${{ env.OUTPUT_DIR }}/Sources/${{ env.SPM_NAME }}/livekit_uniffi.swift:Sources/${{ env.SPM_NAME }}/livekit_uniffi.swift
+            ${{ env.OUTPUT_DIR }}/Sources/${{ env.SPM_NAME }}/livekit_common.swift:Sources/${{ env.SPM_NAME }}/livekit_common.swift
             ${{ env.OUTPUT_DIR }}/Sources/${{ env.SPM_NAME }}/livekit_datatrack.swift:Sources/${{ env.SPM_NAME }}/livekit_datatrack.swift
           token: ${{ secrets.UNIFFI_XCFRAMEWORK_PAT }}
           pr-body: |

--- a/.github/workflows/uniffi-swift.yml
+++ b/.github/workflows/uniffi-swift.yml
@@ -85,8 +85,7 @@ jobs:
 
       - name: Publish to hosting repo
         if: ${{ !inputs.dry_run }}
-        # TODO: repin to the merge commit once livekit/publish-xcframework-action#5 lands.
-        uses: livekit/publish-xcframework-action@94cb0ea28a25e18469c4a3e43c7f162a84da2169 # feat/glob-sources @ feat: allow path patterns as file sources (#5)
+        uses: livekit/publish-xcframework-action@a1bc3de909f9c0a2b7f92172a95d6dd35cb20b1a # main @ feat: allow path patterns as file sources (#5)
         with:
           xcframework-zip: ${{ env.OUTPUT_DIR }}/Rust${{ env.SPM_NAME }}.xcframework.zip
           version: ${{ inputs.version }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3963,7 +3963,9 @@ dependencies = [
 name = "livekit-common"
 version = "0.1.1"
 dependencies = [
+ "bytes",
  "livekit-protocol",
+ "uniffi",
 ]
 
 [[package]]
@@ -3999,6 +4001,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "indexmap 2.14.0",
+ "livekit-common",
  "livekit-protocol",
  "livekit-runtime",
  "log",
@@ -4104,6 +4107,7 @@ dependencies = [
  "camino",
  "futures-util",
  "livekit-api",
+ "livekit-common",
  "livekit-datatrack",
  "livekit-protocol",
  "log",

--- a/livekit-common/Cargo.toml
+++ b/livekit-common/Cargo.toml
@@ -9,10 +9,10 @@ repository.workspace = true
 
 [dependencies]
 livekit-protocol = { workspace = true }
-bytes = { workspace = true }
+bytes = { workspace = true, optional = true }
 uniffi = { workspace = true, features = ["scaffolding-ffi-buffer-fns"], optional = true }
 
 [features]
 # Exposes this crate's shared FFI type registrations. Enabled transitively by
 # livekit-uniffi so every component borrows one converter per type.
-uniffi = ["dep:uniffi"]
+uniffi = ["dep:uniffi", "dep:bytes"]

--- a/livekit-common/Cargo.toml
+++ b/livekit-common/Cargo.toml
@@ -9,3 +9,10 @@ repository.workspace = true
 
 [dependencies]
 livekit-protocol = { workspace = true }
+bytes = { workspace = true }
+uniffi = { workspace = true, features = ["scaffolding-ffi-buffer-fns"], optional = true }
+
+[features]
+# Exposes this crate's shared FFI type registrations. Enabled transitively by
+# livekit-uniffi so every component borrows one converter per type.
+uniffi = ["dep:uniffi"]

--- a/livekit-common/src/ffi_types.rs
+++ b/livekit-common/src/ffi_types.rs
@@ -1,0 +1,29 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared UniFFI type registrations.
+//!
+//! A remote type such as [`bytes::Bytes`] can only be registered once per UniFFI component:
+//! `custom_type!` emits a `public` converter per component, and the generated Swift files are
+//! compiled into a single module, so a second registration fails to build. Registering it here
+//! and having each component borrow it with `uniffi::use_remote_type!` keeps exactly one
+//! declaration no matter how many crates need the type.
+//!
+//! Owning a registration requires being a UniFFI component: `custom_type!` needs
+//! `crate::UniFfiTag`, and bindgen rejects type metadata that belongs to no namespace
+//! (`Unknown namespace for CustomType`). Hence the `setup_scaffolding!` in `lib.rs`.
+
+use bytes::Bytes;
+
+uniffi::custom_type!(Bytes, Vec<u8>, { remote });

--- a/livekit-common/src/lib.rs
+++ b/livekit-common/src/lib.rs
@@ -22,6 +22,14 @@ use livekit_protocol as proto;
 
 mod enum_dispatch;
 
+// Must sit at the crate root: it defines `crate::UniFfiTag`, which the registrations in
+// `ffi_types` resolve against.
+#[cfg(feature = "uniffi")]
+uniffi::setup_scaffolding!();
+
+#[cfg(feature = "uniffi")]
+mod ffi_types;
+
 // -------------------------------------------------------------------------------------------------
 // Client protocol
 // -------------------------------------------------------------------------------------------------

--- a/livekit-common/uniffi.toml
+++ b/livekit-common/uniffi.toml
@@ -1,0 +1,4 @@
+[bindings.swift]
+# Matches the Rust<Name> convention used by the other components; the cargo-swift
+# fork folds every component's header into the single RustLiveKitUniFFI framework.
+ffi_module_name = "RustLiveKitCommon"

--- a/livekit-datatrack/Cargo.toml
+++ b/livekit-datatrack/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [dependencies]
 livekit-protocol = { workspace = true }
+livekit-common = { workspace = true, optional = true }
 livekit-runtime = { workspace = true, features = ["tokio"] }
 log = { workspace = true }
 thiserror = { workspace = true }
@@ -25,7 +26,7 @@ uniffi = { workspace = true, features = ["scaffolding-ffi-buffer-fns"], optional
 indexmap = "2"
 
 [features]
-uniffi = ["dep:uniffi"]
+uniffi = ["dep:uniffi", "dep:livekit-common", "livekit-common/uniffi"]
 __fuzz = ["dep:fake"]
 
 [dev-dependencies]

--- a/livekit-datatrack/src/e2ee.rs
+++ b/livekit-datatrack/src/e2ee.rs
@@ -76,7 +76,7 @@ pub trait DecryptionProvider: Send + Sync + Debug {
 }
 
 #[cfg(feature = "uniffi")]
-uniffi::custom_type!(Bytes, Vec<u8>, { remote });
+uniffi::use_remote_type!(livekit_common::Bytes);
 
 #[cfg(feature = "uniffi")]
 uniffi::custom_type!(InitializationVector, Vec<u8>, {

--- a/livekit-uniffi/Cargo.toml
+++ b/livekit-uniffi/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 
 [dependencies]
 livekit-protocol = { workspace = true }
+livekit-common = { workspace = true, features = ["uniffi"] }
 livekit-api = { workspace = true, default-features = false, features = ["access-token"] }
 livekit-datatrack = { workspace = true, features = ["uniffi"] }
 uniffi = { workspace = true, features = ["scaffolding-ffi-buffer-fns", "tokio"] }

--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -475,24 +475,6 @@ mkdir -p "${out_dir}"
 mv "${SPM_NAME}" "${out_dir}"
 """
 
-# Post-generation Swift workarounds for issues cargo-swift / the templates don't handle.
-# Currently: the `Bytes` custom type is registered in both crates, so uniffi emits its
-# converter in both component Swift files, which collide in one module ("invalid
-# redeclaration of 'Bytes'"). Drop the duplicate from livekit_datatrack.swift.
-# Upstream: https://github.com/mozilla/uniffi-rs/issues/2933. Idempotent.
-[tasks.swift-workarounds]
-private = true
-script_runner = "@shell"
-script = '''
-file="${PACKAGES_DIR}/swift/${SPM_NAME}/Sources/${SPM_NAME}/livekit_datatrack.swift"
-if [ ! -f "$file" ]; then
-  echo "swift-workarounds: $file not found, skipping"
-  exit 0
-fi
-perl -0pi -e 's{public typealias Bytes = Data.*?public func FfiConverterTypeBytes_lower\(_ value: Bytes\) -> RustBuffer \{\n    return FfiConverterTypeBytes\.lower\(value\)\n\}}{// cargo-make swift-workarounds: duplicate Bytes converter removed (kept in livekit_uniffi.swift)}s' "$file"
-echo "swift-workarounds: ensured single Bytes converter in $file"
-'''
-
 [tasks.swift-package-flow]
 private = true
 dependencies = [
@@ -501,8 +483,7 @@ dependencies = [
     "swift-check-size",
     "swift-zip-xcframework",
     "swift-generate-manifest",
-    "swift-move-to-packages",
-    "swift-workarounds"
+    "swift-move-to-packages"
 ]
 
 [tasks.swift-package]

--- a/livekit-uniffi/src/common.rs
+++ b/livekit-uniffi/src/common.rs
@@ -14,10 +14,8 @@
 
 use bytes::Bytes;
 
-// `Bytes` is a remote type, so each UniFFI component that registers it with
-// `custom_type!` emits its own converter — and the two component Swift files are
-// compiled into one module, so a second `typealias Bytes` fails to build
-// ("invalid redeclaration of 'Bytes'"). Reuse livekit-datatrack's registration
-// instead of adding a second one; the type is then emitted once, in the file that
-// owns it. Upstream: https://github.com/mozilla/uniffi-rs/issues/2933
-uniffi::use_remote_type!(livekit_datatrack::Bytes);
+// `Bytes` is registered once in livekit-common so every component that needs it borrows the
+// same converter; registering it here as well would emit a second `public typealias Bytes`
+// into this component's Swift file, and both files compile into one module.
+// Upstream: https://github.com/mozilla/uniffi-rs/issues/2933
+uniffi::use_remote_type!(livekit_common::Bytes);

--- a/livekit-uniffi/src/common.rs
+++ b/livekit-uniffi/src/common.rs
@@ -14,4 +14,10 @@
 
 use bytes::Bytes;
 
-uniffi::custom_type!(Bytes, Vec<u8>, { remote });
+// `Bytes` is a remote type, so each UniFFI component that registers it with
+// `custom_type!` emits its own converter — and the two component Swift files are
+// compiled into one module, so a second `typealias Bytes` fails to build
+// ("invalid redeclaration of 'Bytes'"). Reuse livekit-datatrack's registration
+// instead of adding a second one; the type is then emitted once, in the file that
+// owns it. Upstream: https://github.com/mozilla/uniffi-rs/issues/2933
+uniffi::use_remote_type!(livekit_datatrack::Bytes);


### PR DESCRIPTION
`bytes::Bytes` was registered with `custom_type!` in both `livekit-uniffi` and `livekit-datatrack`. A remote type can only be registered once per UniFFI component: each emits its own `public typealias Bytes` and `FfiConverterTypeBytes`, and cargo-swift compiles every component file into one Swift module — `invalid redeclaration of 'Bytes'`. UniFFI's own duplicated helpers coexist because they're `fileprivate`; `custom_type!` emits `public`, so they don't. Patched until now by a perl regex in `swift-workarounds`, which is deleted here.

`livekit-common` now owns the registration and every component borrows it:

```rust
uniffi::use_remote_type!(livekit_common::Bytes);
```

Owning a registration means being a component — `custom_type!` resolves `crate::UniFfiTag`, and bindgen rejects metadata belonging to no namespace (`Unknown namespace for CustomType`). So `livekit-common` gains an optional `uniffi` feature, enabled transitively by `livekit-uniffi`, and a third generated Swift file. **That file had to be added to `uniffi-swift.yml`** — the publish step enumerates sources rather than globbing, so an unlisted component silently ships a package that can't build. Costs 4,160 B on the cdylib (1,107,856 → 1,112,016), leaving 66 KiB under the iOS gate.

Verified: `livekit-common` and `livekit-datatrack` still build without the feature; the three-file Swift module compiles; `client-sdk-swift` `main` builds clean against the generated package, tests included; the xcframework carries all three headers in one framework modulemap.

## Alternatives for the collision

| Option | Verdict |
| --- | --- |
| Keep the perl regex | Fragile — matches literal generated formatting, so it silently no-ops when uniffi's Swift templates shift — and Swift-only, so Kotlin and Python kept shipping two declarations. |
| Let `livekit-datatrack` own it | Free (80 B, no new component), but an unintuitive home for a generic byte buffer, and any future component would have to depend on `livekit-datatrack` to borrow it. Was the first version of this PR. |
| Collapse to one component — drop `uniffi` from `livekit-datatrack` and mirror its types with `#[uniffi::remote]` | Removes the class outright and returns the duplication below. But ~150 lines of mirrored Rust, hand-written adapters for the two `with_foreign` traits, and dropping `#[non_exhaustive]` from two enums. Separate PR. |

Upstream: [#2933](https://github.com/mozilla/uniffi-rs/issues/2933) (open) is this bug, and this PR takes the external-type route it proposes. [#2126](https://github.com/mozilla/uniffi-rs/issues/2126) (open) — no `#[uniffi::remote(Trait)]` in 0.31 or 0.32 — is why collapsing needs trait adapters. [#2802](https://github.com/mozilla/uniffi-rs/issues/2802) (open) is the same conflict across separate UniFFI *libraries*.

## Alternatives for the duplication

Not addressed here. Each component re-emits the whole FFI runtime: ≈19 KB across three of them — 8.3 KB native and ~10.6 KB of Swift code+data, from two measured per-component deltas of ~4.2 KB and 5,287 B.

| Option | Verdict |
| --- | --- |
| Hoist the shared Swift runtime into one `internal` file | Worse — prototyped at **+14,592 B** on the linked binary, because it destroys the per-file specializations that make the duplicate copies cheap. Buys ~5% compile time. |
| Wait for upstream to emit the common part once | Asked for twice, declined twice. Not in flight. |
| Collapse to one component | The only thing that actually returns it. |

Upstream: [#408](https://github.com/mozilla/uniffi-rs/issues/408) / [#409](https://github.com/mozilla/uniffi-rs/pull/409) (closed) asked to eliminate re-declared Swift helpers and were resolved with the `UNIFFI_SHARED_H` guard plus `fileprivate` — duplicates left to coexist rather than removed. [#2257](https://github.com/mozilla/uniffi-rs/issues/2257) (closed) asked to combine the per-crate outputs; closed without a feature. [#2153](https://github.com/mozilla/uniffi-rs/issues/2153) (open) is the only live proposal that would share the runtime, and also documents the Python breakage: bindgen writes `from . import livekit_datatrack` into a flat out-dir with no `__init__.py`, giving `ImportError: attempted relative import with no known parent package`. [#2930](https://github.com/mozilla/uniffi-rs/issues/2930) (open) is the Swift → bindings-pipeline migration such a change would land on.