### PR TITLE
Use "line-tables-only" for dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,10 @@ winit = "0.30.13"
 hound = "3.5"
 cc = { version = "1.0", features = ["parallel"] }
 
+[profile.dev]
+debug = "line-tables-only"
+# Set to `true` instead for enhanced debugging at the cost of slower builds.
+
 [profile.release]
 opt-level = "z"
 lto = true

--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -310,6 +310,12 @@ SWIFT_DSYMS_FLAG = { value = "--debug-symbols", condition = { profiles = ["relea
 # to each per-arch .dylib at target/<arch>/release/deps/lib<name>.dylib.dSYM.
 CARGO_PROFILE_RELEASE_DEBUG = { value = "limited", condition = { profiles = ["release"] } }
 CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO = { value = "packed", condition = { profiles = ["release"] } }
+# The workspace dev profile is `debug = "line-tables-only"` for build speed,
+# but the debug xcframework exists for lldb Rust-side debugging (variable
+# inspection needs full DWARF — see support/swift/DEBUGGING.md). Restore it
+# here so `swift-package-debug` keeps its promise regardless of the workspace
+# default.
+CARGO_PROFILE_DEV_DEBUG = { value = "full", condition = { profiles = ["development"] } }
 # Space-separated platform list, overridable for partial builds (e.g. the
 # macos-only debug flow below).
 SPM_PLATFORMS = { value = "macos ios maccatalyst visionos tvos", condition = { env_not_set = ["SPM_PLATFORMS"] } }


### PR DESCRIPTION
Speed up compile times during development & CI runs by not generating full debug info. Some more info [here](https://kobzol.github.io/rust/rustc/2025/05/20/disable-debuginfo-to-improve-rust-compile-times.html). TLDR: if you are not using a debugger, the extra debug info is useless.