### PR TITLE
libwebrtc: expose network_type on IceCandidateStats

### DIFF
--- a/.changeset/libwebrtc_network_type_stat.md
+++ b/.changeset/libwebrtc_network_type_stat.md
@@ -1,5 +1,7 @@
 ---
 libwebrtc: minor
+livekit: patch
+livekit-ffi: patch
 ---
 
 # Expose network_type on IceCandidateStats

--- a/.changeset/libwebrtc_network_type_stat.md
+++ b/.changeset/libwebrtc_network_type_stat.md
@@ -1,0 +1,10 @@
+---
+libwebrtc: minor
+---
+
+# Expose network_type on IceCandidateStats
+
+Chromium's local `RTCIceCandidateStats` carries a non-standard `networkType` field (WiFi,
+cellular, ethernet, etc.), but `IceCandidateStats` had no place to put it, so it was silently
+dropped during `get_stats()` deserialization. Adds `network_type: Option<String>` to the struct;
+non-breaking since it already derives `#[serde(default)]`.

--- a/libwebrtc/src/stats.rs
+++ b/libwebrtc/src/stats.rs
@@ -601,6 +601,9 @@ pub mod dictionaries {
         pub related_port: i32,
         pub username_fragment: String,
         pub tcp_type: Option<IceTcpCandidateType>,
+        /// Chromium's non-standard `RTCIceCandidateStats.networkType` (WiFi, cellular, ethernet,
+        /// etc.), reported only for local candidates.
+        pub network_type: Option<String>,
     }
 
     #[derive(Debug, Default, Clone, Deserialize)]


### PR DESCRIPTION
## Summary
- Chromium's local `RTCIceCandidateStats` carries a non-standard `networkType` field (WiFi, cellular, ethernet, etc.), but `IceCandidateStats` has no place to put it, so it's silently dropped during `get_stats()` deserialization.
- Adds `pub network_type: Option<String>` to `IceCandidateStats` in `libwebrtc/src/stats.rs`. The struct already derives `#[serde(rename_all = "camelCase")] #[serde(default)]`, so this maps to the existing `networkType` JSON key and is non-breaking for any RTCIceCandidateStats that doesn't emit it (server-reflexive/relay/remote candidates, or non-Chromium backends).

## Test plan
- [x] `cargo check -p libwebrtc`