### PR TITLE
Fix Two Memory Leaks in RoomSession and DataChannel

### DIFF
--- a/.changeset/break_arc_cycles.md
+++ b/.changeset/break_arc_cycles.md
@@ -1,0 +1,6 @@
+---
+livekit: patch
+livekit-ffi: patch
+---
+
+Break two arc cycles between RoomSession and itself and DataChannel and itself introduced via closures.

--- a/livekit/src/room/mod.rs
+++ b/livekit/src/room/mod.rs
@@ -759,10 +759,14 @@ impl Room {
 
         e2ee_manager.on_state_changed({
             let dispatcher = dispatcher.clone();
-            let inner = inner.clone();
+            let inner = Arc::downgrade(&inner);
             move |participant_identity, state| {
                 // Forward e2ee events to the room
                 // (Ignore if the participant is not in the room anymore)
+                let Some(inner) = inner.upgrade() else {
+                    // RoomSession is gone, nothing left to forward the events to.
+                    return;
+                };
 
                 let participant = if participant_identity.as_str()
                     == inner.local_participant.identity().as_str()

--- a/livekit/src/rtc_engine/rtc_events.rs
+++ b/livekit/src/rtc_engine/rtc_events.rs
@@ -60,7 +60,6 @@ pub enum RtcEvent {
     },
     DataChannelBufferedAmountChange {
         sent: u64,
-        amount: u64,
         kind: DataPacketKind,
     },
 }
@@ -166,16 +165,14 @@ fn on_message(emitter: RtcEmitter, kind: DataPacketKind) -> rtc::data_channel::O
 
 fn on_buffered_amount_change(
     emitter: RtcEmitter,
-    dc: DataChannel,
     kind: DataPacketKind,
 ) -> rtc::data_channel::OnBufferedAmountChange {
     Box::new(move |sent| {
-        let amount = dc.buffered_amount();
-        let _ = emitter.send(RtcEvent::DataChannelBufferedAmountChange { sent, amount, kind });
+        let _ = emitter.send(RtcEvent::DataChannelBufferedAmountChange { sent, kind });
     })
 }
 
 pub fn forward_dc_events(dc: &mut DataChannel, kind: DataPacketKind, rtc_emitter: RtcEmitter) {
     dc.on_message(Some(on_message(rtc_emitter.clone(), kind)));
-    dc.on_buffered_amount_change(Some(on_buffered_amount_change(rtc_emitter, dc.clone(), kind)));
+    dc.on_buffered_amount_change(Some(on_buffered_amount_change(rtc_emitter, kind)));
 }

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -1677,7 +1677,7 @@ impl SessionInner {
                     );
                 }
             }
-            RtcEvent::DataChannelBufferedAmountChange { sent, amount: _, kind } => {
+            RtcEvent::DataChannelBufferedAmountChange { sent, kind } => {
                 let ev = DataChannelEvent {
                     kind,
                     detail: DataChannelEventDetail::BufferedAmountChange(sent),


### PR DESCRIPTION
This PR fixes two leaks, one with an ArcCycle between a `Room` and itself due to passing a strong reference to the `RoomSession` into a closure (`on_state_changed` contained by the `RoomSession`). For this we simply downgrade the Arc in the same way we do above on line 758 in `mod.rs` for the `local_participant`.

For the second leak we noticed a DataChannel cycle triggered via the `forward_dc_events` call in `rtc_events.rs`, specifically `dc.on_buffered_amount_change(Some(on_buffered_amount_change(rtc_emitter, dc.clone(), kind)));` (i.e. we're cloning the dc and passing it into itself, creating the strong reference cycle).

Initially we were going to just pass the amount from dc directly, but noticed we don't actually need that in the struct, so opted to remove the field directly. If it's needed for other reasons we can add it back without cloning the data channel arc.

The leak is proportional to room joins, and so we set up a simple rig to test joining and leaving rooms to measure the leak amount via jemalloc's `stats.allocated` gauge and got these results:

| Build | Per Room Join (kb) |
|-------|--------------------|
| main  | 162                |
| PR    | 20                 |

Although this is a bit minimal, over many calls a day the leak accumulates quite a bit.