### PR TITLE
Capture: pattern source

### DIFF
--- a/.changeset/capture-source-pattern.md
+++ b/.changeset/capture-source-pattern.md
@@ -1,0 +1,6 @@
+---
+livekit-capture: minor
+livekit-ffi: minor
+---
+
+Add a capture source that renders a test pattern on the GPU.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3964,10 +3964,14 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "livekit",
+ "log",
+ "pollster",
  "schemars",
  "serde",
  "thiserror 2.0.19",
  "tokio",
+ "wgpu",
+ "yuv-sys",
 ]
 
 [[package]]

--- a/livekit-capture/AGENTS.md
+++ b/livekit-capture/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+## Adding a source
+
+- Add a feature gate in `Cargo.toml`
+  - Name the feature after the source module with a `source-` prefix
+    (e.g., module `gstreamer` → feature `source-gstreamer`)
+  - If the new source requires dependencies, they should only be include when feature is enabled
+- Define a module for the new source in `src/sources/mod.rs`:
+  ```rust
+  #[cfg(feature = "source-my-source")]
+  pub mod my_source;
+  ```
+- Follow conventions for existing sources
+- Source implementation should be self-contained in its module and submodules
+  - Only hoist functionality to a higher level module when shared by multiple sources
+- Source (e.g, `MyVideoSource`) is constructed from a config struct (e.g., `MyVideoSourceConfig`)
+- Add conditional derives for `serde` and `schemars` for config
+- Implement `PixelVideoSource` or `EncodedVideoSource` for your source
+  - NEVER add a source that is not consumable uniformly through one of these traits
+  - Doing so would break API contract and break integration for consumers
+- Keep API surface minimal and hide implementation details

--- a/livekit-capture/Cargo.toml
+++ b/livekit-capture/Cargo.toml
@@ -10,10 +10,14 @@ repository.workspace = true
 [dependencies]
 bytes = { workspace = true }
 livekit = { workspace = true }
+log = { workspace = true }
+pollster = { version = "0.4", optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
+wgpu = { workspace = true, optional = true }
+yuv-sys = { workspace = true, features = ["jpeg"], optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "time", "macros"] }
@@ -26,3 +30,6 @@ schemars = ["dep:schemars", "serde"]
 # Async convenience wrappers for blocking source construction when using
 # a tokio runtime.
 tokio = ["tokio/rt"]
+
+# Pixel sources
+source-pattern = ["dep:pollster", "dep:wgpu", "dep:yuv-sys"]

--- a/livekit-capture/README.md
+++ b/livekit-capture/README.md
@@ -5,17 +5,17 @@
 > There may be bugs, and APIs and configuration options are subject to change during this period.
 
 This crate provides video capture sources and the pumps that publish them
-with the LiveKit [Rust SDK](../livekit/README.md). Implement one small trait
-to add a source. The application runs and supervises every source the same
-way.
+with the LiveKit [Rust SDK](../livekit/README.md). Pick a ready-made source,
+or implement one small trait to add your own. The application runs and
+supervises every source the same way.
 
 ## Source and pump
 
 Two concepts make up the crate. Video reaches a LiveKit track in one of two
 forms, so the source and the pump each have two variants.
 
-**A source** produces video, one blocking call at a time. Implement one of
-these two traits:
+**A source** produces video, one blocking call at a time. Use a ready-made
+source (see [Sources](#sources)), or implement the trait to add your own:
 
 - A `pixel::PixelVideoSource` produces raw `VideoFrame`s — from a camera, for
   example. The WebRTC encoder encodes them.
@@ -40,9 +40,9 @@ A pump supplies the RTC source and the publish options, so publication is the
 same for either path.
 
 ```rust
-let pump = PixelVideoPump::new(MyVideoSource::new(config).await?);
+let pump = PixelVideoPump::new(PatternVideoSource::new(config).await?);
 
-let track = LocalVideoTrack::create_video_track("my-source", pump.rtc_source());
+let track = LocalVideoTrack::create_video_track("pattern", pump.rtc_source());
 let options = pump.publish_options();
 room.local_participant().publish_track(LocalTrack::Video(track), options).await?;
 
@@ -52,9 +52,11 @@ let running = pump.spawn()?;
 let stats = running.stop_and_join_async().await?;
 ```
 
-## Adding a source
+## Sources
 
-Implement `pixel::PixelVideoSource` for raw frames or
-`encoded::EncodedVideoSource` for pre-encoded access units. A source is
-constructed from its own config struct and is driven by the matching pump —
-no other integration is needed.
+Each source lives in its own module under `sources`, behind a Cargo feature
+named `source-<module>`. Each module documents its source.
+
+| Feature            | Source                 | Kind    |
+| ------------------ | ---------------------- | ------- |
+| `source-pattern`   | `PatternVideoSource`   | pixel   |

--- a/livekit-capture/shaders/gradient.wgsl
+++ b/livekit-capture/shaders/gradient.wgsl
@@ -1,0 +1,5 @@
+// Animated color gradient: the built-in gradient pattern.
+fn shade(uv: vec2<f32>) -> vec4<f32> {
+    let color = 0.5 + 0.5 * cos(lk.time_s + uv.xyx * 4.0 + vec3<f32>(0.0, 2.0, 4.0));
+    return vec4<f32>(color, 1.0);
+}

--- a/livekit-capture/shaders/logo.wgsl
+++ b/livekit-capture/shaders/logo.wgsl
@@ -1,0 +1,101 @@
+// Bouncing LiveKit logo: the built-in logo pattern.
+//
+// A white 7x7-cell tile carries the LiveKit glyph in black at its
+// center. The tile moves in a straight line and reflects off the frame
+// edges. Position is a pure function of time.
+//
+// All rectangles get about two pixels of edge feather. The soft edges
+// make sub-pixel motion smooth, and they survive chroma subsampling and
+// video encoding.
+
+// The glyph as a 5x5 bitmap. Each row is a 5-bit mask. The highest bit
+// is the leftmost column:
+//
+//   1 0 0 0 1
+//   1 0 0 1 0
+//   1 0 1 0 0
+//   1 0 0 1 0
+//   1 1 1 0 1
+const GLYPH_ROWS: array<u32, 5> = array<u32, 5>(0x11u, 0x12u, 0x14u, 0x12u, 0x1du);
+
+// Cells per tile side, and the glyph offset into the tile, in cells.
+const TILE_CELLS: f32 = 7.0;
+const GLYPH_OFFSET: f32 = 1.0;
+
+// Tile height as a fraction of the frame height. This keeps the logo
+// the same visual size at every resolution.
+const LOGO_SIZE: f32 = 0.25;
+
+// Speed along each axis, in frame heights per second. The two values
+// have no small common multiple, so the bounce path repeats slowly.
+const SPEED: vec2<f32> = vec2<f32>(0.23, 0.17);
+
+// Starting phase, so the logo does not start in a corner.
+const START_PHASE: vec2<f32> = vec2<f32>(0.34, 0.71);
+
+// White and black keep every edge luma-only. Luma has full resolution
+// in 4:2:0 video, so these edges encode cleanly.
+const TILE_COLOR: vec3<f32> = vec3<f32>(1.0, 1.0, 1.0);
+const GLYPH_COLOR: vec3<f32> = vec3<f32>(0.0, 0.0, 0.0);
+const BACKGROUND: vec3<f32> = vec3<f32>(0.0, 0.0, 0.0);
+
+// Folds a growing phase into ping-pong motion between 0.0 and 1.0.
+fn ping_pong(phase: f32) -> f32 {
+    return 1.0 - abs(1.0 - 2.0 * fract(phase * 0.5));
+}
+
+// Coverage of the rectangle [min_p, max_p] at point `p`. The interior
+// is fully opaque. Alpha falls to zero over `feather` outside the edge,
+// so touching rectangles union without seams.
+fn rect_alpha(p: vec2<f32>, min_p: vec2<f32>, max_p: vec2<f32>, feather: f32) -> f32 {
+    let center = (min_p + max_p) * 0.5;
+    let half_size = (max_p - min_p) * 0.5;
+    let d = abs(p - center) - half_size;
+    let outside = length(max(d, vec2<f32>(0.0)));
+    let inside = min(max(d.x, d.y), 0.0);
+    return 1.0 - smoothstep(0.0, feather, outside + inside);
+}
+
+fn shade(uv: vec2<f32>) -> vec4<f32> {
+    // Work in a space that is `aspect` wide and 1.0 tall, so the cells
+    // stay square. Pixels in this space are 1.0 / height on both axes.
+    let height = max(lk.resolution.y, 1.0);
+    let aspect = lk.resolution.x / height;
+    let p = vec2<f32>(uv.x * aspect, uv.y);
+
+    // Distance the logo can travel along each axis. The lower bound
+    // keeps the math finite when the frame is narrower than the logo.
+    let travel = max(vec2<f32>(aspect, 1.0) - vec2<f32>(LOGO_SIZE), vec2<f32>(0.0001));
+    let phase = START_PHASE + lk.time_s * SPEED / travel;
+    let origin = vec2<f32>(ping_pong(phase.x), ping_pong(phase.y)) * travel;
+
+    // About two output pixels of edge feather.
+    let feather = 2.0 / height;
+
+    // Skip the coverage math outside the tile and its feather band.
+    let local = p - origin;
+    if local.x < -feather || local.x > LOGO_SIZE + feather
+        || local.y < -feather || local.y > LOGO_SIZE + feather {
+        return vec4<f32>(BACKGROUND, 1.0);
+    }
+
+    // Coverage of the tile, and of the glyph cells inside it.
+    let tile = rect_alpha(p, origin, origin + vec2<f32>(LOGO_SIZE), feather);
+
+    let cell_size = LOGO_SIZE / TILE_CELLS;
+    var glyph = 0.0;
+    for (var row = 0u; row < 5u; row = row + 1u) {
+        let bits = GLYPH_ROWS[row];
+        for (var col = 0u; col < 5u; col = col + 1u) {
+            if ((bits >> (4u - col)) & 1u) == 0u {
+                continue;
+            }
+            let cell_min = origin
+                + (vec2<f32>(f32(col), f32(row)) + vec2<f32>(GLYPH_OFFSET)) * cell_size;
+            glyph = max(glyph, rect_alpha(p, cell_min, cell_min + vec2<f32>(cell_size), feather));
+        }
+    }
+
+    let logo = mix(TILE_COLOR, GLYPH_COLOR, glyph);
+    return vec4<f32>(mix(BACKGROUND, logo, tile), 1.0);
+}

--- a/livekit-capture/shaders/prelude.wgsl
+++ b/livekit-capture/shaders/prelude.wgsl
@@ -1,0 +1,34 @@
+// Prelude prepended to every pattern fragment snippet by the pattern
+// video source. It declares the uniforms, draws one triangle that covers
+// the full target, and calls the snippet's `shade` function once per
+// pixel.
+//
+// Each pattern snippet must define `fn shade(uv: vec2<f32>) -> vec4<f32>`,
+// and must not redeclare the names below.
+
+struct LkUniforms {
+    resolution: vec2<f32>,
+    time_s: f32,
+    frame_index: u32,
+}
+
+@group(0) @binding(0) var<uniform> lk: LkUniforms;
+
+struct LkVertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> LkVertexOutput {
+    let corner = vec2<f32>(f32((vertex_index << 1u) & 2u), f32(vertex_index & 2u));
+    var out: LkVertexOutput;
+    out.position = vec4<f32>(corner * 2.0 - 1.0, 0.0, 1.0);
+    out.uv = vec2<f32>(corner.x, 1.0 - corner.y);
+    return out;
+}
+
+@fragment
+fn fs_main(in: LkVertexOutput) -> @location(0) vec4<f32> {
+    return shade(in.uv);
+}

--- a/livekit-capture/src/error.rs
+++ b/livekit-capture/src/error.rs
@@ -20,6 +20,9 @@
 
 use std::{error::Error as StdError, fmt};
 
+#[cfg(feature = "source-pattern")]
+pub use crate::renderer::RendererError;
+
 /// Error returned by a capture source.
 ///
 /// `Display` and [`StdError::source`] delegate to the wrapped backend

--- a/livekit-capture/src/renderer.rs
+++ b/livekit-capture/src/renderer.rs
@@ -1,0 +1,485 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Crate-internal GPU renderer shared by the shader-backed sources.
+//!
+//! [`ShaderRenderer`] renders a WGSL module offscreen through wgpu, one
+//! frame at a time, and reads each frame back as I420. The caller
+//! supplies the module and the per-frame uniform bytes. [`FramePacer`]
+//! paces the frames against an ideal timeline.
+
+use crate::{primitive::VideoResolution, pump::PumpStop};
+use livekit::webrtc::video_frame::I420Buffer;
+use std::{
+    sync::{mpsc, Arc, Mutex},
+    thread,
+    time::{Duration, Instant},
+};
+use thiserror::Error;
+
+/// Render target format. Its memory layout (B, G, R, A) is the layout
+/// libyuv names ARGB.
+const TARGET_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Bgra8Unorm;
+
+/// Bytes per pixel of [`TARGET_FORMAT`].
+const TARGET_BYTES_PER_PIXEL: u32 = 4;
+
+/// Upper bound on one blocking GPU wait, so the stop token is observed
+/// promptly.
+const STOP_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Total time to wait for one frame readback before the renderer fails.
+const READBACK_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Error returned by the GPU renderer.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum RendererError {
+    /// No compatible GPU adapter is available.
+    #[error("no compatible GPU adapter: {0}")]
+    NoAdapter(String),
+    /// The GPU adapter rejected the device request.
+    #[error("failed to open the GPU device: {0}")]
+    Device(String),
+    /// The shader or its pipeline failed to build.
+    #[error("failed to build the shader pipeline: {0}")]
+    ShaderCompile(String),
+    /// The GPU reported an error.
+    #[error("GPU error: {0}")]
+    Backend(String),
+    /// Reading the rendered frame back from the GPU failed.
+    #[error("failed to read the frame back from the GPU: {0}")]
+    Readback(String),
+    /// Pixel conversion failed.
+    #[error("failed to convert the rendered frame to I420: {0}")]
+    Convert(&'static str),
+}
+
+/// Paces frames against an ideal timeline, so frame timestamps are
+/// jitter-free.
+#[derive(Debug)]
+pub(crate) struct FramePacer {
+    interval_us: u64,
+    started: Option<Instant>,
+    frame_index: u64,
+}
+
+impl FramePacer {
+    /// Creates a pacer. The frame rate must be non-zero.
+    pub(crate) fn new(framerate_fps: u32) -> Self {
+        let interval_us = (Duration::from_secs(1) / framerate_fps).as_micros() as u64;
+        Self { interval_us, started: None, frame_index: 0 }
+    }
+
+    /// Sleeps until the next frame is due. Returns the elapsed time on
+    /// the ideal timeline and the index of the frame.
+    ///
+    /// The sleep is at most one frame interval.
+    pub(crate) fn wait_for_next_frame(&mut self) -> (Duration, u64) {
+        let started = *self.started.get_or_insert_with(Instant::now);
+        let elapsed = Duration::from_micros(self.frame_index.saturating_mul(self.interval_us));
+        let due = started + elapsed;
+        if let Some(wait) = due.checked_duration_since(Instant::now()) {
+            thread::sleep(wait);
+        }
+        let frame_index = self.frame_index;
+        self.frame_index += 1;
+        (elapsed, frame_index)
+    }
+}
+
+/// Renders a WGSL module offscreen and reads frames back as I420.
+///
+/// The module must define a vertex entry point `vs_main` and a fragment
+/// entry point `fs_main`. The renderer draws one triangle, which must
+/// cover the full target. The module can declare one uniform buffer at
+/// group 0, binding 0. The caller supplies its bytes for each frame.
+pub(crate) struct ShaderRenderer {
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    pipeline: wgpu::RenderPipeline,
+    bind_group: wgpu::BindGroup,
+    uniform_buffer: wgpu::Buffer,
+    uniform_size: u64,
+    target: wgpu::Texture,
+    target_view: wgpu::TextureView,
+    /// Readback destination, reused across frames. Rows are padded to
+    /// the wgpu copy alignment.
+    staging: wgpu::Buffer,
+    padded_bytes_per_row: u32,
+    resolution: VideoResolution,
+    /// First uncaptured GPU error, stashed by the device error handler
+    /// and surfaced on the next frame.
+    device_error: Arc<Mutex<Option<String>>>,
+}
+
+impl ShaderRenderer {
+    /// Opens a GPU device, compiles the module, and builds the pipeline
+    /// and readback resources.
+    pub(crate) fn new(
+        resolution: VideoResolution,
+        module_code: &str,
+        uniform_size: u64,
+    ) -> Result<Self, RendererError> {
+        let VideoResolution { width, height } = resolution;
+        let padded_bytes_per_row = padded_bytes_per_row(width)
+            .ok_or_else(|| RendererError::Backend("resolution is too large".to_owned()))?;
+
+        // Rendering is offscreen, so no display handle is needed. WGPU_*
+        // environment variables can override the backend and adapter
+        // selection.
+        let instance =
+            wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::from_env().unwrap_or_default(),
+            ..Default::default()
+        }))
+        .map_err(|err| RendererError::NoAdapter(err.to_string()))?;
+
+        let info = adapter.get_info();
+        log::info!("Rendering with GPU \"{}\" ({})", info.name, info.backend);
+
+        // Clamp the default limits to what the adapter supports, so weaker
+        // adapters (GL, software rasterizers) still open. A resolution
+        // beyond the clamped limits fails texture creation below.
+        let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("lk_render_device"),
+            required_limits: wgpu::Limits::default().or_worse_values_from(&adapter.limits()),
+            ..Default::default()
+        }))
+        .map_err(|err| RendererError::Device(err.to_string()))?;
+
+        // Runtime GPU errors have no return channel of their own: stash
+        // the first one and report it from the next render_frame call.
+        let device_error: Arc<Mutex<Option<String>>> = Arc::default();
+        let sink = Arc::clone(&device_error);
+        device.on_uncaptured_error(Arc::new(move |error: wgpu::Error| {
+            log::error!("render GPU error: {error}");
+            let mut slot = sink.lock().unwrap();
+            if slot.is_none() {
+                *slot = Some(error.to_string());
+            }
+        }));
+
+        // Compile the shader and build the pipeline under an error scope,
+        // so a bad shader fails construction with its compile message.
+        let scope = device.push_error_scope(wgpu::ErrorFilter::Validation);
+        let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("lk_render_module"),
+            source: wgpu::ShaderSource::Wgsl(module_code.into()),
+        });
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("lk_render_bind_group_layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: wgpu::BufferSize::new(uniform_size),
+                },
+                count: None,
+            }],
+        });
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("lk_render_pipeline_layout"),
+            bind_group_layouts: &[Some(&bind_group_layout)],
+            immediate_size: 0,
+        });
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("lk_render_pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &module,
+                entry_point: Some("vs_main"),
+                compilation_options: Default::default(),
+                buffers: &[],
+            },
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            fragment: Some(wgpu::FragmentState {
+                module: &module,
+                entry_point: Some("fs_main"),
+                compilation_options: Default::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: TARGET_FORMAT,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            multiview_mask: None,
+            cache: None,
+        });
+        if let Some(error) = pollster::block_on(scope.pop()) {
+            return Err(RendererError::ShaderCompile(error.to_string()));
+        }
+
+        // Build the target and readback resources under their own scope,
+        // so an unsupported resolution also fails construction.
+        let scope = device.push_error_scope(wgpu::ErrorFilter::Validation);
+        let target = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("lk_render_target"),
+            size: wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: TARGET_FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let target_view = target.create_view(&wgpu::TextureViewDescriptor::default());
+        let uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("lk_render_uniforms"),
+            size: uniform_size,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("lk_render_bind_group"),
+            layout: &bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: uniform_buffer.as_entire_binding(),
+            }],
+        });
+        let staging = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("lk_render_staging"),
+            size: u64::from(padded_bytes_per_row) * u64::from(height),
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+        if let Some(error) = pollster::block_on(scope.pop()) {
+            return Err(RendererError::Backend(error.to_string()));
+        }
+
+        Ok(Self {
+            device,
+            queue,
+            pipeline,
+            bind_group,
+            uniform_buffer,
+            uniform_size,
+            target,
+            target_view,
+            staging,
+            padded_bytes_per_row,
+            resolution,
+            device_error,
+        })
+    }
+
+    /// Renders one frame with the given uniform bytes and reads it back
+    /// as I420. Returns `Ok(None)` when the stop token fires during the
+    /// readback wait.
+    ///
+    /// Every blocking wait is bounded by [`STOP_POLL_INTERVAL`], so the
+    /// stop token is observed promptly.
+    pub(crate) fn render_frame(
+        &self,
+        uniform: &[u8],
+        stop: &PumpStop,
+    ) -> Result<Option<I420Buffer>, RendererError> {
+        debug_assert_eq!(uniform.len() as u64, self.uniform_size);
+        self.check_device_error()?;
+
+        let VideoResolution { width, height } = self.resolution;
+        self.queue.write_buffer(&self.uniform_buffer, 0, uniform);
+
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: Some("lk_render") });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("lk_render_pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &self.target_view,
+                    depth_slice: None,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                ..Default::default()
+            });
+            pass.set_pipeline(&self.pipeline);
+            pass.set_bind_group(0, &self.bind_group, &[]);
+            pass.draw(0..3, 0..1);
+        }
+        encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture: &self.target,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &self.staging,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(self.padded_bytes_per_row),
+                    rows_per_image: None,
+                },
+            },
+            wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+        );
+        // Schedule the mapping with the submission, so no separate
+        // map_async call is needed after submit.
+        let (mapped_tx, mapped_rx) = mpsc::channel();
+        encoder.map_buffer_on_submit(&self.staging, wgpu::MapMode::Read, .., move |result| {
+            let _ = mapped_tx.send(result);
+        });
+        let submission = self.queue.submit([encoder.finish()]);
+
+        if !self.wait_for_map(submission, &mapped_rx, stop)? {
+            // Stopped: cancel the pending mapping to leave the buffer
+            // reusable.
+            self.staging.unmap();
+            return Ok(None);
+        }
+
+        let mapped = self.staging.slice(..).get_mapped_range();
+        let converted = convert_to_i420(&mapped, self.padded_bytes_per_row, width, height);
+        drop(mapped);
+        self.staging.unmap();
+        converted.map(Some)
+    }
+
+    /// Waits for the staging buffer to be mapped. Returns `Ok(false)` when
+    /// the stop token fires first.
+    fn wait_for_map(
+        &self,
+        submission: wgpu::SubmissionIndex,
+        mapped: &mpsc::Receiver<Result<(), wgpu::BufferAsyncError>>,
+        stop: &PumpStop,
+    ) -> Result<bool, RendererError> {
+        let deadline = Instant::now() + READBACK_TIMEOUT;
+        loop {
+            let poll = self.device.poll(wgpu::PollType::Wait {
+                submission_index: Some(submission.clone()),
+                timeout: Some(STOP_POLL_INTERVAL),
+            });
+            match poll {
+                Ok(_) | Err(wgpu::PollError::Timeout) => {}
+                Err(err) => return Err(RendererError::Readback(err.to_string())),
+            }
+            match mapped.try_recv() {
+                Ok(Ok(())) => return Ok(true),
+                Ok(Err(err)) => return Err(RendererError::Readback(err.to_string())),
+                Err(mpsc::TryRecvError::Empty) => {}
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    return Err(RendererError::Readback("map callback was dropped".to_owned()));
+                }
+            }
+            self.check_device_error()?;
+            if stop.is_stopped() {
+                return Ok(false);
+            }
+            if Instant::now() >= deadline {
+                return Err(RendererError::Readback("timed out waiting for the GPU".to_owned()));
+            }
+        }
+    }
+
+    /// Reports the first stashed GPU error, if there is one.
+    fn check_device_error(&self) -> Result<(), RendererError> {
+        match &*self.device_error.lock().unwrap() {
+            Some(message) => Err(RendererError::Backend(message.clone())),
+            None => Ok(()),
+        }
+    }
+}
+
+/// Returns the staging-buffer row stride: the pixel row size rounded up
+/// to the wgpu copy alignment. `None` when the value overflows `u32`.
+fn padded_bytes_per_row(width: u32) -> Option<u32> {
+    let unpadded = u64::from(width) * u64::from(TARGET_BYTES_PER_PIXEL);
+    let align = u64::from(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
+    u32::try_from(unpadded.div_ceil(align) * align).ok()
+}
+
+/// Returns whether a GPU adapter is available. Tests that need a GPU
+/// skip when there is none.
+#[cfg(test)]
+pub(crate) fn gpu_available() -> bool {
+    let instance =
+        wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());
+    pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions::default())).is_ok()
+}
+
+/// Converts one padded BGRA image to a freshly allocated I420 buffer.
+fn convert_to_i420(
+    source: &[u8],
+    source_stride: u32,
+    width: u32,
+    height: u32,
+) -> Result<I420Buffer, RendererError> {
+    if source.len() < source_stride as usize * height as usize {
+        return Err(RendererError::Convert("mapped frame is too short"));
+    }
+    let source_stride = i32::try_from(source_stride)
+        .map_err(|_| RendererError::Convert("stride exceeds supported range"))?;
+    let width_i32 = i32::try_from(width)
+        .map_err(|_| RendererError::Convert("width exceeds supported range"))?;
+    let height_i32 = i32::try_from(height)
+        .map_err(|_| RendererError::Convert("height exceeds supported range"))?;
+
+    let mut buffer = I420Buffer::new(width, height);
+    let (stride_y, stride_u, stride_v) = buffer.strides();
+    let (dst_y, dst_u, dst_v) = buffer.data_mut();
+    // SAFETY: The source slice covers `height` rows of `source_stride` bytes, and the
+    // destination planes come from a freshly allocated I420Buffer with matching width,
+    // height, and strides.
+    let ret = unsafe {
+        yuv_sys::rs_ARGBToI420(
+            source.as_ptr(),
+            source_stride,
+            dst_y.as_mut_ptr(),
+            stride_y as i32,
+            dst_u.as_mut_ptr(),
+            stride_u as i32,
+            dst_v.as_mut_ptr(),
+            stride_v as i32,
+            width_i32,
+            height_i32,
+        )
+    };
+    if ret != 0 {
+        return Err(RendererError::Convert("ARGBToI420 failed"));
+    }
+    Ok(buffer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rows_are_padded_to_the_copy_alignment() {
+        assert_eq!(padded_bytes_per_row(64), Some(256));
+        assert_eq!(padded_bytes_per_row(321), Some(1536));
+        assert_eq!(padded_bytes_per_row(1280), Some(5120));
+        assert_eq!(padded_bytes_per_row(u32::MAX), None);
+    }
+
+    #[test]
+    fn pacer_reports_the_ideal_timeline() {
+        let mut pacer = FramePacer::new(1000);
+        let (first_elapsed, first_index) = pacer.wait_for_next_frame();
+        let (second_elapsed, second_index) = pacer.wait_for_next_frame();
+        assert_eq!((first_elapsed.as_micros(), first_index), (0, 0));
+        assert_eq!((second_elapsed.as_micros(), second_index), (1_000, 1));
+    }
+}

--- a/livekit-capture/src/sources/mod.rs
+++ b/livekit-capture/src/sources/mod.rs
@@ -12,20 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Video capture for the LiveKit Rust SDK.
-//!
-//! A capture source produces video: pixel frames ([`pixel`]) or pre-encoded
-//! access units ([`encoded`]). A pump drives a source and publishes its
-//! output to an RTC video source. Ready-made sources live in [`sources`]
-//! and can be enabled by their corresponding features.
-
-pub mod encoded;
-pub mod error;
-pub mod pixel;
-pub mod primitive;
-pub mod pump;
-pub mod sources;
+//! Ready-made capture sources. Each source is gated behind its own
+//! `source-*` feature.
 
 #[cfg(feature = "source-pattern")]
-mod renderer;
-mod utils;
+pub mod pattern;

--- a/livekit-capture/src/sources/pattern.rs
+++ b/livekit-capture/src/sources/pattern.rs
@@ -1,0 +1,320 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test pattern video source.
+//!
+//! [`PatternVideoSource`] renders a built-in test pattern ([`Pattern`])
+//! on the GPU and yields the result as pixel video. Rendering is
+//! offscreen through [wgpu], so the source needs no window or display.
+//!
+//! The source reads each frame back from the GPU and converts it to I420
+//! on the CPU.
+//!
+//! [wgpu]: https://wgpu.rs
+
+use crate::{
+    error::SourceError,
+    pixel::PixelVideoSource,
+    primitive::VideoResolution,
+    pump::PumpStop,
+    renderer::{FramePacer, RendererError, ShaderRenderer},
+};
+use livekit::webrtc::video_frame::{BoxVideoFrame, VideoFrame, VideoRotation};
+use std::{fmt, time::Duration};
+use thiserror::Error;
+
+/// Size of the uniform block: `vec2<f32>` + `f32` + `u32`.
+const UNIFORM_BUFFER_SIZE: u64 = 16;
+
+/// Period after which the shader time uniform wraps: 2^13 seconds,
+/// about 2.3 hours.
+///
+/// f32 seconds lose precision as they grow. The wrap keeps the time
+/// resolution finer than one millisecond on long runs, at the cost of
+/// one pattern discontinuity per period. Frame timestamps do not wrap.
+const TIME_WRAP_PERIOD_US: u64 = 8_192_000_000;
+
+/// Prelude prepended to every fragment snippet. It draws one triangle
+/// that covers the full target and calls `shade` per pixel.
+const FRAGMENT_PRELUDE: &str = include_str!("../../shaders/prelude.wgsl");
+
+/// Fragment snippet for [`Pattern::Gradient`].
+const GRADIENT_SHADER: &str = include_str!("../../shaders/gradient.wgsl");
+
+/// Fragment snippet for [`Pattern::Logo`].
+const LOGO_SHADER: &str = include_str!("../../shaders/logo.wgsl");
+
+/// Test pattern rendered by a [`PatternVideoSource`].
+///
+/// Every pattern is a pure function of position, resolution, and time:
+/// the same configuration produces the same frames on every machine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "snake_case")
+)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[non_exhaustive]
+pub enum Pattern {
+    /// Animated color gradient.
+    Gradient,
+    /// Bouncing LiveKit logo.
+    Logo,
+}
+
+impl Pattern {
+    /// Returns the complete WGSL module to compile.
+    fn module_code(&self) -> String {
+        match self {
+            Self::Gradient => assemble_module(GRADIENT_SHADER),
+            Self::Logo => assemble_module(LOGO_SHADER),
+        }
+    }
+}
+
+/// Prepends the prelude to a pattern's fragment snippet.
+fn assemble_module(snippet: &str) -> String {
+    format!("{FRAGMENT_PRELUDE}\n{snippet}")
+}
+
+/// Configuration for a [`PatternVideoSource`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(deny_unknown_fields)
+)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct PatternVideoSourceConfig {
+    /// Output resolution.
+    pub resolution: VideoResolution,
+    /// Output frame rate in frames per second.
+    pub framerate_fps: u32,
+    /// Pattern to render.
+    pub pattern: Pattern,
+}
+
+/// Error returned by a pattern video source.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum PatternVideoSourceError {
+    /// The configured resolution has a zero component.
+    #[error("pattern source resolution must be non-zero")]
+    ZeroResolution,
+    /// The configured frame rate is zero.
+    #[error("pattern source frame rate must be non-zero")]
+    ZeroFramerate,
+    /// The GPU renderer failed.
+    #[error(transparent)]
+    Render(#[from] RendererError),
+}
+
+/// Pixel video source that renders a test pattern on the GPU.
+///
+/// The source sleeps to pace itself to the configured frame rate. It
+/// never reaches the end of its stream — stop the pump that drives it
+/// instead.
+pub struct PatternVideoSource {
+    config: PatternVideoSourceConfig,
+    renderer: ShaderRenderer,
+    pacer: FramePacer,
+}
+
+impl PatternVideoSource {
+    /// Creates the source. GPU setup runs on the tokio blocking pool.
+    ///
+    /// Requires a running tokio runtime. Use
+    /// [`PatternVideoSource::new_blocking`] outside of async contexts.
+    #[cfg(feature = "tokio")]
+    pub async fn new(config: PatternVideoSourceConfig) -> Result<Self, SourceError> {
+        crate::utils::run_blocking(move || Self::new_blocking(config)).await
+    }
+
+    /// Selects a GPU adapter, compiles the pattern's shader, and builds
+    /// the render pipeline.
+    ///
+    /// Construction fails when no GPU is available, or for a zero
+    /// resolution or frame rate.
+    pub fn new_blocking(config: PatternVideoSourceConfig) -> Result<Self, SourceError> {
+        validate_config(&config).map_err(SourceError::new)?;
+        let renderer = ShaderRenderer::new(
+            config.resolution,
+            &config.pattern.module_code(),
+            UNIFORM_BUFFER_SIZE,
+        )
+        .map_err(|error| SourceError::new(PatternVideoSourceError::Render(error)))?;
+        let pacer = FramePacer::new(config.framerate_fps);
+        Ok(Self { config, renderer, pacer })
+    }
+
+    /// Returns the configuration the source was created with.
+    pub fn config(&self) -> &PatternVideoSourceConfig {
+        &self.config
+    }
+}
+
+impl PixelVideoSource for PatternVideoSource {
+    fn resolution(&self) -> VideoResolution {
+        self.config.resolution
+    }
+
+    // The pacing sleep is at most one frame interval, and the renderer
+    // bounds every readback wait, so the stop token is observed promptly.
+    fn next_frame(&mut self, stop: &PumpStop) -> Result<Option<BoxVideoFrame>, SourceError> {
+        let (elapsed, frame_index) = self.pacer.wait_for_next_frame();
+
+        // The shader time wraps to keep its f32 precision on long runs,
+        // and the uniform frame index wraps after u32::MAX frames.
+        let elapsed_us = elapsed.as_micros() as u64;
+        let time_s = Duration::from_micros(elapsed_us % TIME_WRAP_PERIOD_US).as_secs_f32();
+        let uniform = uniform_bytes(self.config.resolution, time_s, frame_index as u32);
+
+        let buffer = self
+            .renderer
+            .render_frame(&uniform, stop)
+            .map_err(|error| SourceError::new(PatternVideoSourceError::Render(error)))?;
+        let Some(buffer) = buffer else {
+            // The stop token fired during the readback wait.
+            return Ok(None);
+        };
+
+        Ok(Some(VideoFrame {
+            rotation: VideoRotation::VideoRotation0,
+            timestamp_us: elapsed.as_micros() as i64,
+            frame_metadata: None,
+            buffer: Box::new(buffer),
+        }))
+    }
+}
+
+impl fmt::Debug for PatternVideoSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PatternVideoSource").field("config", &self.config).finish_non_exhaustive()
+    }
+}
+
+/// Validates the CPU-checkable parts of a configuration.
+fn validate_config(config: &PatternVideoSourceConfig) -> Result<(), PatternVideoSourceError> {
+    let VideoResolution { width, height } = config.resolution;
+    if width == 0 || height == 0 {
+        return Err(PatternVideoSourceError::ZeroResolution);
+    }
+    if config.framerate_fps == 0 {
+        return Err(PatternVideoSourceError::ZeroFramerate);
+    }
+    Ok(())
+}
+
+/// Serializes the uniform block: resolution, time, and frame index.
+fn uniform_bytes(
+    resolution: VideoResolution,
+    time_s: f32,
+    frame_index: u32,
+) -> [u8; UNIFORM_BUFFER_SIZE as usize] {
+    let mut bytes = [0u8; UNIFORM_BUFFER_SIZE as usize];
+    bytes[0..4].copy_from_slice(&(resolution.width as f32).to_ne_bytes());
+    bytes[4..8].copy_from_slice(&(resolution.height as f32).to_ne_bytes());
+    bytes[8..12].copy_from_slice(&time_s.to_ne_bytes());
+    bytes[12..16].copy_from_slice(&frame_index.to_ne_bytes());
+    bytes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::renderer::gpu_available;
+
+    const RESOLUTION: VideoResolution = VideoResolution { width: 64, height: 36 };
+
+    fn gradient_config() -> PatternVideoSourceConfig {
+        PatternVideoSourceConfig {
+            resolution: RESOLUTION,
+            framerate_fps: 1000,
+            pattern: Pattern::Gradient,
+        }
+    }
+
+    #[test]
+    fn validation_rejects_zero_resolution_and_framerate() {
+        let mut config = gradient_config();
+        config.resolution = VideoResolution::new(0, 36);
+        assert!(matches!(validate_config(&config), Err(PatternVideoSourceError::ZeroResolution)));
+
+        let mut config = gradient_config();
+        config.framerate_fps = 0;
+        assert!(matches!(validate_config(&config), Err(PatternVideoSourceError::ZeroFramerate)));
+    }
+
+    #[test]
+    fn pattern_modules_include_the_prelude() {
+        for pattern in [Pattern::Gradient, Pattern::Logo] {
+            let code = pattern.module_code();
+            assert!(code.contains("fn vs_main"), "{pattern:?} is missing the prelude");
+            assert!(code.contains("fn fs_main"), "{pattern:?} is missing the prelude");
+            assert!(code.contains("fn shade"), "{pattern:?} is missing a shade function");
+        }
+    }
+
+    #[test]
+    fn gradient_renders_frames_at_the_frame_rate() {
+        if !gpu_available() {
+            eprintln!("skipping: no GPU adapter available");
+            return;
+        }
+        let mut source = PatternVideoSource::new_blocking(gradient_config()).unwrap();
+
+        let stop = PumpStop::new();
+        let first = source.next_frame(&stop).unwrap().unwrap();
+        let second = source.next_frame(&stop).unwrap().unwrap();
+        assert_eq!((first.buffer.width(), first.buffer.height()), (64, 36));
+        assert_eq!(first.timestamp_us, 0);
+        assert_eq!(second.timestamp_us, 1_000);
+
+        // The gradient's top-left pixel at time zero is red-dominant:
+        // RGB (255, 68, 47), which is about (121, 91, 211) in
+        // limited-range BT.601. A red/blue channel swap in the readback
+        // path flips the two chroma values, so this check catches it.
+        let i420 = first.buffer.as_i420().expect("pattern source yields I420 buffers");
+        let (y, u, v) = i420.data();
+        assert!(y[0].abs_diff(121) <= 5, "unexpected luma {}", y[0]);
+        assert!(u[0].abs_diff(91) <= 6, "unexpected chroma-u {}", u[0]);
+        assert!(v[0].abs_diff(211) <= 6, "unexpected chroma-v {}", v[0]);
+    }
+
+    #[test]
+    fn logo_renders_on_a_black_background() {
+        if !gpu_available() {
+            eprintln!("skipping: no GPU adapter available");
+            return;
+        }
+        let mut source = PatternVideoSource::new_blocking(PatternVideoSourceConfig {
+            resolution: RESOLUTION,
+            framerate_fps: 1000,
+            pattern: Pattern::Logo,
+        })
+        .unwrap();
+
+        let frame = source.next_frame(&PumpStop::new()).unwrap().unwrap();
+        let i420 = frame.buffer.as_i420().expect("pattern source yields I420 buffers");
+        let (y, _, _) = i420.data();
+
+        // The logo starts away from the corners, so the top-left pixel is
+        // background black (luma 16 in limited range), and the lit tile
+        // pixels stand out well above it.
+        assert!(y[0] <= 20, "top-left pixel is not background: {}", y[0]);
+        let lit = y.iter().filter(|&&luma| luma > 60).count();
+        assert!(lit > 5, "no logo pixels found (lit count {lit})");
+    }
+}

--- a/livekit-ffi-node-bindings/proto/capture_pb.d.ts
+++ b/livekit-ffi-node-bindings/proto/capture_pb.d.ts
@@ -24,6 +24,27 @@ import type { TrackPublishOptions } from "./room_pb.js";
 import type { FfiOwnedHandle } from "./handle_pb.js";
 
 /**
+ * Test patterns built into livekit-capture.
+ *
+ * @generated from enum livekit.proto.Pattern
+ */
+export declare enum Pattern {
+  /**
+   * Animated color gradient.
+   *
+   * @generated from enum value: PATTERN_GRADIENT = 0;
+   */
+  GRADIENT = 0,
+
+  /**
+   * Bouncing LiveKit logo.
+   *
+   * @generated from enum value: PATTERN_LOGO = 1;
+   */
+  LOGO = 1,
+}
+
+/**
  * Kind of media a capture source produces.
  *
  * @generated from enum livekit.proto.CaptureSourceKind
@@ -63,6 +84,48 @@ export declare enum CaptureExit {
    * @generated from enum value: CAPTURE_EXIT_END_OF_STREAM = 1;
    */
   END_OF_STREAM = 1,
+}
+
+/**
+ * Test pattern rendered on the GPU.
+ *
+ * @generated from message livekit.proto.PatternVideoSourceConfig
+ */
+export declare class PatternVideoSourceConfig extends Message<PatternVideoSourceConfig> {
+  /**
+   * Output resolution.
+   *
+   * @generated from field: required livekit.proto.VideoSourceResolution resolution = 1;
+   */
+  resolution?: VideoSourceResolution;
+
+  /**
+   * Output frame rate in frames per second.
+   *
+   * @generated from field: required uint32 framerate_fps = 2;
+   */
+  framerateFps?: number;
+
+  /**
+   * Pattern to render.
+   *
+   * @generated from field: required livekit.proto.Pattern pattern = 3;
+   */
+  pattern?: Pattern;
+
+  constructor(data?: PartialMessage<PatternVideoSourceConfig>);
+
+  static readonly runtime: typeof proto2;
+  static readonly typeName = "livekit.proto.PatternVideoSourceConfig";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): PatternVideoSourceConfig;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): PatternVideoSourceConfig;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): PatternVideoSourceConfig;
+
+  static equals(a: PatternVideoSourceConfig | PlainMessage<PatternVideoSourceConfig> | undefined, b: PatternVideoSourceConfig | PlainMessage<PatternVideoSourceConfig> | undefined): boolean;
 }
 
 /**
@@ -147,6 +210,112 @@ export declare class OwnedCaptureSource extends Message<OwnedCaptureSource> {
   static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): OwnedCaptureSource;
 
   static equals(a: OwnedCaptureSource | PlainMessage<OwnedCaptureSource> | undefined, b: OwnedCaptureSource | PlainMessage<OwnedCaptureSource> | undefined): boolean;
+}
+
+/**
+ * Create a new capture source from configuration.
+ *
+ * Completes asynchronously with a NewCaptureSourceCallback: construction
+ * starts the producer and may wait for its first output to discover stream
+ * settings.
+ *
+ * @generated from message livekit.proto.NewCaptureSourceRequest
+ */
+export declare class NewCaptureSourceRequest extends Message<NewCaptureSourceRequest> {
+  /**
+   * @generated from oneof livekit.proto.NewCaptureSourceRequest.config
+   */
+  config: {
+    /**
+     * @generated from field: livekit.proto.PatternVideoSourceConfig pattern = 2;
+     */
+    value: PatternVideoSourceConfig;
+    case: "pattern";
+  } | { case: undefined; value?: undefined };
+
+  /**
+   * @generated from field: optional uint64 request_async_id = 3;
+   */
+  requestAsyncId?: bigint;
+
+  constructor(data?: PartialMessage<NewCaptureSourceRequest>);
+
+  static readonly runtime: typeof proto2;
+  static readonly typeName = "livekit.proto.NewCaptureSourceRequest";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): NewCaptureSourceRequest;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): NewCaptureSourceRequest;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): NewCaptureSourceRequest;
+
+  static equals(a: NewCaptureSourceRequest | PlainMessage<NewCaptureSourceRequest> | undefined, b: NewCaptureSourceRequest | PlainMessage<NewCaptureSourceRequest> | undefined): boolean;
+}
+
+/**
+ * @generated from message livekit.proto.NewCaptureSourceResponse
+ */
+export declare class NewCaptureSourceResponse extends Message<NewCaptureSourceResponse> {
+  /**
+   * @generated from field: required uint64 async_id = 1;
+   */
+  asyncId?: bigint;
+
+  constructor(data?: PartialMessage<NewCaptureSourceResponse>);
+
+  static readonly runtime: typeof proto2;
+  static readonly typeName = "livekit.proto.NewCaptureSourceResponse";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): NewCaptureSourceResponse;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): NewCaptureSourceResponse;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): NewCaptureSourceResponse;
+
+  static equals(a: NewCaptureSourceResponse | PlainMessage<NewCaptureSourceResponse> | undefined, b: NewCaptureSourceResponse | PlainMessage<NewCaptureSourceResponse> | undefined): boolean;
+}
+
+/**
+ * @generated from message livekit.proto.NewCaptureSourceCallback
+ */
+export declare class NewCaptureSourceCallback extends Message<NewCaptureSourceCallback> {
+  /**
+   * @generated from field: required uint64 async_id = 1;
+   */
+  asyncId?: bigint;
+
+  /**
+   * @generated from oneof livekit.proto.NewCaptureSourceCallback.message
+   */
+  message: {
+    /**
+     * @generated from field: string error = 2;
+     */
+    value: string;
+    case: "error";
+  } | {
+    /**
+     * @generated from field: livekit.proto.OwnedCaptureSource source = 3;
+     */
+    value: OwnedCaptureSource;
+    case: "source";
+  } | { case: undefined; value?: undefined };
+
+  constructor(data?: PartialMessage<NewCaptureSourceCallback>);
+
+  static readonly runtime: typeof proto2;
+  static readonly typeName = "livekit.proto.NewCaptureSourceCallback";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): NewCaptureSourceCallback;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): NewCaptureSourceCallback;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): NewCaptureSourceCallback;
+
+  static equals(a: NewCaptureSourceCallback | PlainMessage<NewCaptureSourceCallback> | undefined, b: NewCaptureSourceCallback | PlainMessage<NewCaptureSourceCallback> | undefined): boolean;
 }
 
 /**

--- a/livekit-ffi-node-bindings/proto/capture_pb.js
+++ b/livekit-ffi-node-bindings/proto/capture_pb.js
@@ -26,6 +26,19 @@ const { TrackPublishOptions } = require("./room_pb.js");
 const { FfiOwnedHandle } = require("./handle_pb.js");
 
 /**
+ * Test patterns built into livekit-capture.
+ *
+ * @generated from enum livekit.proto.Pattern
+ */
+const Pattern = /*@__PURE__*/ proto2.makeEnum(
+  "livekit.proto.Pattern",
+  [
+    {no: 0, name: "PATTERN_GRADIENT", localName: "GRADIENT"},
+    {no: 1, name: "PATTERN_LOGO", localName: "LOGO"},
+  ],
+);
+
+/**
  * Kind of media a capture source produces.
  *
  * @generated from enum livekit.proto.CaptureSourceKind
@@ -52,6 +65,20 @@ const CaptureExit = /*@__PURE__*/ proto2.makeEnum(
 );
 
 /**
+ * Test pattern rendered on the GPU.
+ *
+ * @generated from message livekit.proto.PatternVideoSourceConfig
+ */
+const PatternVideoSourceConfig = /*@__PURE__*/ proto2.makeMessageType(
+  "livekit.proto.PatternVideoSourceConfig",
+  () => [
+    { no: 1, name: "resolution", kind: "message", T: VideoSourceResolution, req: true },
+    { no: 2, name: "framerate_fps", kind: "scalar", T: 13 /* ScalarType.UINT32 */, req: true },
+    { no: 3, name: "pattern", kind: "enum", T: proto2.getEnumType(Pattern), req: true },
+  ],
+);
+
+/**
  * @generated from message livekit.proto.CaptureSourceInfo
  */
 const CaptureSourceInfo = /*@__PURE__*/ proto2.makeMessageType(
@@ -73,6 +100,45 @@ const OwnedCaptureSource = /*@__PURE__*/ proto2.makeMessageType(
   () => [
     { no: 1, name: "handle", kind: "message", T: FfiOwnedHandle, req: true },
     { no: 2, name: "info", kind: "message", T: CaptureSourceInfo, req: true },
+  ],
+);
+
+/**
+ * Create a new capture source from configuration.
+ *
+ * Completes asynchronously with a NewCaptureSourceCallback: construction
+ * starts the producer and may wait for its first output to discover stream
+ * settings.
+ *
+ * @generated from message livekit.proto.NewCaptureSourceRequest
+ */
+const NewCaptureSourceRequest = /*@__PURE__*/ proto2.makeMessageType(
+  "livekit.proto.NewCaptureSourceRequest",
+  () => [
+    { no: 2, name: "pattern", kind: "message", T: PatternVideoSourceConfig, oneof: "config" },
+    { no: 3, name: "request_async_id", kind: "scalar", T: 4 /* ScalarType.UINT64 */, opt: true },
+  ],
+);
+
+/**
+ * @generated from message livekit.proto.NewCaptureSourceResponse
+ */
+const NewCaptureSourceResponse = /*@__PURE__*/ proto2.makeMessageType(
+  "livekit.proto.NewCaptureSourceResponse",
+  () => [
+    { no: 1, name: "async_id", kind: "scalar", T: 4 /* ScalarType.UINT64 */, req: true },
+  ],
+);
+
+/**
+ * @generated from message livekit.proto.NewCaptureSourceCallback
+ */
+const NewCaptureSourceCallback = /*@__PURE__*/ proto2.makeMessageType(
+  "livekit.proto.NewCaptureSourceCallback",
+  () => [
+    { no: 1, name: "async_id", kind: "scalar", T: 4 /* ScalarType.UINT64 */, req: true },
+    { no: 2, name: "error", kind: "scalar", T: 9 /* ScalarType.STRING */, oneof: "message" },
+    { no: 3, name: "source", kind: "message", T: OwnedCaptureSource, oneof: "message" },
   ],
 );
 
@@ -159,10 +225,15 @@ const CaptureSourceEvent = /*@__PURE__*/ proto2.makeMessageType(
 );
 
 
+exports.Pattern = Pattern;
 exports.CaptureSourceKind = CaptureSourceKind;
 exports.CaptureExit = CaptureExit;
+exports.PatternVideoSourceConfig = PatternVideoSourceConfig;
 exports.CaptureSourceInfo = CaptureSourceInfo;
 exports.OwnedCaptureSource = OwnedCaptureSource;
+exports.NewCaptureSourceRequest = NewCaptureSourceRequest;
+exports.NewCaptureSourceResponse = NewCaptureSourceResponse;
+exports.NewCaptureSourceCallback = NewCaptureSourceCallback;
 exports.StartCaptureRequest = StartCaptureRequest;
 exports.StartCaptureResponse = StartCaptureResponse;
 exports.StopCaptureRequest = StopCaptureRequest;

--- a/livekit-ffi-node-bindings/proto/ffi_pb.d.ts
+++ b/livekit-ffi-node-bindings/proto/ffi_pb.d.ts
@@ -28,7 +28,7 @@ import type { PerformRpcCallback, PerformRpcRequest, PerformRpcResponse, Registe
 import type { EnableRemoteTrackPublicationRequest, EnableRemoteTrackPublicationResponse, SetRemoteTrackPublicationQualityRequest, SetRemoteTrackPublicationQualityResponse, UpdateRemoteTrackPublicationDimensionRequest, UpdateRemoteTrackPublicationDimensionResponse } from "./track_publication_pb.js";
 import type { ByteStreamOpenCallback, ByteStreamOpenRequest, ByteStreamOpenResponse, ByteStreamReaderEvent, ByteStreamReaderReadAllCallback, ByteStreamReaderReadAllRequest, ByteStreamReaderReadAllResponse, ByteStreamReaderReadIncrementalRequest, ByteStreamReaderReadIncrementalResponse, ByteStreamReaderWriteToFileCallback, ByteStreamReaderWriteToFileRequest, ByteStreamReaderWriteToFileResponse, ByteStreamWriterCloseCallback, ByteStreamWriterCloseRequest, ByteStreamWriterCloseResponse, ByteStreamWriterWriteCallback, ByteStreamWriterWriteRequest, ByteStreamWriterWriteResponse, StreamSendBytesCallback, StreamSendBytesRequest, StreamSendBytesResponse, StreamSendFileCallback, StreamSendFileRequest, StreamSendFileResponse, StreamSendTextCallback, StreamSendTextRequest, StreamSendTextResponse, TextStreamOpenCallback, TextStreamOpenRequest, TextStreamOpenResponse, TextStreamReaderEvent, TextStreamReaderReadAllCallback, TextStreamReaderReadAllRequest, TextStreamReaderReadAllResponse, TextStreamReaderReadIncrementalRequest, TextStreamReaderReadIncrementalResponse, TextStreamWriterCloseCallback, TextStreamWriterCloseRequest, TextStreamWriterCloseResponse, TextStreamWriterWriteCallback, TextStreamWriterWriteRequest, TextStreamWriterWriteResponse } from "./data_stream_pb.js";
 import type { DataTrackStreamEvent, DataTrackStreamReadRequest, DataTrackStreamReadResponse, DefineSchemaCallback, DefineSchemaRequest, DefineSchemaResponse, GetSchemaCallback, GetSchemaRequest, GetSchemaResponse, LocalDataTrackIsPublishedRequest, LocalDataTrackIsPublishedResponse, LocalDataTrackTryPushRequest, LocalDataTrackTryPushResponse, LocalDataTrackUnpublishRequest, LocalDataTrackUnpublishResponse, PublishDataTrackCallback, PublishDataTrackRequest, PublishDataTrackResponse, RemoteDataTrackIsPublishedRequest, RemoteDataTrackIsPublishedResponse, RemoteDataTrackSetPipelineOptionsRequest, RemoteDataTrackSetPipelineOptionsResponse, SubscribeDataTrackRequest, SubscribeDataTrackResponse } from "./data_track_pb.js";
-import type { CaptureSourceEvent, StartCaptureRequest, StartCaptureResponse, StopCaptureRequest, StopCaptureResponse } from "./capture_pb.js";
+import type { CaptureSourceEvent, NewCaptureSourceCallback, NewCaptureSourceRequest, NewCaptureSourceResponse, StartCaptureRequest, StartCaptureResponse, StopCaptureRequest, StopCaptureResponse } from "./capture_pb.js";
 
 /**
  * @generated from enum livekit.proto.LogLevel
@@ -616,6 +616,12 @@ export declare class FfiRequest extends Message<FfiRequest> {
     /**
      * Capture sources (livekit-capture; requires the `capture` feature)
      *
+     * @generated from field: livekit.proto.NewCaptureSourceRequest new_capture_source = 87;
+     */
+    value: NewCaptureSourceRequest;
+    case: "newCaptureSource";
+  } | {
+    /**
      * @generated from field: livekit.proto.StartCaptureRequest start_capture = 88;
      */
     value: StartCaptureRequest;
@@ -1192,6 +1198,12 @@ export declare class FfiResponse extends Message<FfiResponse> {
     /**
      * Capture sources (livekit-capture; requires the `capture` feature)
      *
+     * @generated from field: livekit.proto.NewCaptureSourceResponse new_capture_source = 87;
+     */
+    value: NewCaptureSourceResponse;
+    case: "newCaptureSource";
+  } | {
+    /**
      * @generated from field: livekit.proto.StartCaptureResponse start_capture = 88;
      */
     value: StartCaptureResponse;
@@ -1514,6 +1526,12 @@ export declare class FfiEvent extends Message<FfiEvent> {
     /**
      * Capture sources (livekit-capture; requires the `capture` feature)
      *
+     * @generated from field: livekit.proto.NewCaptureSourceCallback new_capture_source = 47;
+     */
+    value: NewCaptureSourceCallback;
+    case: "newCaptureSource";
+  } | {
+    /**
      * @generated from field: livekit.proto.CaptureSourceEvent capture_source_event = 48;
      */
     value: CaptureSourceEvent;

--- a/livekit-ffi-node-bindings/proto/ffi_pb.js
+++ b/livekit-ffi-node-bindings/proto/ffi_pb.js
@@ -30,7 +30,7 @@ const { PerformRpcCallback, PerformRpcRequest, PerformRpcResponse, RegisterRpcMe
 const { EnableRemoteTrackPublicationRequest, EnableRemoteTrackPublicationResponse, SetRemoteTrackPublicationQualityRequest, SetRemoteTrackPublicationQualityResponse, UpdateRemoteTrackPublicationDimensionRequest, UpdateRemoteTrackPublicationDimensionResponse } = require("./track_publication_pb.js");
 const { ByteStreamOpenCallback, ByteStreamOpenRequest, ByteStreamOpenResponse, ByteStreamReaderEvent, ByteStreamReaderReadAllCallback, ByteStreamReaderReadAllRequest, ByteStreamReaderReadAllResponse, ByteStreamReaderReadIncrementalRequest, ByteStreamReaderReadIncrementalResponse, ByteStreamReaderWriteToFileCallback, ByteStreamReaderWriteToFileRequest, ByteStreamReaderWriteToFileResponse, ByteStreamWriterCloseCallback, ByteStreamWriterCloseRequest, ByteStreamWriterCloseResponse, ByteStreamWriterWriteCallback, ByteStreamWriterWriteRequest, ByteStreamWriterWriteResponse, StreamSendBytesCallback, StreamSendBytesRequest, StreamSendBytesResponse, StreamSendFileCallback, StreamSendFileRequest, StreamSendFileResponse, StreamSendTextCallback, StreamSendTextRequest, StreamSendTextResponse, TextStreamOpenCallback, TextStreamOpenRequest, TextStreamOpenResponse, TextStreamReaderEvent, TextStreamReaderReadAllCallback, TextStreamReaderReadAllRequest, TextStreamReaderReadAllResponse, TextStreamReaderReadIncrementalRequest, TextStreamReaderReadIncrementalResponse, TextStreamWriterCloseCallback, TextStreamWriterCloseRequest, TextStreamWriterCloseResponse, TextStreamWriterWriteCallback, TextStreamWriterWriteRequest, TextStreamWriterWriteResponse } = require("./data_stream_pb.js");
 const { DataTrackStreamEvent, DataTrackStreamReadRequest, DataTrackStreamReadResponse, DefineSchemaCallback, DefineSchemaRequest, DefineSchemaResponse, GetSchemaCallback, GetSchemaRequest, GetSchemaResponse, LocalDataTrackIsPublishedRequest, LocalDataTrackIsPublishedResponse, LocalDataTrackTryPushRequest, LocalDataTrackTryPushResponse, LocalDataTrackUnpublishRequest, LocalDataTrackUnpublishResponse, PublishDataTrackCallback, PublishDataTrackRequest, PublishDataTrackResponse, RemoteDataTrackIsPublishedRequest, RemoteDataTrackIsPublishedResponse, RemoteDataTrackSetPipelineOptionsRequest, RemoteDataTrackSetPipelineOptionsResponse, SubscribeDataTrackRequest, SubscribeDataTrackResponse } = require("./data_track_pb.js");
-const { CaptureSourceEvent, StartCaptureRequest, StartCaptureResponse, StopCaptureRequest, StopCaptureResponse } = require("./capture_pb.js");
+const { CaptureSourceEvent, NewCaptureSourceCallback, NewCaptureSourceRequest, NewCaptureSourceResponse, StartCaptureRequest, StartCaptureResponse, StopCaptureRequest, StopCaptureResponse } = require("./capture_pb.js");
 
 /**
  * @generated from enum livekit.proto.LogLevel
@@ -140,6 +140,7 @@ const FfiRequest = /*@__PURE__*/ proto2.makeMessageType(
     { no: 81, name: "start_recording", kind: "message", T: StartRecordingRequest, oneof: "message" },
     { no: 82, name: "stop_recording", kind: "message", T: StopRecordingRequest, oneof: "message" },
     { no: 83, name: "ready_for_room_event", kind: "message", T: ReadyForRoomEventRequest, oneof: "message" },
+    { no: 87, name: "new_capture_source", kind: "message", T: NewCaptureSourceRequest, oneof: "message" },
     { no: 88, name: "start_capture", kind: "message", T: StartCaptureRequest, oneof: "message" },
     { no: 89, name: "stop_capture", kind: "message", T: StopCaptureRequest, oneof: "message" },
   ],
@@ -237,6 +238,7 @@ const FfiResponse = /*@__PURE__*/ proto2.makeMessageType(
     { no: 80, name: "start_recording", kind: "message", T: StartRecordingResponse, oneof: "message" },
     { no: 81, name: "stop_recording", kind: "message", T: StopRecordingResponse, oneof: "message" },
     { no: 82, name: "ready_for_room_event", kind: "message", T: ReadyForRoomEventResponse, oneof: "message" },
+    { no: 87, name: "new_capture_source", kind: "message", T: NewCaptureSourceResponse, oneof: "message" },
     { no: 88, name: "start_capture", kind: "message", T: StartCaptureResponse, oneof: "message" },
     { no: 89, name: "stop_capture", kind: "message", T: StopCaptureResponse, oneof: "message" },
   ],
@@ -297,6 +299,7 @@ const FfiEvent = /*@__PURE__*/ proto2.makeMessageType(
     { no: 44, name: "simulate_scenario", kind: "message", T: SimulateScenarioCallback, oneof: "message" },
     { no: 45, name: "define_schema", kind: "message", T: DefineSchemaCallback, oneof: "message" },
     { no: 46, name: "get_schema", kind: "message", T: GetSchemaCallback, oneof: "message" },
+    { no: 47, name: "new_capture_source", kind: "message", T: NewCaptureSourceCallback, oneof: "message" },
     { no: 48, name: "capture_source_event", kind: "message", T: CaptureSourceEvent, oneof: "message" },
   ],
 );

--- a/livekit-ffi/Cargo.toml
+++ b/livekit-ffi/Cargo.toml
@@ -23,6 +23,7 @@ tracing = ["tokio/tracing", "console-subscriber"]
 # producers. This enables the capture scaffolding only; enable a
 # `capture-*` feature to include a specific source.
 capture = ["dep:livekit-capture", "livekit-capture/tokio"]
+capture-pattern = ["capture", "livekit-capture/source-pattern"]
 
 [dependencies]
 livekit = { workspace = true }

--- a/livekit-ffi/protocol/capture.proto
+++ b/livekit-ffi/protocol/capture.proto
@@ -37,6 +37,24 @@ import "video_frame.proto";
 // 3. The capture runs until StopCaptureRequest, end of stream, or an error;
 //    a CaptureSourceEvent is delivered exactly once when it ends.
 
+// Test patterns built into livekit-capture.
+enum Pattern {
+  // Animated color gradient.
+  PATTERN_GRADIENT = 0;
+  // Bouncing LiveKit logo.
+  PATTERN_LOGO = 1;
+}
+
+// Test pattern rendered on the GPU.
+message PatternVideoSourceConfig {
+  // Output resolution.
+  required VideoSourceResolution resolution = 1;
+  // Output frame rate in frames per second.
+  required uint32 framerate_fps = 2;
+  // Pattern to render.
+  required Pattern pattern = 3;
+}
+
 // Kind of media a capture source produces.
 enum CaptureSourceKind {
   // Pixel frames, published through the WebRTC encoder.
@@ -63,6 +81,26 @@ message CaptureSourceInfo {
 message OwnedCaptureSource {
   required FfiOwnedHandle handle = 1;
   required CaptureSourceInfo info = 2;
+}
+
+// Create a new capture source from configuration.
+//
+// Completes asynchronously with a NewCaptureSourceCallback: construction
+// starts the producer and may wait for its first output to discover stream
+// settings.
+message NewCaptureSourceRequest {
+  oneof config {
+    PatternVideoSourceConfig pattern = 2;
+  }
+  optional uint64 request_async_id = 3;
+}
+message NewCaptureSourceResponse { required uint64 async_id = 1; }
+message NewCaptureSourceCallback {
+  required uint64 async_id = 1;
+  oneof message {
+    string error = 2;
+    OwnedCaptureSource source = 3;
+  }
 }
 
 // Start pumping frames from a capture source into its RTC video source.

--- a/livekit-ffi/protocol/ffi.proto
+++ b/livekit-ffi/protocol/ffi.proto
@@ -186,6 +186,7 @@ message FfiRequest {
     ReadyForRoomEventRequest ready_for_room_event = 83;
 
     // Capture sources (livekit-capture; requires the `capture` feature)
+    NewCaptureSourceRequest new_capture_source = 87;
     StartCaptureRequest start_capture = 88;
     StopCaptureRequest stop_capture = 89;
 
@@ -319,6 +320,7 @@ message FfiResponse {
     ReadyForRoomEventResponse ready_for_room_event = 82;
 
     // Capture sources (livekit-capture; requires the `capture` feature)
+    NewCaptureSourceResponse new_capture_source = 87;
     StartCaptureResponse start_capture = 88;
     StopCaptureResponse stop_capture = 89;
 
@@ -392,6 +394,7 @@ message FfiEvent {
     GetSchemaCallback get_schema = 46;
 
     // Capture sources (livekit-capture; requires the `capture` feature)
+    NewCaptureSourceCallback new_capture_source = 47;
     CaptureSourceEvent capture_source_event = 48;
 
     // NEXT_ID: 49

--- a/livekit-ffi/src/conversion/capture.rs
+++ b/livekit-ffi/src/conversion/capture.rs
@@ -1,0 +1,56 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::proto;
+use livekit_capture::{encoded::EncodedVideoCodec, primitive::VideoResolution};
+
+#[cfg(feature = "capture-pattern")]
+use crate::{FfiError, FfiResult};
+#[cfg(feature = "capture-pattern")]
+use livekit_capture::sources::pattern::{Pattern, PatternVideoSourceConfig};
+
+impl From<proto::VideoSourceResolution> for VideoResolution {
+    fn from(resolution: proto::VideoSourceResolution) -> Self {
+        Self::new(resolution.width, resolution.height)
+    }
+}
+
+#[cfg(feature = "capture-pattern")]
+pub fn pattern_config_from_proto(
+    config: proto::PatternVideoSourceConfig,
+) -> FfiResult<PatternVideoSourceConfig> {
+    let pattern = proto::Pattern::try_from(config.pattern)
+        .map_err(|_| FfiError::InvalidRequest("invalid pattern".into()))?;
+    Ok(PatternVideoSourceConfig {
+        resolution: config.resolution.into(),
+        framerate_fps: config.framerate_fps,
+        pattern: match pattern {
+            proto::Pattern::Gradient => Pattern::Gradient,
+            proto::Pattern::Logo => Pattern::Logo,
+        },
+    })
+}
+
+pub fn video_codec_to_proto(codec: EncodedVideoCodec) -> Option<proto::VideoCodec> {
+    match codec {
+        EncodedVideoCodec::H264 => Some(proto::VideoCodec::H264),
+        EncodedVideoCodec::H265 => Some(proto::VideoCodec::H265),
+        EncodedVideoCodec::VP8 => Some(proto::VideoCodec::Vp8),
+        EncodedVideoCodec::VP9 => Some(proto::VideoCodec::Vp9),
+        EncodedVideoCodec::AV1 => Some(proto::VideoCodec::Av1),
+        // The codec enum is non-exhaustive; codecs unknown to the protocol
+        // are simply not reported.
+        _ => None,
+    }
+}

--- a/livekit-ffi/src/conversion/mod.rs
+++ b/livekit-ffi/src/conversion/mod.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 pub mod audio_frame;
+#[cfg(feature = "capture")]
+pub mod capture;
 pub mod data_stream;
 pub mod data_track;
 pub mod participant;

--- a/livekit-ffi/src/server/capture.rs
+++ b/livekit-ffi/src/server/capture.rs
@@ -26,11 +26,15 @@ use livekit_capture::{
 };
 use parking_lot::Mutex;
 
-use super::{FfiHandle, FfiServer};
-use crate::{proto, FfiHandleId, FfiResult};
+#[cfg(feature = "capture-pattern")]
+use livekit_capture::sources::pattern::PatternVideoSource;
+
+use super::{video_source::FfiVideoSource, FfiHandle, FfiServer};
+#[cfg(feature = "capture-pattern")]
+use crate::conversion::capture::pattern_config_from_proto;
+use crate::{conversion::capture::video_codec_to_proto, proto, FfiError, FfiHandleId, FfiResult};
 
 /// A capture pump of either kind, boxed at the FFI edge.
-#[allow(dead_code)]
 enum CapturePump {
     Pixel(PixelVideoPump<Box<dyn PixelVideoSource>>),
     Encoded(EncodedVideoPump<Box<dyn EncodedVideoSource>>),
@@ -49,7 +53,6 @@ impl CapturePump {
 ///
 /// The activity can end without client action (end of stream, error); the
 /// FFI object outlives it and is disposed only by the client.
-#[allow(dead_code)]
 enum CaptureState {
     /// Created but not started.
     Idle(CapturePump),
@@ -75,6 +78,131 @@ impl Drop for FfiCaptureSource {
         // producer). The watcher task delivers the terminal event, which may
         // trail the disposal.
         self.stop.stop();
+    }
+}
+
+pub fn on_new_capture_source(
+    server: &'static FfiServer,
+    request: proto::NewCaptureSourceRequest,
+) -> FfiResult<proto::NewCaptureSourceResponse> {
+    let async_id = server.resolve_async_id(request.request_async_id);
+    server.async_runtime.spawn(async move {
+        let message = match create_capture_source(server, request).await {
+            Ok(source) => proto::new_capture_source_callback::Message::Source(source),
+            Err(err) => proto::new_capture_source_callback::Message::Error(err.to_string()),
+        };
+        let _ = server.send_event(proto::ffi_event::Message::NewCaptureSource(
+            proto::NewCaptureSourceCallback { async_id, message: Some(message) },
+        ));
+    });
+    Ok(proto::NewCaptureSourceResponse { async_id })
+}
+
+async fn create_capture_source(
+    server: &'static FfiServer,
+    request: proto::NewCaptureSourceRequest,
+) -> FfiResult<proto::OwnedCaptureSource> {
+    let config =
+        request.config.ok_or(FfiError::InvalidRequest("missing capture source config".into()))?;
+
+    let pump = match config {
+        #[cfg(feature = "capture-pattern")]
+        proto::new_capture_source_request::Config::Pattern(config) => {
+            let source = PatternVideoSource::new(pattern_config_from_proto(config)?)
+                .await
+                .map_err(|err| FfiError::InvalidRequest(err.to_string().into()))?;
+            let source: Box<dyn PixelVideoSource> = Box::new(source);
+            CapturePump::Pixel(PixelVideoPump::new(source))
+        }
+        #[allow(unreachable_patterns)]
+        _ => {
+            return Err(FfiError::InvalidRequest(
+                "capture source is not enabled in this build".into(),
+            ))
+        }
+    };
+
+    let (kind, resolution, codec, publish_options, rtc_source, stop) = match &pump {
+        CapturePump::Pixel(pump) => (
+            proto::CaptureSourceKind::CaptureSourcePixel,
+            pump.source().resolution(),
+            None,
+            pump.publish_options(),
+            pump.rtc_source(),
+            pump.stop_handle(),
+        ),
+        CapturePump::Encoded(pump) => (
+            proto::CaptureSourceKind::CaptureSourceEncoded,
+            pump.source().resolution(),
+            Some(pump.source().codec()),
+            pump.publish_options(),
+            pump.rtc_source(),
+            pump.stop_handle(),
+        ),
+    };
+
+    // The RTC source is a regular client-owned handle, used with the
+    // existing CreateVideoTrack request.
+    let source_handle_id = server.next_id();
+    let video_source = FfiVideoSource {
+        handle_id: source_handle_id,
+        source_type: proto::VideoSourceType::VideoSourceNative,
+        source: rtc_source,
+    };
+    let video_source_info = proto::VideoSourceInfo::from(&video_source);
+    server.store_handle(source_handle_id, video_source);
+
+    let info = proto::CaptureSourceInfo {
+        kind: kind.into(),
+        resolution: proto::VideoSourceResolution {
+            width: resolution.width,
+            height: resolution.height,
+        },
+        codec: codec.and_then(video_codec_to_proto).map(Into::into),
+        recommended_publish_options: recommended_publish_options_to_proto(&publish_options),
+        video_source: proto::OwnedVideoSource {
+            handle: proto::FfiOwnedHandle { id: source_handle_id },
+            info: video_source_info,
+        },
+    };
+
+    let capture_handle_id = server.next_id();
+    server.store_handle(
+        capture_handle_id,
+        FfiCaptureSource {
+            handle_id: capture_handle_id,
+            stop,
+            state: Mutex::new(CaptureState::Idle(pump)),
+        },
+    );
+
+    Ok(proto::OwnedCaptureSource { handle: proto::FfiOwnedHandle { id: capture_handle_id }, info })
+}
+
+/// Maps the pump-derived publish options into the proto options the client
+/// merges its own settings over.
+fn recommended_publish_options_to_proto(
+    options: &livekit::options::TrackPublishOptions,
+) -> proto::TrackPublishOptions {
+    use livekit::options::VideoCodec;
+    let video_codec = match options.video_codec {
+        VideoCodec::VP8 => proto::VideoCodec::Vp8,
+        VideoCodec::H264 => proto::VideoCodec::H264,
+        VideoCodec::AV1 => proto::VideoCodec::Av1,
+        VideoCodec::VP9 => proto::VideoCodec::Vp9,
+        VideoCodec::H265 => proto::VideoCodec::H265,
+    };
+    let video_encoder = match options.video_encoder {
+        livekit::options::VideoEncoderBackend::PreEncoded => {
+            Some(proto::VideoEncoderBackend::EncoderBackendPreEncoded.into())
+        }
+        _ => None,
+    };
+    proto::TrackPublishOptions {
+        video_codec: Some(video_codec.into()),
+        video_encoder,
+        simulcast: Some(options.simulcast),
+        ..Default::default()
     }
 }
 
@@ -155,4 +283,66 @@ pub fn on_stop_capture(
     let ffi_capture = server.retrieve_handle::<FfiCaptureSource>(request.capture_handle)?;
     ffi_capture.stop.stop();
     Ok(proto::StopCaptureResponse { error: None })
+}
+
+#[cfg(all(test, feature = "capture-pattern"))]
+mod tests {
+    use super::*;
+    use crate::FFI_SERVER;
+    use std::time::Duration;
+
+    fn server() -> &'static FfiServer {
+        &FFI_SERVER
+    }
+
+    #[test]
+    fn pattern_capture_lifecycle() {
+        let request = proto::NewCaptureSourceRequest {
+            config: Some(proto::new_capture_source_request::Config::Pattern(
+                proto::PatternVideoSourceConfig {
+                    resolution: proto::VideoSourceResolution { width: 1280, height: 720 },
+                    framerate_fps: 30,
+                    pattern: proto::Pattern::Gradient.into(),
+                },
+            )),
+            request_async_id: None,
+        };
+        let source = server()
+            .async_runtime
+            .block_on(create_capture_source(server(), request))
+            .expect("pattern capture source should build");
+        assert_eq!(source.info.kind(), proto::CaptureSourceKind::CaptureSourcePixel);
+        assert_eq!(source.info.resolution.width, 1280);
+        let capture_handle = source.handle.id;
+
+        // Stopping before starting is allowed; the pump then exits
+        // immediately once started, and the watcher marks it finished.
+        let response =
+            on_stop_capture(server(), proto::StopCaptureRequest { capture_handle }).unwrap();
+        assert_eq!(response.error, None);
+
+        let response =
+            on_start_capture(server(), proto::StartCaptureRequest { capture_handle }).unwrap();
+        assert_eq!(response.error, None);
+
+        let response =
+            on_start_capture(server(), proto::StartCaptureRequest { capture_handle }).unwrap();
+        assert!(response.error.is_some(), "double start must be rejected");
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            {
+                let ffi_capture =
+                    server().retrieve_handle::<FfiCaptureSource>(capture_handle).unwrap();
+                if matches!(*ffi_capture.state.lock(), CaptureState::Finished) {
+                    break;
+                }
+            }
+            assert!(std::time::Instant::now() < deadline, "capture did not finish");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        server().drop_handle(capture_handle);
+        server().drop_handle(source.info.video_source.handle.id);
+    }
 }

--- a/livekit-ffi/src/server/requests.rs
+++ b/livekit-ffi/src/server/requests.rs
@@ -1485,11 +1485,15 @@ pub fn handle_request(
         Request::StopRecording(req) => platform_audio::on_stop_recording(server, req)?.into(),
 
         #[cfg(feature = "capture")]
+        Request::NewCaptureSource(req) => capture::on_new_capture_source(server, req)?.into(),
+        #[cfg(feature = "capture")]
         Request::StartCapture(req) => capture::on_start_capture(server, req)?.into(),
         #[cfg(feature = "capture")]
         Request::StopCapture(req) => capture::on_stop_capture(server, req)?.into(),
         #[cfg(not(feature = "capture"))]
-        Request::StartCapture(_) | Request::StopCapture(_) => {
+        Request::NewCaptureSource(_)
+        | Request::StartCapture(_)
+        | Request::StopCapture(_) => {
             return Err(FfiError::InvalidRequest(
                 "livekit-ffi was built without the 'capture' feature".into(),
             ));


### PR DESCRIPTION
Add a capture source that renders a test pattern using the GPU. This has two variants:
- Gradient: animated color gradient
- Logo: bouncing LiveKit logo

These are useful during development to get a video source without extra dependencies (e.g., a GStreamer pipeline).

Closes BOT-548