### PR TITLE
Agent guidance around memory lifecycle edges

### DIFF
--- a/.changeset/agent_guidance_around_memory_lifecycle_edges.md
+++ b/.changeset/agent_guidance_around_memory_lifecycle_edges.md
@@ -1,0 +1,9 @@
+---
+libwebrtc: patch
+livekit: patch
+livekit-ffi: patch
+webrtc-sys: patch
+---
+
+Add agent guidance for detecting and preventing memory-lifecycle regressions in
+Rust, FFI, and native WebRTC code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,20 @@
   - Isolate only the unsafe operations
   - Every unsafe block should have a `// SAFETY:` comment explaining why the operation is actually safe (e.g., verifying pointers are non-null)
 
+## Memory lifecycle
+
+Rust memory safety does not prevent leaks: `Arc` cycles, stored callbacks, detached tasks, unbounded channels, and native handles can retain resources indefinitely.
+
+- Treat every `Arc::clone`, `Rc::clone`, `shared_ptr` copy, callback capture, observer registration, and spawned task as an ownership edge. If an owner transitively stores the callback/task, the callback/task must not strongly capture that owner.
+- Use `Weak`/`weak_ptr` for non-owning back-references. A strong back-reference is allowed only when teardown explicitly unregisters or clears it before releasing the owner, and a lifecycle regression test proves cleanup.
+- A callback stored by an object must not capture a strong clone of that same object. Reviewers must flag `move` closures capturing `Arc` and C++ lambdas capturing `shared_ptr`/`shared_from_this` when the receiver can retain the callback.
+- Every task, thread, subscription, FFI handle, observer, timer, and channel must have a named owner and deterministic shutdown path. Tasks/threads must be cancelled and joined; observers must be unregistered; channels and queues must be bounded or explicitly justified.
+- For lifecycle-sensitive changes, test observable destruction: `Weak::upgrade() == None`/`weak_ptr::expired()`, FFI handle maps empty, task completion, and thread/FD counts returning near baseline. `Drop`/RAII code alone is not evidence that destruction occurs because reference cycles prevent it from running.
+- Any new C++-reachable feature or Rust FFI handle must add a repeated `initialize → use → disconnect/drop → shutdown` workload. Include success, failure/cancellation, and partial-initialization teardown where applicable.
+- Review ownership changes by sketching the strong-reference graph. Every cycle must contain a weak edge or an explicit, tested unlink operation.
+
+When reviewing changed code, search for `Arc::clone`, `.clone()` inside `move` closures, `tokio::spawn`, unbounded channels, callback setters, `shared_from_this`, listener registration, and FFI `store_handle`. Report lifecycle risks even when the code is type-safe.
+
 ## Style guidelines
 
 - Always format using `cargo fmt`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,15 +53,15 @@
 
 Rust memory safety does not prevent leaks: `Arc` cycles, stored callbacks, detached tasks, unbounded channels, and native handles can retain resources indefinitely.
 
-- Treat every `Arc::clone`, `Rc::clone`, `shared_ptr` copy, callback capture, observer registration, and spawned task as an ownership edge. If an owner transitively stores the callback/task, the callback/task must not strongly capture that owner.
-- Use `Weak`/`weak_ptr` for non-owning back-references. A strong back-reference is allowed only when teardown explicitly unregisters or clears it before releasing the owner, and a lifecycle regression test proves cleanup.
-- A callback stored by an object must not capture a strong clone of that same object. Reviewers must flag `move` closures capturing `Arc` and C++ lambdas capturing `shared_ptr`/`shared_from_this` when the receiver can retain the callback.
+- Treat every `Arc::clone`, `Rc::clone`, callback capture, observer registration, and spawned task as an ownership edge. If an owner transitively stores the callback/task, the callback/task must not strongly capture that owner.
+- Use `Weak` for non-owning back-references. A strong back-reference is allowed only when teardown explicitly unregisters or clears it before releasing the owner, and a lifecycle regression test proves cleanup.
+- A callback stored by an object must not capture a strong clone of that same object. Reviewers must flag `move` closures capturing `Arc` when the receiver can retain the callback.
 - Every task, thread, subscription, FFI handle, observer, timer, and channel must have a named owner and deterministic shutdown path. Tasks/threads must be cancelled and joined; observers must be unregistered; channels and queues must be bounded or explicitly justified.
-- For lifecycle-sensitive changes, test observable destruction: `Weak::upgrade() == None`/`weak_ptr::expired()`, FFI handle maps empty, task completion, and thread/FD counts returning near baseline. `Drop`/RAII code alone is not evidence that destruction occurs because reference cycles prevent it from running.
-- Any new C++-reachable feature or Rust FFI handle must add a repeated `initialize → use → disconnect/drop → shutdown` workload. Include success, failure/cancellation, and partial-initialization teardown where applicable.
+- For lifecycle-sensitive changes, test observable destruction: `Weak::upgrade() == None`, FFI handle maps empty, task completion, and thread/FD counts returning near baseline. `Drop` code alone is not evidence that destruction occurs because reference cycles prevent it from running.
+- Any new FFI handle must add a repeated `initialize → use → disconnect/drop → shutdown` workload. Include success, failure/cancellation, and partial-initialization teardown where applicable.
 - Review ownership changes by sketching the strong-reference graph. Every cycle must contain a weak edge or an explicit, tested unlink operation.
 
-When reviewing changed code, search for `Arc::clone`, `.clone()` inside `move` closures, `tokio::spawn`, unbounded channels, callback setters, `shared_from_this`, listener registration, and FFI `store_handle`. Report lifecycle risks even when the code is type-safe.
+When reviewing changed code, search for `Arc::clone`, `.clone()` inside `move` closures, `tokio::spawn`, unbounded channels, callback setters, listener registration, and FFI `store_handle`. Report lifecycle risks even when the code is type-safe.
 
 ## Style guidelines
 

--- a/webrtc-sys/AGENTS.md
+++ b/webrtc-sys/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md
+
+C++ and cxx-bridge code in this crate. Follow the repository-root `AGENTS.md` for Rust-wide rules; this file covers native ownership and teardown.
+
+## Memory lifecycle
+
+C++ `shared_ptr` graphs and WebRTC observer registrations can leak independently of Rust `Drop`.
+
+- Treat every `shared_ptr` copy, callback capture, observer registration, and spawned thread as an ownership edge. If an owner transitively stores the callback, the callback must not strongly capture that owner.
+- Use `weak_ptr` for non-owning back-references. A strong back-reference is allowed only when teardown explicitly unregisters or clears it before releasing the owner, and a lifecycle regression test proves cleanup.
+- A callback stored by an object must not capture a strong clone of that same object. Reviewers must flag C++ lambdas capturing `shared_ptr`/`shared_from_this` when the receiver can retain the callback.
+- Every thread, native handle, observer, timer, and queue must have a named owner and deterministic shutdown path. Threads must be joined; observers must be unregistered; native resources (CUDA contexts, FDs, WebRTC factories) must be released on the teardown path.
+- For lifecycle-sensitive changes, test observable destruction: `weak_ptr::expired()`, native handle maps empty, and thread/FD counts returning near baseline. RAII destructors alone are not evidence that destruction occurs because reference cycles prevent them from running.
+- Any new C++-reachable feature must add a repeated `initialize → use → disconnect/drop → shutdown` workload. Include success, failure/cancellation, and partial-initialization teardown where applicable.
+- Review ownership changes by sketching the strong-reference graph. Every cycle must contain a weak edge or an explicit, tested unlink operation.
+
+When reviewing changed code, search for `shared_from_this`, `shared_ptr` copies into lambdas, listener/observer registration, and native handle stores. Report lifecycle risks even when the code compiles.


### PR DESCRIPTION
Introduce `AGENTS.md` guidance around some of the fixes done in this PR stack, to hopefully avoid/catch future regressions.