### PR TITLE
Linking to our WebRTC fork in README

### DIFF
--- a/webrtc-sys/libwebrtc/README.md
+++ b/webrtc-sys/libwebrtc/README.md
@@ -1,7 +1,7 @@
 This directory can contain a checkout of WebRTC from https://github.com/webrtc-sdk/webrtc. 
 The build scripts here will install dependencies, checkout the version that LiveKit
-currently uses, apply some patches to it, and build it. For example to
-do a Linux debug build on x64:
+currently uses, apply some patches to it, and build it. The currently used version is pinned in 
+`.gclient`. For example, the build command to do a Linux debug build on x64 is:
 
 ```sh
 $ ./build-linux.sh --arch x64 --profile release

--- a/webrtc-sys/libwebrtc/README.md
+++ b/webrtc-sys/libwebrtc/README.md
@@ -1,5 +1,5 @@
-This directory can contain a checkout of WebRTC. The build scripts
-here will install dependencies, checkout the version that LiveKit
+This directory can contain a checkout of WebRTC from https://github.com/webrtc-sdk/webrtc. 
+The build scripts here will install dependencies, checkout the version that LiveKit
 currently uses, apply some patches to it, and build it. For example to
 do a Linux debug build on x64:
 


### PR DESCRIPTION
We are lacking some documentation around the WebRTC dependency.