### PR TITLE
Fix Objective-C linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,14 +203,6 @@ cargo build
   
 ```
 
-### MacOS
-
-When building on MacOS, `-ObjC` linker flag is needed. LiveKit's WebRTC implementation make use of ObjectiveC libraries on the Mac. You may get the following error if the app isn't linked with ObjC:
-
-```
-*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[RTCVideoCodecInfo nativeSdpVideoFormat]: unrecognized selector sent to instance 0x600003bc6660'
-```
-
 ## Motivation and Design Goals
 
 LiveKit aims to provide an open source, end-to-end WebRTC stack that works everywhere. We have two goals in mind with this SDK:

--- a/webrtc-sys/libwebrtc/build_ios.sh
+++ b/webrtc-sys/libwebrtc/build_ios.sh
@@ -156,6 +156,7 @@ ninja -C "$OUTPUT_DIR" :default \
 # archive and their methods are missing at runtime ("unrecognized selector")
 # unless every consumer links with -ObjC. Merged into one member, they are
 # loaded whenever any sdk symbol is referenced.
+rm -f "$ARTIFACTS_DIR/lib/libwebrtc.a"
 ld -r -keep_private_externs -o "$OUTPUT_DIR/sdk.o" `find "$OUTPUT_DIR/obj/sdk" -name '*.o'`
 ar -rc "$ARTIFACTS_DIR/lib/libwebrtc.a" "$OUTPUT_DIR/sdk.o" `find "$OUTPUT_DIR/obj" -name '*.o' -not -path "*/third_party/nasm/*" -not -path "*/obj/sdk/*"`
 

--- a/webrtc-sys/libwebrtc/build_ios.sh
+++ b/webrtc-sys/libwebrtc/build_ios.sh
@@ -150,7 +150,14 @@ ninja -C "$OUTPUT_DIR" :default \
 
 # make libwebrtc.a
 # don't include nasm
-ar -rc "$ARTIFACTS_DIR/lib/libwebrtc.a" `find "$OUTPUT_DIR/obj" -name '*.o' -not -path "*/third_party/nasm/*"`
+# Merge the sdk objects into a single archive member. The ObjC categories in
+# sdk/objc (e.g. NSString+StdString) live in object files that export no
+# symbols, so as individual members the linker never pulls them out of the
+# archive and their methods are missing at runtime ("unrecognized selector")
+# unless every consumer links with -ObjC. Merged into one member, they are
+# loaded whenever any sdk symbol is referenced.
+ld -r -keep_private_externs -o "$OUTPUT_DIR/sdk.o" `find "$OUTPUT_DIR/obj/sdk" -name '*.o'`
+ar -rc "$ARTIFACTS_DIR/lib/libwebrtc.a" "$OUTPUT_DIR/sdk.o" `find "$OUTPUT_DIR/obj" -name '*.o' -not -path "*/third_party/nasm/*" -not -path "*/obj/sdk/*"`
 
 # License generation - may fail locally due to GN warnings breaking JSON parsing
 # Use vpython3 from depot_tools for consistent Python version

--- a/webrtc-sys/libwebrtc/build_macos.sh
+++ b/webrtc-sys/libwebrtc/build_macos.sh
@@ -145,7 +145,14 @@ ninja -C "$OUTPUT_DIR" :default \
 
 # make libwebrtc.a
 # don't include nasm
-ar -rc "$ARTIFACTS_DIR/lib/libwebrtc.a" `find "$OUTPUT_DIR/obj" -name '*.o' -not -path "*/third_party/nasm/*"`
+# Merge the sdk objects into a single archive member. The ObjC categories in
+# sdk/objc (e.g. NSString+StdString) live in object files that export no
+# symbols, so as individual members the linker never pulls them out of the
+# archive and their methods are missing at runtime ("unrecognized selector")
+# unless every consumer links with -ObjC. Merged into one member, they are
+# loaded whenever any sdk symbol is referenced.
+ld -r -keep_private_externs -o "$OUTPUT_DIR/sdk.o" `find "$OUTPUT_DIR/obj/sdk" -name '*.o'`
+ar -rc "$ARTIFACTS_DIR/lib/libwebrtc.a" "$OUTPUT_DIR/sdk.o" `find "$OUTPUT_DIR/obj" -name '*.o' -not -path "*/third_party/nasm/*" -not -path "*/obj/sdk/*"`
 
 # License generation - may fail locally due to GN warnings breaking JSON parsing
 # Use vpython3 from depot_tools for consistent Python version

--- a/webrtc-sys/libwebrtc/build_macos.sh
+++ b/webrtc-sys/libwebrtc/build_macos.sh
@@ -151,6 +151,7 @@ ninja -C "$OUTPUT_DIR" :default \
 # archive and their methods are missing at runtime ("unrecognized selector")
 # unless every consumer links with -ObjC. Merged into one member, they are
 # loaded whenever any sdk symbol is referenced.
+rm -f "$ARTIFACTS_DIR/lib/libwebrtc.a"
 ld -r -keep_private_externs -o "$OUTPUT_DIR/sdk.o" `find "$OUTPUT_DIR/obj/sdk" -name '*.o'`
 ar -rc "$ARTIFACTS_DIR/lib/libwebrtc.a" "$OUTPUT_DIR/sdk.o" `find "$OUTPUT_DIR/obj" -name '*.o' -not -path "*/third_party/nasm/*" -not -path "*/obj/sdk/*"`
 


### PR DESCRIPTION
The ObjC categories in _libwebrtc.a_ (e.g. `NSString (StdString)`) export no symbols, so the linker drops them and macOS/iOS binaries abort at startup:
```
+[NSString stringForStdString:]: unrecognized selector sent to class
```

The usual fix, `-ObjC` (currently documented in the README as required for consumers), can't be applied at the crate level since Cargo doesn't propagate link args to dependent crates. Instead, merge all `obj/sdk` objects into one archive member when assembling _libwebrtc.a_, so the categories load together with the referenced SDK symbols and consumers need no flag as of the next prebuilt release.

After this merges, [_livekit-examples/rust-dev-client_](https://github.com/livekit-examples/rust-dev-client) should be updated to remove the workaround.