### PR TITLE
Fix livekit-runtime version bump

### DIFF
--- a/.changeset/remove_livekit_runtime.md
+++ b/.changeset/remove_livekit_runtime.md
@@ -1,7 +1,7 @@
 ---
 libwebrtc: minor
-livekit: minor
-livekit-api: minor
+livekit: major
+livekit-api: major
 livekit-datatrack: minor
 livekit-ffi: minor
 livekit-net: minor


### PR DESCRIPTION
Make the livekit-runtime change a minor bump (knope uses `major` to mean `minor` before 1.0.0)