### PR TITLE
Capture: clock source

### DIFF
--- a/.changeset/capture-source-clock.md
+++ b/.changeset/capture-source-clock.md
@@ -1,0 +1,6 @@
+---
+livekit-capture: minor
+livekit-ffi: minor
+---
+
+Add a capture source that renders a wall clock on the GPU.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3963,6 +3963,7 @@ name = "livekit-capture"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "chrono",
  "livekit",
  "log",
  "pollster",

--- a/livekit-capture/Cargo.toml
+++ b/livekit-capture/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [dependencies]
 bytes = { workspace = true }
+chrono = { version = "0.4", default-features = false, features = ["clock"], optional = true }
 livekit = { workspace = true }
 log = { workspace = true }
 pollster = { version = "0.4", optional = true }
@@ -32,4 +33,5 @@ schemars = ["dep:schemars", "serde"]
 tokio = ["tokio/rt"]
 
 # Pixel sources
+source-clock = ["dep:chrono", "dep:pollster", "dep:wgpu", "dep:yuv-sys"]
 source-pattern = ["dep:pollster", "dep:wgpu", "dep:yuv-sys"]

--- a/livekit-capture/README.md
+++ b/livekit-capture/README.md
@@ -60,3 +60,4 @@ named `source-<module>`. Each module documents its source.
 | Feature            | Source                 | Kind    |
 | ------------------ | ---------------------- | ------- |
 | `source-pattern`   | `PatternVideoSource`   | pixel   |
+| `source-clock`     | `ClockVideoSource`     | pixel   |

--- a/livekit-capture/shaders/clock.wgsl
+++ b/livekit-capture/shaders/clock.wgsl
@@ -1,0 +1,259 @@
+// Wall clock: the shader for the clock video source.
+//
+// The clock shows HH:MM:SS.mmm as seven-segment digits, with a grid of
+// cells below it. Each grid row fills to show one millisecond digit, so
+// a viewer can read sub-frame time from a paused frame.
+//
+// The CPU samples the wall clock once per frame and sends the twelve
+// character codes in the uniform. Codes 0 to 9 are digits, 10 is a
+// colon, and 11 is a dot.
+//
+// Shapes get about 1.5 output pixels of edge feather, so they stay
+// clean through video encoding.
+
+struct ClockUniform {
+    viewport_size: vec2<f32>,
+    _pad0: vec2<u32>,
+    chars0: vec4<u32>,
+    chars1: vec4<u32>,
+    chars2: vec4<u32>,
+}
+
+@group(0) @binding(0) var<uniform> clock: ClockUniform;
+
+struct VertexOut {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+const CHAR_COUNT: u32 = 12u;
+const COLON_CODE: u32 = 10u;
+const DOT_CODE: u32 = 11u;
+
+// Layout metrics, in layout units. The digits sit in one row, and the
+// millisecond grid sits below them.
+const DIGIT_HEIGHT: f32 = 1.85;
+const CELL_WIDTH: f32 = 1.0;
+const SEGMENT_THICKNESS: f32 = 0.16;
+const COLON_WIDTH: f32 = 0.34;
+const DOT_WIDTH: f32 = 0.24;
+const GAP: f32 = 0.14;
+const TOTAL_WIDTH: f32 = 9.0 * CELL_WIDTH + 2.0 * COLON_WIDTH + DOT_WIDTH + 11.0 * GAP;
+const GRID_COLUMNS: u32 = 9u;
+const GRID_ROWS: u32 = 3u;
+const GRID_CELL: f32 = 0.72;
+const GRID_COLUMN_GAP: f32 = 0.30;
+const GRID_ROW_GAP: f32 = 0.30;
+const GRID_TOP_GAP: f32 = 0.22;
+const GRID_WIDTH: f32 = 9.0 * GRID_CELL + 8.0 * GRID_COLUMN_GAP;
+const GRID_HEIGHT: f32 = 3.0 * GRID_CELL + 2.0 * GRID_ROW_GAP;
+const GROUP_HEIGHT: f32 = DIGIT_HEIGHT + GRID_TOP_GAP + GRID_HEIGHT;
+
+// Warm white for lit shapes, dark gray for unfilled grid cells.
+const FOREGROUND: vec3<f32> = vec3<f32>(1.0, 0.98, 0.92);
+const EMPTY_CELL: vec3<f32> = vec3<f32>(0.14, 0.14, 0.14);
+
+// Segment masks for the digits 0 to 9. Bit `n` lights segment `n` of
+// the seven-segment layout in segment_rect.
+const DIGIT_MASKS: array<u32, 10> = array<u32, 10>(
+    0x3fu,
+    0x06u,
+    0x5bu,
+    0x4fu,
+    0x66u,
+    0x6du,
+    0x7du,
+    0x07u,
+    0x7fu,
+    0x6fu,
+);
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOut {
+    // One triangle that covers the full target. `uv` runs from (0, 0)
+    // at the top left to (1, 1) at the bottom right.
+    let corner = vec2<f32>(f32((vertex_index << 1u) & 2u), f32(vertex_index & 2u));
+    var out: VertexOut;
+    out.position = vec4<f32>(corner * 2.0 - 1.0, 0.0, 1.0);
+    out.uv = vec2<f32>(corner.x, 1.0 - corner.y);
+    return out;
+}
+
+// Returns the character code at `index`, from the uniform.
+fn char_at(index: u32) -> u32 {
+    if index < 4u {
+        return clock.chars0[index];
+    }
+    if index < 8u {
+        return clock.chars1[index - 4u];
+    }
+    return clock.chars2[index - 8u];
+}
+
+fn char_width(code: u32) -> f32 {
+    if code < 10u {
+        return CELL_WIDTH;
+    }
+    if code == COLON_CODE {
+        return COLON_WIDTH;
+    }
+    return DOT_WIDTH;
+}
+
+// Bounds of one seven-segment segment, as (min_x, min_y, max_x, max_y).
+fn segment_rect(segment: u32) -> vec4<f32> {
+    let t = SEGMENT_THICKNESS;
+    let mid = DIGIT_HEIGHT * 0.5;
+
+    switch segment {
+        case 0u: { return vec4<f32>(t, 0.0, CELL_WIDTH - t, t); }
+        case 1u: { return vec4<f32>(CELL_WIDTH - t, t, CELL_WIDTH, mid); }
+        case 2u: { return vec4<f32>(CELL_WIDTH - t, mid, CELL_WIDTH, DIGIT_HEIGHT - t); }
+        case 3u: { return vec4<f32>(t, DIGIT_HEIGHT - t, CELL_WIDTH - t, DIGIT_HEIGHT); }
+        case 4u: { return vec4<f32>(0.0, mid, t, DIGIT_HEIGHT - t); }
+        case 5u: { return vec4<f32>(0.0, t, t, mid); }
+        case 6u: { return vec4<f32>(t, mid - t * 0.5, CELL_WIDTH - t, mid + t * 0.5); }
+        default: { return vec4<f32>(0.0); }
+    }
+}
+
+// Coverage of the rectangle [min_p, max_p] at point `p`. The interior
+// is fully opaque. Alpha falls to zero over `feather` outside the edge,
+// so touching rectangles union without seams.
+fn rect_alpha(p: vec2<f32>, min_p: vec2<f32>, max_p: vec2<f32>, feather: f32) -> f32 {
+    let center = (min_p + max_p) * 0.5;
+    let half_size = (max_p - min_p) * 0.5;
+    let d = abs(p - center) - half_size;
+    let outside = length(max(d, vec2<f32>(0.0)));
+    let inside = min(max(d.x, d.y), 0.0);
+    return 1.0 - smoothstep(0.0, feather, outside + inside);
+}
+
+fn circle_alpha(p: vec2<f32>, center: vec2<f32>, radius: f32, feather: f32) -> f32 {
+    return 1.0 - smoothstep(0.0, feather, length(p - center) - radius);
+}
+
+// Coverage of one seven-segment digit with its origin at `origin`.
+fn digit_alpha(p: vec2<f32>, origin: vec2<f32>, digit: u32, feather: f32) -> f32 {
+    if digit > 9u {
+        return 0.0;
+    }
+
+    let local = p - origin;
+    let mask = DIGIT_MASKS[digit];
+    var alpha = 0.0;
+
+    for (var segment = 0u; segment < 7u; segment = segment + 1u) {
+        if (mask & (1u << segment)) != 0u {
+            let r = segment_rect(segment);
+            alpha = max(alpha, rect_alpha(local, r.xy, r.zw, feather));
+        }
+    }
+
+    return alpha;
+}
+
+// Coverage of a colon or dot separator with its origin at `origin`.
+fn separator_alpha(p: vec2<f32>, origin: vec2<f32>, code: u32, feather: f32) -> f32 {
+    let local = p - origin;
+    let center_x = char_width(code) * 0.5;
+
+    if code == COLON_CODE {
+        let r = 0.095;
+        let top = circle_alpha(local, vec2<f32>(center_x, DIGIT_HEIGHT * 0.38), r, feather);
+        let bottom = circle_alpha(local, vec2<f32>(center_x, DIGIT_HEIGHT * 0.62), r, feather);
+        return max(top, bottom);
+    }
+
+    if code == DOT_CODE {
+        return circle_alpha(local, vec2<f32>(center_x, DIGIT_HEIGHT - 0.095), 0.08, feather);
+    }
+
+    return 0.0;
+}
+
+// Coverage of the twelve clock characters.
+fn chars_alpha(p: vec2<f32>, feather: f32) -> f32 {
+    // Skip the character loop outside the digit row.
+    if p.x < -feather || p.x > TOTAL_WIDTH + feather
+        || p.y < -feather || p.y > DIGIT_HEIGHT + feather {
+        return 0.0;
+    }
+
+    var cursor = 0.0;
+    var alpha = 0.0;
+
+    for (var index = 0u; index < CHAR_COUNT; index = index + 1u) {
+        let code = char_at(index);
+        let origin = vec2<f32>(cursor, 0.0);
+
+        if code < 10u {
+            alpha = max(alpha, digit_alpha(p, origin, code, feather));
+        } else {
+            alpha = max(alpha, separator_alpha(p, origin, code, feather));
+        }
+
+        cursor = cursor + char_width(code) + GAP;
+    }
+
+    return alpha;
+}
+
+// Coverage of the millisecond grid: filled cells in x, unfilled cells
+// in y. Each row fills to show one millisecond digit.
+fn grid_alpha(p: vec2<f32>, feather: f32) -> vec2<f32> {
+    let grid_origin =
+        vec2<f32>((TOTAL_WIDTH - GRID_WIDTH) * 0.5, DIGIT_HEIGHT + GRID_TOP_GAP);
+
+    // Skip the cell loop outside the grid.
+    let local = p - grid_origin;
+    if local.x < -feather || local.x > GRID_WIDTH + feather
+        || local.y < -feather || local.y > GRID_HEIGHT + feather {
+        return vec2<f32>(0.0, 0.0);
+    }
+
+    var filled = 0.0;
+    var unfilled = 0.0;
+
+    for (var row = 0u; row < GRID_ROWS; row = row + 1u) {
+        let row_digit = char_at(9u + row);
+        for (var column = 0u; column < GRID_COLUMNS; column = column + 1u) {
+            let cell_origin = grid_origin + vec2<f32>(
+                f32(column) * (GRID_CELL + GRID_COLUMN_GAP),
+                f32(row) * (GRID_CELL + GRID_ROW_GAP),
+            );
+            let cell_alpha = rect_alpha(p, cell_origin, cell_origin + vec2<f32>(GRID_CELL), feather);
+            if column < row_digit {
+                filled = max(filled, cell_alpha);
+            } else {
+                unfilled = max(unfilled, cell_alpha);
+            }
+        }
+    }
+
+    return vec2<f32>(filled, unfilled);
+}
+
+@fragment
+fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
+    // Work in a space that is `aspect` wide and 1.0 tall.
+    let height = max(clock.viewport_size.y, 1.0);
+    let aspect = max(clock.viewport_size.x / height, 0.1);
+    let p = vec2<f32>(in.uv.x * aspect, in.uv.y);
+
+    // Fit the clock into the frame with a margin, and center it.
+    let scale = min((aspect * 0.94) / TOTAL_WIDTH, 0.82 / GROUP_HEIGHT);
+    let scaled_size = vec2<f32>(TOTAL_WIDTH, GROUP_HEIGHT) * scale;
+    let origin = vec2<f32>((aspect - scaled_size.x) * 0.5, (1.0 - scaled_size.y) * 0.5);
+    let local_p = (p - origin) / scale;
+
+    // About 1.5 output pixels of edge feather, in layout units.
+    let feather = 1.5 / (height * scale);
+
+    let chars = chars_alpha(local_p, feather);
+    let grid = grid_alpha(local_p, feather);
+    let alpha = max(chars, grid.x);
+
+    let color = max(EMPTY_CELL * grid.y, FOREGROUND * alpha);
+    return vec4<f32>(color, 1.0);
+}

--- a/livekit-capture/src/error.rs
+++ b/livekit-capture/src/error.rs
@@ -20,7 +20,7 @@
 
 use std::{error::Error as StdError, fmt};
 
-#[cfg(feature = "source-pattern")]
+#[cfg(any(feature = "source-clock", feature = "source-pattern"))]
 pub use crate::renderer::RendererError;
 
 /// Error returned by a capture source.

--- a/livekit-capture/src/lib.rs
+++ b/livekit-capture/src/lib.rs
@@ -26,6 +26,6 @@ pub mod primitive;
 pub mod pump;
 pub mod sources;
 
-#[cfg(feature = "source-pattern")]
+#[cfg(any(feature = "source-clock", feature = "source-pattern"))]
 mod renderer;
 mod utils;

--- a/livekit-capture/src/sources/clock.rs
+++ b/livekit-capture/src/sources/clock.rs
@@ -1,0 +1,272 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Wall-clock video source, for latency measurement.
+//!
+//! [`ClockVideoSource`] renders the local time as HH:MM:SS.mmm on the
+//! GPU, with a grid below the digits that shows the milliseconds as
+//! filled cells. The source samples the wall clock once per frame.
+//! Rendering is offscreen through [wgpu], so the source needs no window
+//! or display.
+//!
+//! The source reads each frame back from the GPU and converts it to I420
+//! on the CPU.
+//!
+//! [wgpu]: https://wgpu.rs
+
+use crate::{
+    error::SourceError,
+    pixel::PixelVideoSource,
+    primitive::VideoResolution,
+    pump::PumpStop,
+    renderer::{FramePacer, RendererError, ShaderRenderer},
+};
+use chrono::Timelike;
+use livekit::webrtc::video_frame::{BoxVideoFrame, VideoFrame, VideoRotation};
+use std::fmt;
+use thiserror::Error;
+
+/// Complete WGSL module for the clock.
+const CLOCK_SHADER: &str = include_str!("../../shaders/clock.wgsl");
+
+/// Number of characters on the clock face: HH:MM:SS.mmm.
+const CHAR_COUNT: usize = 12;
+
+/// Character codes for the separators. Codes 0 to 9 are digits.
+const COLON: u32 = 10;
+const DOT: u32 = 11;
+
+/// Size of the uniform block: `vec2<f32>` + padding + 3 * `vec4<u32>`.
+const UNIFORM_BUFFER_SIZE: u64 = 64;
+
+/// Configuration for a [`ClockVideoSource`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(deny_unknown_fields)
+)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct ClockVideoSourceConfig {
+    /// Output resolution.
+    pub resolution: VideoResolution,
+    /// Output frame rate in frames per second.
+    pub framerate_fps: u32,
+}
+
+/// Error returned by a clock video source.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ClockVideoSourceError {
+    /// The configured resolution has a zero component.
+    #[error("clock source resolution must be non-zero")]
+    ZeroResolution,
+    /// The configured frame rate is zero.
+    #[error("clock source frame rate must be non-zero")]
+    ZeroFramerate,
+    /// The GPU renderer failed.
+    #[error(transparent)]
+    Render(#[from] RendererError),
+}
+
+/// Pixel video source that renders a wall clock with millisecond
+/// precision.
+///
+/// The source sleeps to pace itself to the configured frame rate. It
+/// never reaches the end of its stream — stop the pump that drives it
+/// instead.
+pub struct ClockVideoSource {
+    config: ClockVideoSourceConfig,
+    renderer: ShaderRenderer,
+    pacer: FramePacer,
+}
+
+impl ClockVideoSource {
+    /// Creates the source. GPU setup runs on the tokio blocking pool.
+    ///
+    /// Requires a running tokio runtime. Use
+    /// [`ClockVideoSource::new_blocking`] outside of async contexts.
+    #[cfg(feature = "tokio")]
+    pub async fn new(config: ClockVideoSourceConfig) -> Result<Self, SourceError> {
+        crate::utils::run_blocking(move || Self::new_blocking(config)).await
+    }
+
+    /// Selects a GPU adapter, compiles the clock shader, and builds the
+    /// render pipeline.
+    ///
+    /// Construction fails when no GPU is available, or for a zero
+    /// resolution or frame rate.
+    pub fn new_blocking(config: ClockVideoSourceConfig) -> Result<Self, SourceError> {
+        validate_config(&config).map_err(SourceError::new)?;
+        let renderer = ShaderRenderer::new(config.resolution, CLOCK_SHADER, UNIFORM_BUFFER_SIZE)
+            .map_err(|error| SourceError::new(ClockVideoSourceError::Render(error)))?;
+        let pacer = FramePacer::new(config.framerate_fps);
+        Ok(Self { config, renderer, pacer })
+    }
+
+    /// Returns the configuration the source was created with.
+    pub fn config(&self) -> ClockVideoSourceConfig {
+        self.config
+    }
+}
+
+impl PixelVideoSource for ClockVideoSource {
+    fn resolution(&self) -> VideoResolution {
+        self.config.resolution
+    }
+
+    // The pacing sleep is at most one frame interval, and the renderer
+    // bounds every readback wait, so the stop token is observed promptly.
+    fn next_frame(&mut self, stop: &PumpStop) -> Result<Option<BoxVideoFrame>, SourceError> {
+        let (elapsed, _) = self.pacer.wait_for_next_frame();
+
+        // Sample the wall clock after the pacing sleep, so the shown
+        // time is as close as possible to the capture time.
+        let now = chrono::Local::now();
+        let chars =
+            clock_chars(now.hour(), now.minute(), now.second(), now.nanosecond() / 1_000_000);
+        let uniform = uniform_bytes(self.config.resolution, &chars);
+
+        let buffer = self
+            .renderer
+            .render_frame(&uniform, stop)
+            .map_err(|error| SourceError::new(ClockVideoSourceError::Render(error)))?;
+        let Some(buffer) = buffer else {
+            // The stop token fired during the readback wait.
+            return Ok(None);
+        };
+
+        Ok(Some(VideoFrame {
+            rotation: VideoRotation::VideoRotation0,
+            timestamp_us: elapsed.as_micros() as i64,
+            frame_metadata: None,
+            buffer: Box::new(buffer),
+        }))
+    }
+}
+
+impl fmt::Debug for ClockVideoSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ClockVideoSource").field("config", &self.config).finish_non_exhaustive()
+    }
+}
+
+/// Validates the CPU-checkable parts of a configuration.
+fn validate_config(config: &ClockVideoSourceConfig) -> Result<(), ClockVideoSourceError> {
+    let VideoResolution { width, height } = config.resolution;
+    if width == 0 || height == 0 {
+        return Err(ClockVideoSourceError::ZeroResolution);
+    }
+    if config.framerate_fps == 0 {
+        return Err(ClockVideoSourceError::ZeroFramerate);
+    }
+    Ok(())
+}
+
+/// Returns the twelve character codes for HH:MM:SS.mmm.
+fn clock_chars(hour: u32, minute: u32, second: u32, millisecond: u32) -> [u32; CHAR_COUNT] {
+    [
+        (hour / 10) % 10,
+        hour % 10,
+        COLON,
+        (minute / 10) % 10,
+        minute % 10,
+        COLON,
+        (second / 10) % 10,
+        second % 10,
+        DOT,
+        (millisecond / 100) % 10,
+        (millisecond / 10) % 10,
+        millisecond % 10,
+    ]
+}
+
+/// Serializes the uniform block: viewport size, padding, and the twelve
+/// character codes at their 16-byte-aligned offset.
+fn uniform_bytes(
+    resolution: VideoResolution,
+    chars: &[u32; CHAR_COUNT],
+) -> [u8; UNIFORM_BUFFER_SIZE as usize] {
+    let mut bytes = [0u8; UNIFORM_BUFFER_SIZE as usize];
+    bytes[0..4].copy_from_slice(&(resolution.width as f32).to_ne_bytes());
+    bytes[4..8].copy_from_slice(&(resolution.height as f32).to_ne_bytes());
+    for (index, code) in chars.iter().enumerate() {
+        let offset = 16 + index * 4;
+        bytes[offset..offset + 4].copy_from_slice(&code.to_ne_bytes());
+    }
+    bytes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::renderer::gpu_available;
+
+    fn test_config() -> ClockVideoSourceConfig {
+        ClockVideoSourceConfig {
+            resolution: VideoResolution { width: 320, height: 180 },
+            framerate_fps: 1000,
+        }
+    }
+
+    #[test]
+    fn clock_chars_render_three_millisecond_digits() {
+        assert_eq!(clock_chars(12, 34, 56, 789), [1, 2, COLON, 3, 4, COLON, 5, 6, DOT, 7, 8, 9]);
+    }
+
+    #[test]
+    fn validation_rejects_zero_resolution_and_framerate() {
+        let mut config = test_config();
+        config.resolution = VideoResolution::new(0, 180);
+        assert!(matches!(validate_config(&config), Err(ClockVideoSourceError::ZeroResolution)));
+
+        let mut config = test_config();
+        config.framerate_fps = 0;
+        assert!(matches!(validate_config(&config), Err(ClockVideoSourceError::ZeroFramerate)));
+    }
+
+    #[test]
+    fn uniform_places_chars_at_their_alignment() {
+        let chars = clock_chars(12, 34, 56, 789);
+        let bytes = uniform_bytes(VideoResolution::new(1280, 720), &chars);
+        assert_eq!(f32::from_ne_bytes(bytes[0..4].try_into().unwrap()), 1280.0);
+        assert_eq!(f32::from_ne_bytes(bytes[4..8].try_into().unwrap()), 720.0);
+        assert_eq!(u32::from_ne_bytes(bytes[16..20].try_into().unwrap()), 1);
+        assert_eq!(u32::from_ne_bytes(bytes[60..64].try_into().unwrap()), 9);
+    }
+
+    #[test]
+    fn clock_renders_frames() {
+        if !gpu_available() {
+            eprintln!("skipping: no GPU adapter available");
+            return;
+        }
+        let mut source = ClockVideoSource::new_blocking(test_config()).unwrap();
+
+        let stop = PumpStop::new();
+        let first = source.next_frame(&stop).unwrap().unwrap();
+        let second = source.next_frame(&stop).unwrap().unwrap();
+        assert_eq!((first.buffer.width(), first.buffer.height()), (320, 180));
+        assert_eq!(first.timestamp_us, 0);
+        assert_eq!(second.timestamp_us, 1_000);
+
+        // The clock is centered with a margin, so the top-left pixel is
+        // background black, and the lit digits stand out well above it.
+        let i420 = first.buffer.as_i420().expect("clock source yields I420 buffers");
+        let (y, _, _) = i420.data();
+        assert!(y[0] <= 20, "top-left pixel is not background: {}", y[0]);
+        let lit = y.iter().filter(|&&luma| luma > 100).count();
+        assert!(lit > 20, "no clock pixels found (lit count {lit})");
+    }
+}

--- a/livekit-capture/src/sources/mod.rs
+++ b/livekit-capture/src/sources/mod.rs
@@ -15,5 +15,8 @@
 //! Ready-made capture sources. Each source is gated behind its own
 //! `source-*` feature.
 
+#[cfg(feature = "source-clock")]
+pub mod clock;
+
 #[cfg(feature = "source-pattern")]
 pub mod pattern;

--- a/livekit-ffi-node-bindings/proto/capture_pb.d.ts
+++ b/livekit-ffi-node-bindings/proto/capture_pb.d.ts
@@ -129,6 +129,42 @@ export declare class PatternVideoSourceConfig extends Message<PatternVideoSource
 }
 
 /**
+ * Wall clock with millisecond precision, rendered on the GPU. Shows the
+ * local time of the machine that runs the FFI server.
+ *
+ * @generated from message livekit.proto.ClockVideoSourceConfig
+ */
+export declare class ClockVideoSourceConfig extends Message<ClockVideoSourceConfig> {
+  /**
+   * Output resolution.
+   *
+   * @generated from field: required livekit.proto.VideoSourceResolution resolution = 1;
+   */
+  resolution?: VideoSourceResolution;
+
+  /**
+   * Output frame rate in frames per second.
+   *
+   * @generated from field: required uint32 framerate_fps = 2;
+   */
+  framerateFps?: number;
+
+  constructor(data?: PartialMessage<ClockVideoSourceConfig>);
+
+  static readonly runtime: typeof proto2;
+  static readonly typeName = "livekit.proto.ClockVideoSourceConfig";
+  static readonly fields: FieldList;
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ClockVideoSourceConfig;
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ClockVideoSourceConfig;
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ClockVideoSourceConfig;
+
+  static equals(a: ClockVideoSourceConfig | PlainMessage<ClockVideoSourceConfig> | undefined, b: ClockVideoSourceConfig | PlainMessage<ClockVideoSourceConfig> | undefined): boolean;
+}
+
+/**
  * @generated from message livekit.proto.CaptureSourceInfo
  */
 export declare class CaptureSourceInfo extends Message<CaptureSourceInfo> {
@@ -231,6 +267,12 @@ export declare class NewCaptureSourceRequest extends Message<NewCaptureSourceReq
      */
     value: PatternVideoSourceConfig;
     case: "pattern";
+  } | {
+    /**
+     * @generated from field: livekit.proto.ClockVideoSourceConfig clock = 5;
+     */
+    value: ClockVideoSourceConfig;
+    case: "clock";
   } | { case: undefined; value?: undefined };
 
   /**

--- a/livekit-ffi-node-bindings/proto/capture_pb.js
+++ b/livekit-ffi-node-bindings/proto/capture_pb.js
@@ -79,6 +79,20 @@ const PatternVideoSourceConfig = /*@__PURE__*/ proto2.makeMessageType(
 );
 
 /**
+ * Wall clock with millisecond precision, rendered on the GPU. Shows the
+ * local time of the machine that runs the FFI server.
+ *
+ * @generated from message livekit.proto.ClockVideoSourceConfig
+ */
+const ClockVideoSourceConfig = /*@__PURE__*/ proto2.makeMessageType(
+  "livekit.proto.ClockVideoSourceConfig",
+  () => [
+    { no: 1, name: "resolution", kind: "message", T: VideoSourceResolution, req: true },
+    { no: 2, name: "framerate_fps", kind: "scalar", T: 13 /* ScalarType.UINT32 */, req: true },
+  ],
+);
+
+/**
  * @generated from message livekit.proto.CaptureSourceInfo
  */
 const CaptureSourceInfo = /*@__PURE__*/ proto2.makeMessageType(
@@ -116,6 +130,7 @@ const NewCaptureSourceRequest = /*@__PURE__*/ proto2.makeMessageType(
   "livekit.proto.NewCaptureSourceRequest",
   () => [
     { no: 2, name: "pattern", kind: "message", T: PatternVideoSourceConfig, oneof: "config" },
+    { no: 5, name: "clock", kind: "message", T: ClockVideoSourceConfig, oneof: "config" },
     { no: 3, name: "request_async_id", kind: "scalar", T: 4 /* ScalarType.UINT64 */, opt: true },
   ],
 );
@@ -229,6 +244,7 @@ exports.Pattern = Pattern;
 exports.CaptureSourceKind = CaptureSourceKind;
 exports.CaptureExit = CaptureExit;
 exports.PatternVideoSourceConfig = PatternVideoSourceConfig;
+exports.ClockVideoSourceConfig = ClockVideoSourceConfig;
 exports.CaptureSourceInfo = CaptureSourceInfo;
 exports.OwnedCaptureSource = OwnedCaptureSource;
 exports.NewCaptureSourceRequest = NewCaptureSourceRequest;

--- a/livekit-ffi/Cargo.toml
+++ b/livekit-ffi/Cargo.toml
@@ -23,6 +23,7 @@ tracing = ["tokio/tracing", "console-subscriber"]
 # producers. This enables the capture scaffolding only; enable a
 # `capture-*` feature to include a specific source.
 capture = ["dep:livekit-capture", "livekit-capture/tokio"]
+capture-clock = ["capture", "livekit-capture/source-clock"]
 capture-pattern = ["capture", "livekit-capture/source-pattern"]
 
 [dependencies]

--- a/livekit-ffi/protocol/capture.proto
+++ b/livekit-ffi/protocol/capture.proto
@@ -55,6 +55,15 @@ message PatternVideoSourceConfig {
   required Pattern pattern = 3;
 }
 
+// Wall clock with millisecond precision, rendered on the GPU. Shows the
+// local time of the machine that runs the FFI server.
+message ClockVideoSourceConfig {
+  // Output resolution.
+  required VideoSourceResolution resolution = 1;
+  // Output frame rate in frames per second.
+  required uint32 framerate_fps = 2;
+}
+
 // Kind of media a capture source produces.
 enum CaptureSourceKind {
   // Pixel frames, published through the WebRTC encoder.
@@ -91,6 +100,7 @@ message OwnedCaptureSource {
 message NewCaptureSourceRequest {
   oneof config {
     PatternVideoSourceConfig pattern = 2;
+    ClockVideoSourceConfig clock = 5;
   }
   optional uint64 request_async_id = 3;
 }

--- a/livekit-ffi/src/conversion/capture.rs
+++ b/livekit-ffi/src/conversion/capture.rs
@@ -17,12 +17,21 @@ use livekit_capture::{encoded::EncodedVideoCodec, primitive::VideoResolution};
 
 #[cfg(feature = "capture-pattern")]
 use crate::{FfiError, FfiResult};
+#[cfg(feature = "capture-clock")]
+use livekit_capture::sources::clock::ClockVideoSourceConfig;
 #[cfg(feature = "capture-pattern")]
 use livekit_capture::sources::pattern::{Pattern, PatternVideoSourceConfig};
 
 impl From<proto::VideoSourceResolution> for VideoResolution {
     fn from(resolution: proto::VideoSourceResolution) -> Self {
         Self::new(resolution.width, resolution.height)
+    }
+}
+
+#[cfg(feature = "capture-clock")]
+impl From<proto::ClockVideoSourceConfig> for ClockVideoSourceConfig {
+    fn from(config: proto::ClockVideoSourceConfig) -> Self {
+        Self { resolution: config.resolution.into(), framerate_fps: config.framerate_fps }
     }
 }
 

--- a/livekit-ffi/src/server/capture.rs
+++ b/livekit-ffi/src/server/capture.rs
@@ -26,6 +26,8 @@ use livekit_capture::{
 };
 use parking_lot::Mutex;
 
+#[cfg(feature = "capture-clock")]
+use livekit_capture::sources::clock::ClockVideoSource;
 #[cfg(feature = "capture-pattern")]
 use livekit_capture::sources::pattern::PatternVideoSource;
 
@@ -109,6 +111,14 @@ async fn create_capture_source(
         #[cfg(feature = "capture-pattern")]
         proto::new_capture_source_request::Config::Pattern(config) => {
             let source = PatternVideoSource::new(pattern_config_from_proto(config)?)
+                .await
+                .map_err(|err| FfiError::InvalidRequest(err.to_string().into()))?;
+            let source: Box<dyn PixelVideoSource> = Box::new(source);
+            CapturePump::Pixel(PixelVideoPump::new(source))
+        }
+        #[cfg(feature = "capture-clock")]
+        proto::new_capture_source_request::Config::Clock(config) => {
+            let source = ClockVideoSource::new(config.into())
                 .await
                 .map_err(|err| FfiError::InvalidRequest(err.to_string().into()))?;
             let source: Box<dyn PixelVideoSource> = Box::new(source);


### PR DESCRIPTION
Add a capture source that renders a wall clock using the GPU.

This is useful for video latency measurements.

Closes: BOT-549