### PR TITLE
uniffi-android: drop minsdkversion to 21

### DIFF
--- a/.changeset/drop_android_minsdk_to_21.md
+++ b/.changeset/drop_android_minsdk_to_21.md
@@ -1,0 +1,5 @@
+---
+livekit-uniffi: patch
+---
+
+Lower the Android UniFFI AAR minSdk from 24 to 21

--- a/livekit-uniffi/support/android/build.gradle.kts
+++ b/livekit-uniffi/support/android/build.gradle.kts
@@ -19,7 +19,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
+        minSdk = 21
 
         consumerProguardFiles("consumer-rules.pro")
     }


### PR DESCRIPTION
### PR description

Drops the min sdk version for uniffi-android. The initial implementation set it to 24, but there wasn't a need for it. This lowers it down to 21 to match the Android LiveKit SDK min version.

### Breaking changes

N/A

### MSRV

N/A

### Testing

Checked dependencies to make sure that nothing was causing the min version set. Built with no errors (the build checks compatibility with minSdk).

### Async

N/A
