### PR TITLE
Update JNA dependency version to 5.19.1

### DIFF
--- a/.changeset/update_jna_dependency_version_to_5_19_1.md
+++ b/.changeset/update_jna_dependency_version_to_5_19_1.md
@@ -1,0 +1,5 @@
+---
+livekit-uniffi: patch
+---
+
+Update Android's JNA dependency version to 5.19.1 to support 16KB page sizes

--- a/livekit-uniffi/support/android/build.gradle.kts
+++ b/livekit-uniffi/support/android/build.gradle.kts
@@ -60,7 +60,7 @@ android {
 
 dependencies {
     implementation("androidx.annotation:annotation:1.9.0")
-    implementation("net.java.dev.jna:jna:5.16.0@aar")
+    implementation("net.java.dev.jna:jna:5.19.1@aar")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
 }
 


### PR DESCRIPTION
Old 5.16.0 version doesn't work in 16KB page size mode. Upgrading to latest 5.19.1 which has the fixes required for support this.

Was identified as an issue in the Data Streams V2 PR for the android sdk:

https://github.com/livekit/client-sdk-android/pull/997/changes#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR43