### PR TITLE
CudaContext lifecycle memory fixes

### DIFF
--- a/.changeset/fix_cuda_video_lifecycle_cleanup.md
+++ b/.changeset/fix_cuda_video_lifecycle_cleanup.md
@@ -1,0 +1,14 @@
+---
+libwebrtc: patch
+livekit: patch
+livekit-ffi: patch
+webrtc-sys: patch
+---
+
+Fix CUDA and FFI resource cleanup during SDK shutdown.
+
+NVIDIA encoder and decoder factories now share a reference-counted CUDA context
+and destroy it when the final factory is dropped. FFI shutdown now releases
+leftover handles one at a time so nested `drop_handle` calls do not re-enter
+`DashMap::clear()`. Adds regression coverage for FFI-handle, watcher, and
+configuration cleanup during disposal.

--- a/livekit-ffi/src/server/mod.rs
+++ b/livekit-ffi/src/server/mod.rs
@@ -187,10 +187,14 @@ impl FfiServer {
         self.logger.set_capture_logs(false);
 
         // Closing rooms does not release resources owned by FFI handles.
-        // Cancel handle watchers before dropping all stored native resources.
+        // Cancel handle watchers first, then drop handles one by one so Drop
+        // impls can call drop_handle without re-entering DashMap::clear().
         *self.config.lock() = None;
         self.handle_dropped_txs.clear();
-        self.ffi_handles.clear();
+        let leftover: Vec<_> = self.ffi_handles.iter().map(|entry| *entry.key()).collect();
+        for id in leftover {
+            let _ = self.ffi_handles.remove(&id);
+        }
     }
 
     pub fn send_event(&self, message: proto::ffi_event::Message) -> FfiResult<()> {

--- a/livekit-ffi/src/server/mod.rs
+++ b/livekit-ffi/src/server/mod.rs
@@ -170,6 +170,10 @@ impl FfiServer {
             .collect()
     }
 
+    /// Closes active rooms and releases every resource owned by an FFI handle.
+    ///
+    /// Clearing the handle map is required even after rooms are closed because
+    /// room handles retain their RTC engines and peer connection factories.
     pub async fn dispose(&'static self) {
         log::debug!("disposing ffi server");
 
@@ -182,8 +186,11 @@ impl FfiServer {
 
         self.logger.set_capture_logs(false);
 
-        // Drop all handles
-        *self.config.lock() = None; // Invalidate the config
+        // Closing rooms does not release resources owned by FFI handles.
+        // Cancel handle watchers before dropping all stored native resources.
+        *self.config.lock() = None;
+        self.handle_dropped_txs.clear();
+        self.ffi_handles.clear();
     }
 
     pub fn send_event(&self, message: proto::ffi_event::Message) -> FfiResult<()> {
@@ -262,10 +269,10 @@ impl FfiServer {
     pub fn drop_handle(&self, id: FfiHandleId) -> bool {
         let existed = self.ffi_handles.remove(&id).is_some();
         self.handle_dropped_txs.remove(&id);
-        if !existed {
+        if !existed && self.is_setup() {
             log::warn!("Attempted to drop unknown FFI handle: {id}");
         }
-        return existed;
+        existed
     }
 
     pub fn watch_handle_dropped(&self, handle: FfiHandleId) -> oneshot::Receiver<()> {

--- a/livekit-ffi/src/server/mod.rs
+++ b/livekit-ffi/src/server/mod.rs
@@ -49,8 +49,8 @@ mod utils;
 pub mod video_source;
 pub mod video_stream;
 
-//#[cfg(test)]
-//mod tests;
+#[cfg(test)]
+mod tests;
 
 #[cfg(test)]
 mod audio_filter_tests;

--- a/livekit-ffi/src/server/tests.rs
+++ b/livekit-ffi/src/server/tests.rs
@@ -343,3 +343,83 @@ fn publish_video_track() {
         })
 }
 */
+
+use std::sync::{
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+    Arc,
+};
+
+use super::{FfiConfig, FfiHandle};
+use crate::{FfiHandleId, FFI_SERVER};
+
+struct DropsHandle {
+    handle: FfiHandleId,
+    did_attempt_drop: Arc<AtomicBool>,
+    drop_count: Arc<AtomicUsize>,
+}
+
+impl FfiHandle for DropsHandle {}
+
+impl Drop for DropsHandle {
+    fn drop(&mut self) {
+        self.did_attempt_drop.store(true, Ordering::SeqCst);
+        self.drop_count.fetch_add(1, Ordering::SeqCst);
+        let _ = FFI_SERVER.drop_handle(self.handle);
+    }
+}
+
+#[test]
+fn dispose_cleans_up_resources() {
+    let did_attempt_drop = Arc::new(AtomicBool::new(false));
+    let drop_count = Arc::new(AtomicUsize::new(0));
+    let child_handle = FFI_SERVER.next_id();
+    let first_parent_handle = FFI_SERVER.next_id();
+    let second_parent_handle = FFI_SERVER.next_id();
+
+    // Configure the server so disposal must also clear its callback state.
+    FFI_SERVER.setup(FfiConfig {
+        callback_fn: Arc::new(|_| {}),
+        capture_logs: false,
+        sdk: "livekit-ffi-test".to_owned(),
+        sdk_version: "test".to_owned(),
+    });
+    assert!(FFI_SERVER.is_setup());
+
+    // Parent drops re-enter drop_handle for this child, matching nested FFI
+    // resource cleanup during shutdown.
+    FFI_SERVER.store_handle(child_handle, ());
+    let mut child_dropped_rx = FFI_SERVER.watch_handle_dropped(child_handle);
+    FFI_SERVER.store_handle(
+        first_parent_handle,
+        DropsHandle {
+            handle: child_handle,
+            did_attempt_drop: did_attempt_drop.clone(),
+            drop_count: drop_count.clone(),
+        },
+    );
+    FFI_SERVER.store_handle(
+        second_parent_handle,
+        DropsHandle {
+            handle: child_handle,
+            did_attempt_drop: did_attempt_drop.clone(),
+            drop_count: drop_count.clone(),
+        },
+    );
+
+    // Dispose must release handles, cancel their watchers, and clear config.
+    FFI_SERVER.async_runtime.block_on(FFI_SERVER.dispose());
+
+    assert!(did_attempt_drop.load(Ordering::SeqCst));
+    assert_eq!(drop_count.load(Ordering::SeqCst), 2);
+    assert!(FFI_SERVER.ffi_handles.is_empty());
+    assert!(!FFI_SERVER.is_setup());
+    assert!(matches!(
+        child_dropped_rx.try_recv(),
+        Err(tokio::sync::oneshot::error::TryRecvError::Closed)
+    ));
+
+    // A repeated shutdown is a no-op after the first cleanup.
+    FFI_SERVER.async_runtime.block_on(FFI_SERVER.dispose());
+    assert!(FFI_SERVER.ffi_handles.is_empty());
+    assert!(!FFI_SERVER.is_setup());
+}

--- a/webrtc-sys/src/nvidia/cuda_context.cpp
+++ b/webrtc-sys/src/nvidia/cuda_context.cpp
@@ -10,6 +10,7 @@
 #endif
 
 #include <iostream>
+#include <mutex>
 
 #if defined(WIN32)
 static const char CUDA_DYNAMIC_LIBRARY[] = "nvcuda.dll";
@@ -35,6 +36,13 @@ namespace livekit_ffi {
 
 static void* s_module_ptr = nullptr;
 static const int kRequiredDriverVersion = 11000;
+
+// Serializes access to the singleton context, its reference count, and the
+// dynamically loaded CUDA module.
+static std::mutex& cudaMutex() {
+  static std::mutex mutex;
+  return mutex;
+}
 
 static bool load_cuda_modules() {
   if (s_module_ptr)
@@ -90,7 +98,7 @@ static bool check_cuda_device() {
     return false;
   }
 
-  return  true;
+  return true;
 }
 
 CudaContext* CudaContext::GetInstance() {
@@ -99,11 +107,19 @@ CudaContext* CudaContext::GetInstance() {
 }
 
 bool CudaContext::IsAvailable() {
+  std::lock_guard<std::mutex> lock(cudaMutex());
   return load_cuda_modules() && check_cuda_device();
 }
 
 bool CudaContext::Initialize() {
-  // Initialize CUDA context
+  std::lock_guard<std::mutex> lock(cudaMutex());
+  if (cu_context_ != nullptr) {
+    ++ref_count_;
+    RTC_LOG(LS_INFO) << "CUDA context already initialized; reusing existing "
+                        "context (refs="
+                     << ref_count_ << ").";
+    return true;
+  }
 
   bool success = load_cuda_modules();
   if (!success) {
@@ -162,11 +178,13 @@ bool CudaContext::Initialize() {
 
   cu_device_ = cu_device;
   cu_context_ = context;
+  ref_count_ = 1;
 
   return true;
 }
 
 CUcontext CudaContext::GetContext() const {
+  std::lock_guard<std::mutex> lock(cudaMutex());
   RTC_DCHECK(cu_context_ != nullptr);
   // Ensure the context is current
   CUcontext current;
@@ -183,7 +201,16 @@ CUcontext CudaContext::GetContext() const {
 }
 
 void CudaContext::Shutdown() {
-  // Shutdown CUDA context
+  std::lock_guard<std::mutex> lock(cudaMutex());
+  if (ref_count_ == 0) {
+    return;
+  }
+  --ref_count_;
+  if (ref_count_ > 0) {
+    RTC_LOG(LS_INFO) << "CUDA context released (refs=" << ref_count_ << ").";
+    return;
+  }
+
   if (cu_context_) {
     cuCtxDestroy(cu_context_);
     cu_context_ = nullptr;

--- a/webrtc-sys/src/nvidia/cuda_context.cpp
+++ b/webrtc-sys/src/nvidia/cuda_context.cpp
@@ -179,9 +179,7 @@ bool CudaContext::Initialize() {
   cu_device_ = cu_device;
   cu_context_ = context;
   ref_count_ = 1;
-  ++create_count_;
-  RTC_LOG(LS_INFO) << "CUDA context initialized (refs=1, creates="
-                   << create_count_ << ", destroys=" << destroy_count_ << ").";
+  RTC_LOG(LS_INFO) << "CUDA context initialized (refs=1).";
 
   return true;
 }
@@ -236,13 +234,9 @@ void CudaContext::Shutdown() {
           << "Failed to destroy CUDA context: " << error_name
           << " (code=" << static_cast<int>(result)
           << "); cleanup is indeterminate and CUDA resources may have leaked. "
-             "A later Initialize() will create a new context (refs=0, creates="
-          << create_count_ << ", destroys=" << destroy_count_ << ").";
+             "A later Initialize() will create a new context (refs=0).";
     } else {
-      ++destroy_count_;
-      RTC_LOG(LS_INFO)
-          << "CUDA context destroyed successfully (refs=0, creates="
-          << create_count_ << ", destroys=" << destroy_count_ << ").";
+      RTC_LOG(LS_INFO) << "CUDA context destroyed successfully (refs=0).";
     }
   }
   if (s_module_ptr) {

--- a/webrtc-sys/src/nvidia/cuda_context.cpp
+++ b/webrtc-sys/src/nvidia/cuda_context.cpp
@@ -179,8 +179,16 @@ bool CudaContext::Initialize() {
   cu_device_ = cu_device;
   cu_context_ = context;
   ref_count_ = 1;
+  ++create_count_;
+  RTC_LOG(LS_INFO) << "CUDA context initialized (refs=1, creates="
+                   << create_count_ << ", destroys=" << destroy_count_ << ").";
 
   return true;
+}
+
+bool CudaContext::IsInitialized() const {
+  std::lock_guard<std::mutex> lock(cudaMutex());
+  return cu_context_ != nullptr;
 }
 
 CUcontext CudaContext::GetContext() const {
@@ -212,8 +220,30 @@ void CudaContext::Shutdown() {
   }
 
   if (cu_context_) {
-    cuCtxDestroy(cu_context_);
+    const CUresult result = cuCtxDestroy(cu_context_);
+    // NVIDIA documents that cuCtxDestroy() may report an error from an earlier
+    // asynchronous launch, so the context state is indeterminate after this
+    // call. Never reuse the handle; allow a later Initialize() to create a new
+    // context instead.
     cu_context_ = nullptr;
+    if (result != CUDA_SUCCESS) {
+      const char* error_name = nullptr;
+      if (cuGetErrorName(result, &error_name) != CUDA_SUCCESS ||
+          error_name == nullptr) {
+        error_name = "unknown";
+      }
+      RTC_LOG(LS_ERROR)
+          << "Failed to destroy CUDA context: " << error_name
+          << " (code=" << static_cast<int>(result)
+          << "); cleanup is indeterminate and CUDA resources may have leaked. "
+             "A later Initialize() will create a new context (refs=0, creates="
+          << create_count_ << ", destroys=" << destroy_count_ << ").";
+    } else {
+      ++destroy_count_;
+      RTC_LOG(LS_INFO)
+          << "CUDA context destroyed successfully (refs=0, creates="
+          << create_count_ << ", destroys=" << destroy_count_ << ").";
+    }
   }
   if (s_module_ptr) {
 #if defined(WIN32)

--- a/webrtc-sys/src/nvidia/cuda_context.h
+++ b/webrtc-sys/src/nvidia/cuda_context.h
@@ -5,23 +5,45 @@
 
 namespace livekit_ffi {
 
+/// @brief Process-wide CUDA context shared by NVIDIA codec factories.
+///
+/// Every successful Initialize() call acquires one reference and must be
+/// paired with one Shutdown() call. The underlying CUDA context is destroyed
+/// when the final reference is released.
 class CudaContext {
  public:
   CudaContext() = default;
   ~CudaContext() = default;
 
+  /// @brief Checks whether a compatible CUDA device and driver are available.
+  /// @return True when CUDA can be used.
   static bool IsAvailable();
 
+  /// @brief Returns the process-wide context manager.
+  /// @return Non-owning pointer to the singleton context manager.
   static CudaContext* GetInstance();
+
+  /// @brief Acquires a reference to the CUDA context, creating it if needed.
+  /// @return True on success; false if CUDA initialization fails.
   bool Initialize();
+
+  /// @brief Reports whether the underlying CUDA context exists.
+  /// @return True after successful initialization and before final shutdown.
   bool IsInitialized() const { return cu_context_ != nullptr; }
+
+  /// @brief Returns the CUDA context and makes it current on the calling
+  /// thread.
+  /// @return The initialized CUDA context.
   CUcontext GetContext() const;
 
+  /// @brief Releases one reference and destroys the context after the last one.
   void Shutdown();
 
  private:
   CUdevice cu_device_ = 0;
   CUcontext cu_context_ = nullptr;
+  // Guarded by cudaMutex() in cuda_context.cpp.
+  int ref_count_ = 0;
 };
 
 }  // namespace livekit_ffi

--- a/webrtc-sys/src/nvidia/cuda_context.h
+++ b/webrtc-sys/src/nvidia/cuda_context.h
@@ -3,6 +3,8 @@
 
 #include <cuda.h>
 
+#include <cstdint>
+
 namespace livekit_ffi {
 
 /// @brief Process-wide CUDA context shared by NVIDIA codec factories.
@@ -29,7 +31,7 @@ class CudaContext {
 
   /// @brief Reports whether the underlying CUDA context exists.
   /// @return True after successful initialization and before final shutdown.
-  bool IsInitialized() const { return cu_context_ != nullptr; }
+  bool IsInitialized() const;
 
   /// @brief Returns the CUDA context and makes it current on the calling
   /// thread.
@@ -44,6 +46,8 @@ class CudaContext {
   CUcontext cu_context_ = nullptr;
   // Guarded by cudaMutex() in cuda_context.cpp.
   int ref_count_ = 0;
+  std::uint64_t create_count_ = 0;
+  std::uint64_t destroy_count_ = 0;
 };
 
 }  // namespace livekit_ffi

--- a/webrtc-sys/src/nvidia/cuda_context.h
+++ b/webrtc-sys/src/nvidia/cuda_context.h
@@ -3,8 +3,6 @@
 
 #include <cuda.h>
 
-#include <cstdint>
-
 namespace livekit_ffi {
 
 /// @brief Process-wide CUDA context shared by NVIDIA codec factories.
@@ -46,8 +44,6 @@ class CudaContext {
   CUcontext cu_context_ = nullptr;
   // Guarded by cudaMutex() in cuda_context.cpp.
   int ref_count_ = 0;
-  std::uint64_t create_count_ = 0;
-  std::uint64_t destroy_count_ = 0;
 };
 
 }  // namespace livekit_ffi

--- a/webrtc-sys/src/nvidia/nvidia_decoder_factory.cpp
+++ b/webrtc-sys/src/nvidia/nvidia_decoder_factory.cpp
@@ -122,12 +122,22 @@ NvidiaVideoDecoderFactory::NvidiaVideoDecoderFactory()
     supported_formats_ = SupportedNvDecoderCodecs(cu_context_->GetContext());
   } else {
     RTC_LOG(LS_ERROR) << "Failed to initialize CUDA context.";
+    cu_context_ = nullptr;
   }
   RTC_LOG(LS_INFO) << "NvidiaVideoDecoderFactory created with "
                    << supported_formats_.size() << " supported formats.";
 }
 
-NvidiaVideoDecoderFactory::~NvidiaVideoDecoderFactory() {}
+NvidiaVideoDecoderFactory::~NvidiaVideoDecoderFactory() {
+  if (cu_context_) {
+    // This ownership model relies on WebRTC releasing decoders before their
+    // owning factory, so the factory lifetime bounds this context reference.
+    RTC_LOG(LS_INFO) << "NvidiaVideoDecoderFactory destroyed; releasing CUDA "
+                        "context.";
+    cu_context_->Shutdown();
+    cu_context_ = nullptr;
+  }
+}
 
 bool NvidiaVideoDecoderFactory::IsSupported() {
   if (IsNvdecDisabledByEnv()) {
@@ -156,11 +166,12 @@ std::unique_ptr<VideoDecoder> NvidiaVideoDecoderFactory::Create(
     if (format.IsSameCodec(supported_format)) {
       // If the format is supported, create and return the decoder.
       if (!cu_context_) {
-        cu_context_ = livekit_ffi::CudaContext::GetInstance();
-        if (!cu_context_->Initialize()) {
+        auto* ctx = livekit_ffi::CudaContext::GetInstance();
+        if (!ctx->Initialize()) {
           RTC_LOG(LS_ERROR) << "Failed to initialize CUDA context.";
           return nullptr;
         }
+        cu_context_ = ctx;
       }
       if (format.name == "H264") {
         RTC_LOG(LS_INFO) << "Using NVIDIA HW decoder (NVDEC) for H264";

--- a/webrtc-sys/src/nvidia/nvidia_encoder_factory.cpp
+++ b/webrtc-sys/src/nvidia/nvidia_encoder_factory.cpp
@@ -251,7 +251,16 @@ NvidiaVideoEncoderFactory::NvidiaVideoEncoderFactory() {
   }
 }
 
-NvidiaVideoEncoderFactory::~NvidiaVideoEncoderFactory() {}
+NvidiaVideoEncoderFactory::~NvidiaVideoEncoderFactory() {
+  if (cu_context_) {
+    // This ownership model relies on WebRTC releasing encoders before their
+    // owning factory, so the factory lifetime bounds this context reference.
+    RTC_LOG(LS_INFO) << "NvidiaVideoEncoderFactory destroyed; releasing CUDA "
+                        "context.";
+    cu_context_->Shutdown();
+    cu_context_ = nullptr;
+  }
+}
 
 namespace {
 
@@ -283,11 +292,12 @@ std::unique_ptr<VideoEncoder> NvidiaVideoEncoderFactory::Create(
   for (const auto& supported_format : supported_formats_) {
     if (format.IsSameCodec(supported_format)) {
       if (!cu_context_) {
-        cu_context_ = livekit_ffi::CudaContext::GetInstance();
-        if (!cu_context_->Initialize()) {
+        auto* ctx = livekit_ffi::CudaContext::GetInstance();
+        if (!ctx->Initialize()) {
           RTC_LOG(LS_ERROR) << "Failed to initialize CUDA context.";
           return nullptr;
         }
+        cu_context_ = ctx;
       }
 
       if (format.name == "H264") {


### PR DESCRIPTION
This PR addresses two issues related to memory lifecycle/safety: `CudaContext` and `FfiServer` cleanup on dispose.

CudaContext:

- Prior to this PR, users could inadvertently re-initialize memory via `CudaContext` multiple times
- Similarly, the decoders that initialized the context never destroyed it during their destructors
- This addresses both issues and adds thread safety and debug logs

FfiServer:

- Adds proper cleanup to dispose()
- Adds tests around this