### PR TITLE
yuv-sys: actionable error when libyuv submodule is not initialized

### DIFF
--- a/.changeset/yuv_sys_submodule_guard_error.md
+++ b/.changeset/yuv_sys_submodule_guard_error.md
@@ -1,0 +1,7 @@
+---
+yuv-sys: patch
+livekit-ffi: patch
+imgproc: patch
+---
+
+yuv-sys: fail with an actionable error when the libyuv submodule is not initialized

--- a/yuv-sys/build.rs
+++ b/yuv-sys/build.rs
@@ -141,7 +141,6 @@ fn main() {
              Run: git submodule update --init --recursive"
         );
     }
-    
     let cloned = clone_if_needed(&output_dir, &libyuv_dir);
 
     let include_files = fs::read_dir(include_dir.join("libyuv"))

--- a/yuv-sys/build.rs
+++ b/yuv-sys/build.rs
@@ -134,6 +134,14 @@ fn main() {
     let is_aarch64 = target_arch == "aarch64";
     let is_arm32 = target_arch == "arm";
 
+    // The vendored libyuv submodule must be initialized before we copy it.
+    if !Path::new("libyuv").join("include/libyuv.h").exists() {
+        panic!(
+            "yuv-sys/libyuv submodule is missing or empty. \
+             Run: git submodule update --init --recursive"
+        );
+    }
+    
     let cloned = clone_if_needed(&output_dir, &libyuv_dir);
 
     let include_files = fs::read_dir(include_dir.join("libyuv"))


### PR DESCRIPTION
## Problem

A fresh `git clone` without `--recursive` leaves `yuv-sys/libyuv` empty. The build script copies the empty directory and fails several calls later with:

thread 'main' panicked at yuv-sys/build.rs:140:10:
called Result::unwrap() on an Err value: Os { code: 2, kind: NotFound, message: "No such file or directory" }

Nothing in the error points at the submodule as the cause, and the README build instructions don't mention `--recursive`. CI/container builds don't hit this because the Dockerfile initializes submodules explicitly — it only affects local builds from a fresh clone.

## Fix

Check for `libyuv/include/libyuv.h` before the copy and panic with the remedy.

## Verification

- `git submodule deinit -f yuv-sys/libyuv` → build fails with the new message
- `git submodule update --init` → clean build succeeds (macOS, aarch64)