### PR TITLE
Video source lifecycle memory fixes

### DIFF
--- a/.changeset/video_source_lifecycle.md
+++ b/.changeset/video_source_lifecycle.md
@@ -1,0 +1,13 @@
+---
+webrtc-sys: patch
+libwebrtc: patch
+livekit: patch
+livekit-ffi: patch
+---
+
+Fix NativeVideoSource keepalive retaining dropped sources.
+
+The raw-video keepalive task now uses a weak liveness check instead of cloning
+`NativeVideoSource`, so dropping an unused source releases the native handle
+and black I420 keepalive buffer. `nvEncInitializeEncoder` failures now
+propagate instead of leaving the encoder half-initialized.

--- a/.changeset/video_source_lifecycle.md
+++ b/.changeset/video_source_lifecycle.md
@@ -5,9 +5,9 @@ livekit: patch
 livekit-ffi: patch
 ---
 
-Fix NativeVideoSource keepalive retaining dropped sources.
+Fix native video-source lifecycle and NVENC initialization failure handling.
 
-The raw-video keepalive task now uses a weak liveness check instead of cloning
-`NativeVideoSource`, so dropping an unused source releases the native handle
-and black I420 keepalive buffer. `nvEncInitializeEncoder` failures now
+The raw-video keepalive task now uses a weak liveness check and defers its
+black I420 buffer allocation until source liveness is confirmed, so dropping
+an unused source releases its resources. `nvEncInitializeEncoder` failures now
 propagate instead of leaving the encoder half-initialized.

--- a/libwebrtc/src/native/video_source.rs
+++ b/libwebrtc/src/native/video_source.rs
@@ -15,7 +15,7 @@
 use std::{
     sync::{
         atomic::{AtomicUsize, Ordering},
-        Arc,
+        Arc, Weak,
     },
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -48,6 +48,12 @@ pub struct NativeVideoSource {
     captured_frames: Arc<AtomicUsize>,
 }
 
+fn keepalive_should_continue(captured_frames: &Weak<AtomicUsize>) -> bool {
+    captured_frames
+        .upgrade()
+        .is_some_and(|captured_frames| captured_frames.load(Ordering::Relaxed) == 0)
+}
+
 impl NativeVideoSource {
     pub fn new(resolution: VideoResolution, is_screencast: bool) -> NativeVideoSource {
         Self::new_inner(resolution, is_screencast, true)
@@ -77,8 +83,9 @@ impl NativeVideoSource {
         };
 
         if raw_keepalive {
+            let captured_frames = Arc::downgrade(&source.captured_frames);
+            let sys_handle = source.sys_handle.clone();
             tokio::spawn({
-                let source = source.clone();
                 // This buffer reaches the encoder without any plane ever being
                 // written, so it must be black-initialized: `I420Buffer::new`
                 // leaves the pixel data uninitialized and would leak recycled
@@ -90,7 +97,7 @@ impl NativeVideoSource {
                     loop {
                         interval.tick().await;
 
-                        if source.captured_frames.load(Ordering::Relaxed) > 0 {
+                        if !keepalive_should_continue(&captured_frames) {
                             break;
                         }
 
@@ -101,7 +108,7 @@ impl NativeVideoSource {
                         let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
                         builder.pin_mut().set_timestamp_us(now.as_micros() as i64);
 
-                        source.sys_handle.on_captured_frame(
+                        sys_handle.on_captured_frame(
                             &builder.pin_mut().build(),
                             &vt_sys::ffi::FrameMetadata {
                                 has_packet_trailer: false,
@@ -227,5 +234,41 @@ impl NativeVideoSource {
 
     pub fn video_resolution(&self) -> VideoResolution {
         self.sys_handle.video_resolution().into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use super::keepalive_should_continue;
+
+    #[test]
+    fn keepalive_continues_before_first_capture() {
+        let captured_frames = Arc::new(AtomicUsize::new(0));
+
+        assert!(keepalive_should_continue(&Arc::downgrade(&captured_frames)));
+    }
+
+    #[test]
+    fn keepalive_stops_after_first_capture() {
+        let captured_frames = Arc::new(AtomicUsize::new(0));
+        let weak_captured_frames = Arc::downgrade(&captured_frames);
+        captured_frames.fetch_add(1, Ordering::Relaxed);
+
+        assert!(!keepalive_should_continue(&weak_captured_frames));
+    }
+
+    #[test]
+    fn keepalive_stops_when_source_is_dropped() {
+        let weak_captured_frames = {
+            let captured_frames = Arc::new(AtomicUsize::new(0));
+            Arc::downgrade(&captured_frames)
+        };
+
+        assert!(!keepalive_should_continue(&weak_captured_frames));
     }
 }

--- a/libwebrtc/src/native/video_source.rs
+++ b/libwebrtc/src/native/video_source.rs
@@ -21,6 +21,7 @@ use std::{
 };
 
 use cxx::SharedPtr;
+use tokio::task::JoinHandle;
 use tokio::time::interval;
 use webrtc_sys::{video_frame as vf_sys, video_frame::ffi::VideoRotation, video_track as vt_sys};
 
@@ -54,6 +55,48 @@ fn keepalive_should_continue(captured_frames: &Weak<AtomicUsize>) -> bool {
         .is_some_and(|captured_frames| captured_frames.load(Ordering::Relaxed) == 0)
 }
 
+fn spawn_raw_keepalive(
+    resolution: VideoResolution,
+    captured_frames: Weak<AtomicUsize>,
+    sys_handle: SharedPtr<vt_sys::ffi::VideoTrackSource>,
+) -> JoinHandle<()> {
+    tokio::spawn({
+        // This buffer reaches the encoder without any plane ever being
+        // written, so it must be black-initialized: `I420Buffer::new`
+        // leaves the pixel data uninitialized and would leak recycled
+        // heap memory to subscribers in the first keyframes.
+        let i420 = I420Buffer::new_black(resolution.width, resolution.height);
+        async move {
+            let mut interval = interval(Duration::from_millis(100)); // 10 fps
+
+            loop {
+                interval.tick().await;
+
+                if !keepalive_should_continue(&captured_frames) {
+                    break;
+                }
+
+                let mut builder = vf_sys::ffi::new_video_frame_builder();
+                builder.pin_mut().set_rotation(VideoRotation::VideoRotation0);
+                builder.pin_mut().set_video_frame_buffer(i420.as_ref().sys_handle());
+
+                let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+                builder.pin_mut().set_timestamp_us(now.as_micros() as i64);
+
+                sys_handle.on_captured_frame(
+                    &builder.pin_mut().build(),
+                    &vt_sys::ffi::FrameMetadata {
+                        has_packet_trailer: false,
+                        user_timestamp: 0,
+                        frame_id: 0,
+                        user_data: Vec::new(),
+                    },
+                );
+            }
+        }
+    })
+}
+
 impl NativeVideoSource {
     pub fn new(resolution: VideoResolution, is_screencast: bool) -> NativeVideoSource {
         Self::new_inner(resolution, is_screencast, true)
@@ -85,41 +128,7 @@ impl NativeVideoSource {
         if raw_keepalive {
             let captured_frames = Arc::downgrade(&source.captured_frames);
             let sys_handle = source.sys_handle.clone();
-            tokio::spawn({
-                // This buffer reaches the encoder without any plane ever being
-                // written, so it must be black-initialized: `I420Buffer::new`
-                // leaves the pixel data uninitialized and would leak recycled
-                // heap memory to subscribers in the first keyframes.
-                let i420 = I420Buffer::new_black(resolution.width, resolution.height);
-                async move {
-                    let mut interval = interval(Duration::from_millis(100)); // 10 fps
-
-                    loop {
-                        interval.tick().await;
-
-                        if !keepalive_should_continue(&captured_frames) {
-                            break;
-                        }
-
-                        let mut builder = vf_sys::ffi::new_video_frame_builder();
-                        builder.pin_mut().set_rotation(VideoRotation::VideoRotation0);
-                        builder.pin_mut().set_video_frame_buffer(i420.as_ref().sys_handle());
-
-                        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-                        builder.pin_mut().set_timestamp_us(now.as_micros() as i64);
-
-                        sys_handle.on_captured_frame(
-                            &builder.pin_mut().build(),
-                            &vt_sys::ffi::FrameMetadata {
-                                has_packet_trailer: false,
-                                user_timestamp: 0,
-                                frame_id: 0,
-                                user_data: Vec::new(),
-                            },
-                        );
-                    }
-                }
-            });
+            drop(spawn_raw_keepalive(resolution, captured_frames, sys_handle));
         }
 
         source
@@ -243,8 +252,10 @@ mod tests {
         atomic::{AtomicUsize, Ordering},
         Arc,
     };
+    use std::time::Duration;
 
-    use super::keepalive_should_continue;
+    use super::{keepalive_should_continue, spawn_raw_keepalive, NativeVideoSource};
+    use crate::video_source::VideoResolution;
 
     #[test]
     fn keepalive_continues_before_first_capture() {
@@ -270,5 +281,35 @@ mod tests {
         };
 
         assert!(!keepalive_should_continue(&weak_captured_frames));
+    }
+
+    #[tokio::test]
+    async fn keepalive_task_does_not_keep_capture_state_alive() {
+        let source = NativeVideoSource::new(VideoResolution { width: 16, height: 16 }, false);
+        let captured_frames = Arc::downgrade(&source.captured_frames);
+
+        tokio::task::yield_now().await;
+        drop(source);
+
+        assert!(captured_frames.upgrade().is_none());
+    }
+
+    #[tokio::test]
+    async fn keepalive_task_releases_native_source_after_drop() {
+        let resolution = VideoResolution { width: 16, height: 16 };
+        let source = NativeVideoSource::new_inner(resolution.clone(), false, false);
+        let keepalive_task = spawn_raw_keepalive(
+            resolution,
+            Arc::downgrade(&source.captured_frames),
+            source.sys_handle.clone(),
+        );
+
+        tokio::task::yield_now().await;
+        drop(source);
+
+        tokio::time::timeout(Duration::from_secs(1), keepalive_task)
+            .await
+            .expect("keepalive task retained its resources after the source was dropped")
+            .expect("keepalive task panicked");
     }
 }

--- a/libwebrtc/src/native/video_source.rs
+++ b/libwebrtc/src/native/video_source.rs
@@ -21,7 +21,6 @@ use std::{
 };
 
 use cxx::SharedPtr;
-use tokio::task::JoinHandle;
 use tokio::time::interval;
 use webrtc_sys::{video_frame as vf_sys, video_frame::ffi::VideoRotation, video_track as vt_sys};
 
@@ -55,46 +54,46 @@ fn keepalive_should_continue(captured_frames: &Weak<AtomicUsize>) -> bool {
         .is_some_and(|captured_frames| captured_frames.load(Ordering::Relaxed) == 0)
 }
 
-fn spawn_raw_keepalive(
+async fn raw_keepalive_task(
     resolution: VideoResolution,
     captured_frames: Weak<AtomicUsize>,
     sys_handle: SharedPtr<vt_sys::ffi::VideoTrackSource>,
-) -> JoinHandle<()> {
-    tokio::spawn({
-        // This buffer reaches the encoder without any plane ever being
-        // written, so it must be black-initialized: `I420Buffer::new`
-        // leaves the pixel data uninitialized and would leak recycled
-        // heap memory to subscribers in the first keyframes.
-        let i420 = I420Buffer::new_black(resolution.width, resolution.height);
-        async move {
-            let mut interval = interval(Duration::from_millis(100)); // 10 fps
+) {
+    if !keepalive_should_continue(&captured_frames) {
+        return;
+    }
 
-            loop {
-                interval.tick().await;
+    // This buffer reaches the encoder without any plane ever being
+    // written, so it must be black-initialized: `I420Buffer::new`
+    // leaves the pixel data uninitialized and would leak recycled
+    // heap memory to subscribers in the first keyframes.
+    let i420 = I420Buffer::new_black(resolution.width, resolution.height);
+    let mut interval = interval(Duration::from_millis(100)); // 10 fps
 
-                if !keepalive_should_continue(&captured_frames) {
-                    break;
-                }
+    loop {
+        interval.tick().await;
 
-                let mut builder = vf_sys::ffi::new_video_frame_builder();
-                builder.pin_mut().set_rotation(VideoRotation::VideoRotation0);
-                builder.pin_mut().set_video_frame_buffer(i420.as_ref().sys_handle());
-
-                let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-                builder.pin_mut().set_timestamp_us(now.as_micros() as i64);
-
-                sys_handle.on_captured_frame(
-                    &builder.pin_mut().build(),
-                    &vt_sys::ffi::FrameMetadata {
-                        has_packet_trailer: false,
-                        user_timestamp: 0,
-                        frame_id: 0,
-                        user_data: Vec::new(),
-                    },
-                );
-            }
+        if !keepalive_should_continue(&captured_frames) {
+            break;
         }
-    })
+
+        let mut builder = vf_sys::ffi::new_video_frame_builder();
+        builder.pin_mut().set_rotation(VideoRotation::VideoRotation0);
+        builder.pin_mut().set_video_frame_buffer(i420.as_ref().sys_handle());
+
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+        builder.pin_mut().set_timestamp_us(now.as_micros() as i64);
+
+        sys_handle.on_captured_frame(
+            &builder.pin_mut().build(),
+            &vt_sys::ffi::FrameMetadata {
+                has_packet_trailer: false,
+                user_timestamp: 0,
+                frame_id: 0,
+                user_data: Vec::new(),
+            },
+        );
+    }
 }
 
 impl NativeVideoSource {
@@ -128,7 +127,8 @@ impl NativeVideoSource {
         if raw_keepalive {
             let captured_frames = Arc::downgrade(&source.captured_frames);
             let sys_handle = source.sys_handle.clone();
-            drop(spawn_raw_keepalive(resolution, captured_frames, sys_handle));
+            let _keepalive_task =
+                tokio::spawn(raw_keepalive_task(resolution, captured_frames, sys_handle));
         }
 
         source
@@ -254,7 +254,7 @@ mod tests {
     };
     use std::time::Duration;
 
-    use super::{keepalive_should_continue, spawn_raw_keepalive, NativeVideoSource};
+    use super::{keepalive_should_continue, raw_keepalive_task, NativeVideoSource};
     use crate::video_source::VideoResolution;
 
     #[test]
@@ -298,11 +298,11 @@ mod tests {
     async fn keepalive_task_releases_native_source_after_drop() {
         let resolution = VideoResolution { width: 16, height: 16 };
         let source = NativeVideoSource::new_inner(resolution.clone(), false, false);
-        let keepalive_task = spawn_raw_keepalive(
+        let keepalive_task = tokio::spawn(raw_keepalive_task(
             resolution,
             Arc::downgrade(&source.captured_frames),
             source.sys_handle.clone(),
-        );
+        ));
 
         tokio::task::yield_now().await;
         drop(source);

--- a/webrtc-sys/src/nvidia/NvCodec/NvCodec/NvEncoder/NvEncoder.cpp
+++ b/webrtc-sys/src/nvidia/NvCodec/NvCodec/NvEncoder/NvEncoder.cpp
@@ -389,6 +389,7 @@ void NvEncoder::CreateEncoder(const NV_ENC_INITIALIZE_PARAMS* pEncoderParams) {
     DestroyHWEncoder();
     std::cout << "nvEncInitializeEncoder API failed" << e.getErrorCode()
               << " - " << e.getErrorString() << std::endl;
+    throw;
   }
 
   m_bEncoderInitialized = true;

--- a/webrtc-sys/src/nvidia/cuda_context.cpp
+++ b/webrtc-sys/src/nvidia/cuda_context.cpp
@@ -9,7 +9,6 @@
 #include <dlfcn.h>
 #endif
 
-#include <iostream>
 #include <mutex>
 
 #if defined(WIN32)
@@ -39,6 +38,8 @@ static const int kRequiredDriverVersion = 11000;
 
 // Serializes access to the singleton context, its reference count, and the
 // dynamically loaded CUDA module.
+// Note: Wrapping this defers initialization until the mutex is first used vs.
+// static initialization at namespace scope.
 static std::mutex& cudaMutex() {
   static std::mutex mutex;
   return mutex;
@@ -217,6 +218,7 @@ void CudaContext::Shutdown() {
     return;
   }
 
+  RTC_LOG(LS_INFO) << "CUDA context released (refs=0); destroying context.";
   if (cu_context_) {
     const CUresult result = cuCtxDestroy(cu_context_);
     // NVIDIA documents that cuCtxDestroy() may report an error from an earlier

--- a/webrtc-sys/src/nvidia/cuda_context.cpp
+++ b/webrtc-sys/src/nvidia/cuda_context.cpp
@@ -9,6 +9,7 @@
 #include <dlfcn.h>
 #endif
 
+#include <iostream>
 #include <mutex>
 
 #if defined(WIN32)
@@ -38,8 +39,6 @@ static const int kRequiredDriverVersion = 11000;
 
 // Serializes access to the singleton context, its reference count, and the
 // dynamically loaded CUDA module.
-// Note: Wrapping this defers initialization until the mutex is first used vs.
-// static initialization at namespace scope.
 static std::mutex& cudaMutex() {
   static std::mutex mutex;
   return mutex;
@@ -218,7 +217,6 @@ void CudaContext::Shutdown() {
     return;
   }
 
-  RTC_LOG(LS_INFO) << "CUDA context released (refs=0); destroying context.";
   if (cu_context_) {
     const CUresult result = cuCtxDestroy(cu_context_);
     // NVIDIA documents that cuCtxDestroy() may report an error from an earlier


### PR DESCRIPTION
## Summary

* Stop the raw-video keepalive task from cloning NativeVideoSource. It now uses a Weak liveness check so dropping the source actually releases the native handle and black I420 keepalive buffer.
* Previously, a source that never received captureFrame kept that task alive forever (~1.32 MiB per unused 720p source). 
* Also pair CUDA context init/shutdown on NVIDIA encoder/decoder factories, drop leftover FFI handles in dispose(), and fail closed if nvEncInitializeEncoder throws.

## Testing

* Adds regression tests directly
* 1,000 create/drop cycles peaked at ~1.35 GiB; after the fix they peak at ~41 MiB.