### PR TITLE
Require single-line plain-text changeset summaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,3 +95,8 @@ Several crates export items to Swift/Kotlin/Node/Python through UniFFI — `live
 - Every PR needs a changeset
 - Changeset must list any crates which need to be bumped stemming from the change
 - Document changes interactively from the CLI with `knope document-change` or create manually in `/.changeset`
+- Write the changeset summary as a single unwrapped line of plain prose
+  - knope renders a one-line summary as a changelog bullet. A summary spanning more than one line is instead promoted to a `####` heading, with everything after the first line left as loose body text below it — that mix of bullets and headings is what makes the release page look inconsistent
+  - A hard line wrap alone triggers this, with no Markdown involved: a summary wrapped at 80 columns produced the heading `#### Add agent guidance for detecting and preventing memory-lifecycle regressions in`, stranding the rest of the sentence underneath it
+  - So no Markdown blocks — headings, bullet lists, tables, code fences, blockquotes, or bold-led paragraphs. Inline backticks are fine and render correctly
+  - Keep it to a sentence or two written for someone reading the release notes; rationale, alternatives, and migration detail belong in the PR description


### PR DESCRIPTION
The release page formatting is inconsistient - some entries are changelog bullets, others are `####` headings followed by further markdown.

That is knope's rendering rule, not a knope bug. A changeset whose summary is **one line** becomes a bullet:

```
- Add data streams v2 to exposed uniffi interface - #1286 (@1egoman)
```

A summary spanning **more than one line** is promoted to a heading, with everything after the first line dropped below it as loose body text:

```
#### Moves the signalling client into a new `livekit-signaling` crate. livekit-api

re-exports it under the historical `livekit_api::signal_client` path, now marked
deprecated: ...
```

Markdown blocks (tables, bullet lists, bold-led paragraphs) guarantee this, and they keep showing up in agent-written changesets — but a plain hard line wrap is enough on its own. The changeset for #1406 was plain text wrapped at 80 columns and still rendered as `#### Add agent guidance for detecting and preventing memory-lifecycle regressions in`.

So this adds a rule under **Documenting changes** in `AGENTS.md`: write the changeset summary as a single unwrapped line of plain prose, no Markdown blocks (inline backticks are fine — they render correctly), and keep detail in the PR description instead.