### PR TITLE
bugfix: PeerConnectionInterface::AddIceCandidate

### DIFF
--- a/.changeset/add_ice_candidate_completion_ownership.md
+++ b/.changeset/add_ice_candidate_completion_ownership.md
@@ -1,0 +1,19 @@
+---
+webrtc-sys: patch
+libwebrtc: patch
+---
+
+# Keep `add_ice_candidate` completion state alive until libwebrtc completes
+
+The native `PeerConnection::add_ice_candidate` shim passed libwebrtc a lambda that captured
+the Rust context and completion function by reference, even though
+`PeerConnectionInterface::AddIceCandidate` completes asynchronously. Whenever libwebrtc's
+operations chain deferred the completion — for example when a `CreateOffer` or
+`SetRemoteDescription` was still in flight — the shim returned first and destroyed both
+captures. Dropping the context dropped the pending `oneshot::Sender`, so the Rust future
+resolved with `add_ice_candidate cancelled`, and the later callback read freed memory,
+crashing with `SIGSEGV`/`SIGBUS`.
+
+The completion state now lives in a shared, single-use object that outlives the call, is
+safe for the copies libwebrtc makes of the callback, and hands the context back to Rust
+exactly once.

--- a/libwebrtc/src/peer_connection.rs
+++ b/libwebrtc/src/peer_connection.rs
@@ -273,6 +273,8 @@ impl Debug for PeerConnection {
 
 #[cfg(test)]
 mod tests {
+    use std::{future::Future, pin::Pin, task};
+
     use log::trace;
     use tokio::sync::mpsc;
 
@@ -342,5 +344,147 @@ mod tests {
 
         alice.close();
         bob.close();
+    }
+
+    fn test_config() -> RtcConfiguration {
+        RtcConfiguration {
+            ice_servers: vec![],
+            continual_gathering_policy: ContinualGatheringPolicy::GatherOnce,
+            ice_transport_type: IceTransportsType::All,
+            enable_sctp_snap: false,
+        }
+    }
+
+    /// Polls `fut` once so the native operation it starts is queued, without
+    /// waiting for it to complete. Returns whether it already finished.
+    fn poll_once<F: Future>(fut: &mut Pin<Box<F>>) -> bool {
+        let waker = task::Waker::noop();
+        let mut cx = task::Context::from_waker(waker);
+        fut.as_mut().poll(&mut cx).is_ready()
+    }
+
+    /// An offerer that has gathered at least one local ICE candidate, ready to
+    /// be handed to a remote peer.
+    struct Offerer {
+        pc: PeerConnection,
+        offer: SessionDescription,
+        candidate: IceCandidate,
+        _dc: DataChannel,
+    }
+
+    async fn offerer(factory: &PeerConnectionFactory) -> Offerer {
+        let pc = factory.create_peer_connection(test_config()).unwrap();
+
+        let (ice_tx, mut ice_rx) = mpsc::unbounded_channel::<IceCandidate>();
+        pc.on_ice_candidate(Some(Box::new(move |candidate| {
+            let _ = ice_tx.send(candidate);
+        })));
+
+        let dc = pc.create_data_channel("test_dc", DataChannelInit::default()).unwrap();
+        let offer = pc.create_offer(OfferOptions::default()).await.unwrap();
+        pc.set_local_description(offer.clone()).await.unwrap();
+        let candidate = ice_rx.recv().await.unwrap();
+
+        Offerer { pc, offer, candidate, _dc: dc }
+    }
+
+    /// Puts `pc` in a state where its remote description is being applied and
+    /// libwebrtc's operations chain is still busy, so that the completion of
+    /// any operation chained afterwards is deferred past the return of the
+    /// native call. Returns the two futures that must be kept alive.
+    ///
+    /// A freshly created peer connection is still generating its DTLS
+    /// certificate, which keeps `CreateOffer` — and therefore everything queued
+    /// behind it — on the chain.
+    #[allow(clippy::type_complexity)]
+    fn occupy_operations_chain<'a>(
+        pc: &'a PeerConnection,
+        offer: SessionDescription,
+    ) -> (
+        Pin<Box<impl Future<Output = Result<SessionDescription, RtcError>> + 'a>>,
+        Pin<Box<impl Future<Output = Result<(), RtcError>> + 'a>>,
+    ) {
+        let mut create_offer = Box::pin(pc.create_offer(OfferOptions::default()));
+        assert!(
+            !poll_once(&mut create_offer),
+            "CreateOffer completed too early to occupy the chain"
+        );
+
+        let mut set_remote = Box::pin(pc.set_remote_description(offer));
+        assert!(!poll_once(&mut set_remote), "SetRemoteDescription completed too early");
+
+        (create_offer, set_remote)
+    }
+
+    /// Regression test: the completion state of `add_ice_candidate` used to live
+    /// on the stack of the native shim, so a completion deferred by libwebrtc's
+    /// operations chain destroyed the pending `oneshot::Sender` (surfacing as
+    /// `add_ice_candidate cancelled`) and later read freed memory.
+    #[tokio::test]
+    async fn add_ice_candidate_resolves_when_completion_is_deferred() {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let factory = PeerConnectionFactory::default();
+        let bob = offerer(&factory).await;
+        let alice = factory.create_peer_connection(test_config()).unwrap();
+
+        let (create_offer, set_remote) = occupy_operations_chain(&alice, bob.offer);
+
+        alice.add_ice_candidate(bob.candidate).await.unwrap();
+
+        create_offer.await.unwrap();
+        set_remote.await.unwrap();
+
+        alice.close();
+        bob.pc.close();
+    }
+
+    /// Closing a peer connection while an ICE-candidate completion is still
+    /// queued must not read the completion state after it was released.
+    #[tokio::test]
+    async fn close_during_deferred_add_ice_candidate_completion() {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let factory = PeerConnectionFactory::default();
+        let bob = offerer(&factory).await;
+        let alice = factory.create_peer_connection(test_config()).unwrap();
+
+        let (create_offer, set_remote) = occupy_operations_chain(&alice, bob.offer);
+
+        let mut add_ice = Box::pin(alice.add_ice_candidate(bob.candidate));
+        assert!(!poll_once(&mut add_ice), "AddIceCandidate completed too early");
+        alice.close();
+
+        // Whether the candidate lands before the close is a race; either
+        // outcome is fine as long as the future resolves without a crash.
+        let _ = add_ice.await;
+        let _ = create_offer.await;
+        let _ = set_remote.await;
+
+        bob.pc.close();
+    }
+
+    /// Repeats the deferred-completion path enough times to surface a
+    /// use-after-free or double free of the completion state.
+    #[tokio::test]
+    async fn repeated_deferred_add_ice_candidate_completions() {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let factory = PeerConnectionFactory::default();
+
+        for _ in 0..25 {
+            let bob = offerer(&factory).await;
+            let alice = factory.create_peer_connection(test_config()).unwrap();
+
+            let (create_offer, set_remote) = occupy_operations_chain(&alice, bob.offer);
+
+            alice.add_ice_candidate(bob.candidate).await.unwrap();
+
+            create_offer.await.unwrap();
+            set_remote.await.unwrap();
+
+            alice.close();
+            bob.pc.close();
+        }
     }
 }

--- a/webrtc-sys/include/livekit/peer_connection.h
+++ b/webrtc-sys/include/livekit/peer_connection.h
@@ -16,7 +16,10 @@
 
 #pragma once
 
+#include <atomic>
+#include <functional>
 #include <memory>
+#include <optional>
 
 #include "api/peer_connection_interface.h"
 #include "api/scoped_refptr.h"
@@ -43,6 +46,52 @@ webrtc::PeerConnectionInterface::RTCConfiguration to_native_rtc_configuration(
     RtcConfiguration config);
 
 class PeerConnectionObserverWrapper;
+
+// Owns the Rust completion state of an asynchronous `AddIceCandidate` call.
+//
+// `PeerConnectionInterface::AddIceCandidate` takes a copyable
+// `std::function<void(RTCError)>` and invokes it from libwebrtc's operations
+// chain, which may run long after `PeerConnection::add_ice_candidate` has
+// returned. The state therefore cannot be captured by reference from that
+// frame, and the move-only `rust::Box<PeerContext>` cannot be captured by value
+// into a copyable `std::function`. Instances are held behind a `shared_ptr` so
+// that every copy libwebrtc makes of the callback refers to the same state, and
+// `Complete` hands the context back to Rust exactly once no matter how many
+// copies are invoked.
+class AddIceCandidateCompletion {
+ public:
+  AddIceCandidateCompletion(
+      rust::Box<PeerContext> ctx,
+      rust::Fn<void(rust::Box<PeerContext>, RtcError)> on_complete)
+      : ctx_(std::move(ctx)), on_complete_(on_complete) {}
+
+  AddIceCandidateCompletion(const AddIceCandidateCompletion&) = delete;
+  AddIceCandidateCompletion& operator=(const AddIceCandidateCompletion&) =
+      delete;
+
+  // Reports `error` to Rust. Subsequent calls are ignored: the context can only
+  // be moved back to Rust once.
+  void Complete(const webrtc::RTCError& error) {
+    if (completed_.exchange(true, std::memory_order_acq_rel))
+      return;
+
+    on_complete_(std::move(*ctx_), to_error(error));
+    ctx_.reset();
+  }
+
+ private:
+  std::optional<rust::Box<PeerContext>> ctx_;
+  rust::Fn<void(rust::Box<PeerContext>, RtcError)> on_complete_;
+  std::atomic<bool> completed_{false};
+};
+
+// Builds the callback handed to `PeerConnectionInterface::AddIceCandidate`.
+// The returned function keeps `ctx` and `on_complete` alive until libwebrtc
+// invokes it (or drops every copy of it, which drops the context and cancels
+// the pending Rust future).
+std::function<void(const webrtc::RTCError&)> make_add_ice_candidate_callback(
+    rust::Box<PeerContext> ctx,
+    rust::Fn<void(rust::Box<PeerContext>, RtcError)> on_complete);
 
 class PeerConnection : webrtc::PeerConnectionObserver {
  public:
@@ -203,5 +252,18 @@ class PeerConnection : webrtc::PeerConnectionObserver {
 static std::shared_ptr<PeerConnection> _shared_peer_connection() {
   return nullptr;  // Ignore
 }
+
+#ifdef LIVEKIT_TEST
+// Test-only seam reproducing how libwebrtc drives an `AddIceCandidate`
+// completion: the callback outlives the frame that built it, is copied into the
+// operations chain, and is then invoked `invocations` times (zero models a
+// pending operation that is abandoned). Reports back to Rust at most once; an
+// empty `error_message` reports success.
+void complete_add_ice_candidate_for_test(
+    rust::Box<PeerContext> ctx,
+    rust::Fn<void(rust::Box<PeerContext>, RtcError)> on_complete,
+    rust::String error_message,
+    size_t invocations);
+#endif
 
 }  // namespace livekit_ffi

--- a/webrtc-sys/src/peer_connection.cpp
+++ b/webrtc-sys/src/peer_connection.cpp
@@ -166,15 +166,50 @@ void PeerConnection::restart_ice() const {
   peer_connection_->RestartIce();
 }
 
+std::function<void(const webrtc::RTCError&)> make_add_ice_candidate_callback(
+    rust::Box<PeerContext> ctx,
+    rust::Fn<void(rust::Box<PeerContext>, RtcError)> on_complete) {
+  auto completion =
+      std::make_shared<AddIceCandidateCompletion>(std::move(ctx), on_complete);
+  return [completion = std::move(completion)](const webrtc::RTCError& err) {
+    completion->Complete(err);
+  };
+}
+
 void PeerConnection::add_ice_candidate(
     std::shared_ptr<IceCandidate> candidate,
     rust::Box<PeerContext> ctx,
     rust::Fn<void(rust::Box<PeerContext>, RtcError)> on_complete) const {
   peer_connection_->AddIceCandidate(
-      candidate->release(), [&](const webrtc::RTCError& err) {
-        on_complete(std::move(ctx), to_error(err));
-      });
+      candidate->release(),
+      make_add_ice_candidate_callback(std::move(ctx), on_complete));
 }
+
+#ifdef LIVEKIT_TEST
+void complete_add_ice_candidate_for_test(
+    rust::Box<PeerContext> ctx,
+    rust::Fn<void(rust::Box<PeerContext>, RtcError)> on_complete,
+    rust::String error_message,
+    size_t invocations) {
+  // The completion state belongs to `make_add_ice_candidate_callback`'s frame,
+  // which is gone by the time the callback runs.
+  auto callback = make_add_ice_candidate_callback(std::move(ctx), on_complete);
+
+  // libwebrtc's operations chain stores the callback in a copyable
+  // `std::function` and drops the original.
+  auto queued = callback;
+  callback = nullptr;
+
+  webrtc::RTCError error =
+      error_message.empty()
+          ? webrtc::RTCError::OK()
+          : webrtc::RTCError(webrtc::RTCErrorType::INVALID_PARAMETER,
+                             std::string(error_message));
+
+  for (size_t i = 0; i < invocations; ++i)
+    queued(error);
+}
+#endif
 
 std::shared_ptr<DataChannel> PeerConnection::create_data_channel(
     rust::String label,

--- a/webrtc-sys/src/peer_connection.rs
+++ b/webrtc-sys/src/peer_connection.rs
@@ -205,6 +205,15 @@ pub mod ffi {
         fn close(self: &PeerConnection);
 
         fn _shared_peer_connection() -> SharedPtr<PeerConnection>; // Ignore
+
+        /// Test-only seam that drives an `add_ice_candidate` completion the way
+        /// libwebrtc does; see the declaration in `livekit/peer_connection.h`.
+        fn complete_add_ice_candidate_for_test(
+            ctx: Box<PeerContext>,
+            on_complete: fn(ctx: Box<PeerContext>, error: RtcError),
+            error_message: String,
+            invocations: usize,
+        );
     }
 
     extern "Rust" {
@@ -234,5 +243,69 @@ impl Default for ffi::RtcOfferAnswerOptions {
             num_simulcast_layers: 1,
             use_obsolete_sctp_sdp: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc;
+
+    use super::{ffi, PeerContext};
+
+    type Completion = mpsc::Sender<Result<(), String>>;
+
+    /// Mirrors the completion handler `libwebrtc` installs: it takes the
+    /// context back from C++ and reports the result exactly once.
+    // The box is dictated by the FFI signature, not by this function.
+    #[allow(clippy::boxed_local)]
+    fn on_complete(ctx: Box<PeerContext>, error: ffi::RtcError) {
+        let tx = ctx.0.downcast::<Completion>().expect("unexpected peer context payload");
+        let result = if error.message.is_empty() { Ok(()) } else { Err(error.message) };
+        let _ = tx.send(result);
+    }
+
+    fn complete(error_message: &str, invocations: usize) -> mpsc::Receiver<Result<(), String>> {
+        let (tx, rx) = mpsc::channel();
+        let ctx = Box::new(PeerContext(Box::new(tx as Completion)));
+        ffi::complete_add_ice_candidate_for_test(
+            ctx,
+            on_complete,
+            error_message.to_owned(),
+            invocations,
+        );
+        rx
+    }
+
+    /// The callback state must outlive the frame that built it: libwebrtc runs
+    /// it from its operations chain, potentially long after
+    /// `add_ice_candidate` returned.
+    #[test]
+    fn completion_survives_the_frame_that_built_it() {
+        assert_eq!(complete("", 1).try_recv(), Ok(Ok(())));
+    }
+
+    #[test]
+    fn completion_forwards_the_error() {
+        assert_eq!(
+            complete("candidate rejected", 1).try_recv(),
+            Ok(Err("candidate rejected".to_owned()))
+        );
+    }
+
+    /// libwebrtc holds the callback in a copyable `std::function`, so several
+    /// copies may be invoked. The context can only be moved back to Rust once.
+    #[test]
+    fn completion_reports_once_when_invoked_repeatedly() {
+        let rx = complete("", 4);
+
+        assert_eq!(rx.try_recv(), Ok(Ok(())));
+        assert_eq!(rx.try_recv(), Err(mpsc::TryRecvError::Disconnected));
+    }
+
+    /// An abandoned operation drops every copy of the callback without
+    /// invoking it, which releases the context exactly once.
+    #[test]
+    fn dropping_the_callback_releases_the_context() {
+        assert_eq!(complete("", 0).try_recv(), Err(mpsc::TryRecvError::Disconnected));
     }
 }


### PR DESCRIPTION
# Overview

`PeerConnection::add_ice_candidate` handed libwebrtc a `[&]` lambda that captured `ctx` (the
`rust::Box<PeerContext>`) and `on_complete` by reference — both stack parameters of the shim.
`PeerConnectionInterface::AddIceCandidate` completes asynchronously, so whenever libwebrtc's
operations chain deferred the completion, the shim returned and destroyed the captures first.
Dropping the context dropped the pending `oneshot::Sender`, so the Rust future resolved with
`add_ice_candidate cancelled`; the later callback then read freed memory (`SIGSEGV`/`SIGBUS`).

The callback state now lives in `AddIceCandidateCompletion`, held behind a `shared_ptr` by
`make_add_ice_candidate_callback`. It outlives the call, is safe for the copies libwebrtc makes
(`AddIceCandidate` takes a copyable `std::function`, and `OperationsChain` copies it), and an
atomic guard moves the context back to Rust exactly once.

## Reproducing failure (before merge)

The bug only shows when libwebrtc's operations chain is non-empty: `ChainOperation` runs an
operation immediately when the chain is idle, so the callback normally fires synchronously inside
the blocking proxy marshal and the dangling captures are still alive. Stacking a `CreateOffer` on a
freshly created peer connection (its DTLS certificate is still generating) keeps the chain busy and
defers the completion:

```
res=Err(RtcError { error_type: Internal, message: "add_ice_candidate cancelled" })
signal: 10, SIGBUS: access to undefined memory
```

# Tests

**`webrtc-sys`** — four unit tests over a test-only seam that drives the *production* callback
factory the way libwebrtc does (build it in a frame that returns, copy it, drop the original, then
invoke): survives-the-frame, error forwarding, exactly-once across repeated invocations,
release-on-drop.

**`libwebrtc`** — three integration tests on the existing peer-connection fixture: deferred
completion resolves, close during a deferred completion, and 25 repeated deferred completions. Each
asserts the chain is genuinely occupied first, so they cannot pass vacuously.

Against the old `[&]` implementation: 3/4 `webrtc-sys` tests SIGBUS, all 3 `libwebrtc` tests SIGSEGV.

| Command | Result |
|---|---|
| `cargo fmt -- --check` | clean |
| `clang-format` on new C++ regions | clean |
| `cargo test -p libwebrtc -p webrtc-sys -- --test-threads=1` | 29 passed, 0 failed |
| `cargo clippy -p webrtc-sys -p libwebrtc --all-targets` | no warnings in changed files |
| `cargo check --workspace --all-targets` | no errors |
| 20x repeat under `MallocScribble`/`MallocPreScribble`/`MallocGuardEdges` | 0 failures |

ASan was not run: `-Zsanitizer=address` needs nightly and the repo pins stable `1.97.1`; the
prebuilt libwebrtc is not instrumented either. macOS malloc guards were used instead.

# API breaking changes

None. `PeerConnection::add_ice_candidate` keeps its signature and its success/error results; the
change is confined to how the native shim owns the completion state.
