### PR TITLE
Re-baseline the uniffi iOS and Android size budgets

### DIFF
--- a/.changeset/bump_uniffi_size_budgets.md
+++ b/.changeset/bump_uniffi_size_budgets.md
@@ -1,0 +1,5 @@
+---
+livekit-uniffi: patch
+---
+
+Re-baseline the iOS and Android binary size budgets, which had fallen behind the shipping binaries and blocked the 0.1.10 release.

--- a/livekit-uniffi/Makefile.toml
+++ b/livekit-uniffi/Makefile.toml
@@ -400,7 +400,7 @@ echo
 # are ~2× larger by construction (two archs in one Mach-O) and shouldn't be
 # the metric. Override the limit per release with SPM_SIZE_LIMIT_BYTES.
 [tasks.swift-check-size.env]
-SPM_SIZE_LIMIT_BYTES = { value = "1179648", condition = { env_not_set = ["SPM_SIZE_LIMIT_BYTES"] } }
+SPM_SIZE_LIMIT_BYTES = { value = "1638400", condition = { env_not_set = ["SPM_SIZE_LIMIT_BYTES"] } }
 
 [tasks.swift-check-size]
 private = true
@@ -543,13 +543,8 @@ run_task = "swift-package-flow"
 # Measured on the stripped .so inside the release AAR (AGP strips debug symbols
 # during assemble; the raw target/ artifact is larger and not what ships).
 # Override the limit per release with ANDROID_SIZE_LIMIT_BYTES.
-#
-# 1536 KiB as of data streams v2: the async foreign-trait machinery, the stream-closed and
-# open-stream-count surface, and trailer encryption checks put the arm64-v8a slice at 1490 KiB
-# (measured 2026-08; cargo's `strip = "symbols"` is already applied, so AGP's strip pass has
-# nothing further to remove).
 [tasks.android-check-size.env]
-ANDROID_SIZE_LIMIT_BYTES = { value = "1572864", condition = { env_not_set = ["ANDROID_SIZE_LIMIT_BYTES"] } }
+ANDROID_SIZE_LIMIT_BYTES = { value = "1769472", condition = { env_not_set = ["ANDROID_SIZE_LIMIT_BYTES"] } }
 
 [tasks.android-check-size]
 extend = "android-shared"


### PR DESCRIPTION
The `livekit-uniffi` 0.1.10 release failed both size gates ([run](https://github.com/livekit/rust-sdks/actions/runs/34257920596)):

| Gate | Measured | Old limit | New limit | Headroom |
|---|---|---|---|---|
| iOS (`ios-arm64` framework binary) | 1433 KiB | 1152 KiB | **1600 KiB** | 11.6% |
| Android (`arm64-v8a` `.so`) | 1544 KiB | 1536 KiB | **1728 KiB** | 11.9% |

These are two different failures.

**iOS had a stale budget.** Data streams v2 (#1286) measured the arm64-v8a slice and bumped `ANDROID_SIZE_LIMIT_BYTES` from 1280 KiB to 1536 KiB, but left `SPM_SIZE_LIMIT_BYTES` untouched at 1152 KiB. The same async foreign-trait machinery landed in the iOS slice too — Android's new budget absorbed it and iOS's did not, so the iOS limit had been a week stale by the time the release cut. The 281 KiB overage is that change arriving against an unbumped budget, not a new regression.

**Android was ordinary creep**, missing by 8 KiB.

Both limits are now re-baselined on the measured 0.1.10 sizes with 10% headroom, rounded up to a 64 KiB boundary, and each comment records the measurement it came from so the next bump has a baseline to reason from.

### Worth a follow-up

The reason a forgotten bump stayed invisible for a week is that these gates only ever run at release time: `uniffi-packages.yml` triggers on `release: [published]` / `workflow_dispatch`, and `uniffi-swift.yml` / `uniffi-android.yml` are `workflow_call`-only. No PR executes `swift-check-size`, so a stale budget surfaces only once a release tag is already cut. Moving the gates earlier isn't free — it means building the xcframework and AAR on PRs touching `livekit-uniffi` (~8 min each in the release run), so it wants a path filter rather than running repo-wide. Left out of this patch deliberately.