### PR TITLE
Fix the livekit_uniffi build hook for universal builds and allow code_assets 2.x

### DIFF
--- a/.changeset/dart_hook_code_assets_2.md
+++ b/.changeset/dart_hook_code_assets_2.md
@@ -1,0 +1,15 @@
+---
+livekit-uniffi: patch
+---
+
+# Allow code_assets 2.x in the Dart package and stop re-running its build hook
+
+The `livekit_uniffi` Dart package capped `code_assets` below 2.0.0, which has since
+shipped. Its only breaking change (equality on `OS` and `Architecture`) does not
+affect the hook, and the cap would make the package unresolvable next to any
+dependency that already requires 2.x. The constraint now allows it, and the hook
+was verified against `code_assets 2.0.0` / `hooks 2.2.0`.
+
+The hook also registered the downloaded library as a dependency. Dependencies are
+inputs, so the hooks runner saw a file modified during the build and re-ran the
+hook, and the download, once on every fresh build. The registration is removed.

--- a/.changeset/dart_hook_code_assets_2.md
+++ b/.changeset/dart_hook_code_assets_2.md
@@ -13,3 +13,8 @@ was verified against `code_assets 2.0.0` / `hooks 2.2.0`.
 The hook also registered the downloaded library as a dependency. Dependencies are
 inputs, so the hooks runner saw a file modified during the build and re-ran the
 hook, and the download, once on every fresh build. The registration is removed.
+
+The hook also wrote every target's library to the same shared path. A universal
+macOS build runs the hook once per architecture and then merges the results with
+`lipo`, which failed because the second download had overwritten the first. Each
+target now gets its own subdirectory.

--- a/livekit-uniffi/support/dart/hook/build.dart.tera
+++ b/livekit-uniffi/support/dart/hook/build.dart.tera
@@ -71,8 +71,11 @@ Future<Uri> _resolveLibrary(
     return local.uri;
   }
 
-  // Download mode: fetch the prebuilt library for the target. The hooks-runner
-  // already caches hook results across builds, so there's no manual cache check.
+  // Download mode: fetch the prebuilt library for the target. The hooks runner
+  // caches hook results across builds, so there is no manual cache check. The
+  // downloaded file is an output, not an input, so it is deliberately not
+  // registered as a dependency: doing so made the runner see a file modified
+  // during the build and rerun the hook (and the download) once per fresh build.
   final outDir = Directory.fromUri(
     input.outputDirectoryShared.resolve('$_cdylibName/'),
   );
@@ -89,7 +92,7 @@ Future<Uri> _resolveLibrary(
   for (final entry in ZipDecoder().decodeBytes(bytes)) {
     if (!entry.isFile) continue;
     // Guard against zip-slip: `resolve` normalizes `../` and absolute paths, so
-    // an entry that lands outside `base` is a malicious name — reject it. The
+    // an entry that lands outside `base` is a malicious name, so reject it. The
     // SHA-256 check proves integrity against tampering in transit, not that a
     // compromised host can't serve a matching-checksum malicious archive.
     final entryUri = base.resolve(entry.name);
@@ -104,7 +107,6 @@ Future<Uri> _resolveLibrary(
   if (!await libFile.exists()) {
     throw Exception('$libName not found in $zipUrl');
   }
-  output.dependencies.add(libFile.uri);
   return libFile.uri;
 }
 

--- a/livekit-uniffi/support/dart/hook/build.dart.tera
+++ b/livekit-uniffi/support/dart/hook/build.dart.tera
@@ -76,12 +76,17 @@ Future<Uri> _resolveLibrary(
   // downloaded file is an output, not an input, so it is deliberately not
   // registered as a dependency: doing so made the runner see a file modified
   // during the build and rerun the hook (and the download) once per fresh build.
+  //
+  // The shared directory is one per package, not per target, and a universal
+  // macOS build runs this hook once per architecture before lipo merges the
+  // results. Keep each target in its own subdirectory, or the second download
+  // overwrites the first and lipo is handed the same architecture twice.
+  final triple = _targetTriple(os, arch, iosSdk);
   final outDir = Directory.fromUri(
-    input.outputDirectoryShared.resolve('$_cdylibName/'),
+    input.outputDirectoryShared.resolve('$_cdylibName/$triple/'),
   );
   final libFile = File.fromUri(outDir.uri.resolve(libName));
 
-  final triple = _targetTriple(os, arch, iosSdk);
   // Asset naming matches the existing node downloader convention so one set of
   // release assets serves both: `<base>/v<version>/build-<triple>.zip`.
   final zipUrl = Uri.parse('$_downloadBase/v$_version/build-$triple.zip');

--- a/livekit-uniffi/support/dart/pubspec.yaml.tera
+++ b/livekit-uniffi/support/dart/pubspec.yaml.tera
@@ -18,12 +18,16 @@ environment:
 dependencies:
   ffi: ^2.1.0
   # Native Assets build-hook support. pub.dev requires bounded constraints
-  # (`any` fails publish validation), but these must stay wide: the resolvable
-  # version is coupled to the consumer's Dart SDK via a shared `meta` pin
-  # (Flutter 3.44 back-solves to code_assets 1.0.0 / hooks 1.0.2, while a bare
-  # Dart 3.12 resolves 1.2.1 / 2.1.0). Carets here break `flutter pub get`
-  # for consumers on older stable channels.
-  code_assets: ">=1.0.0 <2.0.0"
+  # (`any` fails publish validation), but these must stay wide. The resolvable
+  # version is coupled to the consumer's Dart SDK: older hooks releases pin
+  # `meta`, which Flutter's flutter_test pins exactly, so Flutter 3.44
+  # back-solves to code_assets 1.0.0 / hooks 1.0.2 while a bare Dart 3.12
+  # resolves newer ones. Carets here break `flutter pub get` for consumers on
+  # older stable channels, and a tight upper bound makes this package
+  # unresolvable next to any package that already requires the next major.
+  # The hook uses only the stable core of both APIs (target config, CodeAsset,
+  # DynamicLoadingBundled), which is unchanged across these majors.
+  code_assets: ">=1.0.0 <3.0.0"
   hooks: ">=1.0.2 <3.0.0"
   # Used by hook/build.dart to download and verify prebuilt libraries.
   archive: ^4.0.0


### PR DESCRIPTION
### Before you submit your PR

Make sure the following is true before submitting your PR:

- [x] I have read the [contributing guidelines](https://github.com/livekit/rust-sdks/blob/main/CONTRIBUTING.md) and validated that this PR will be accepted.
- [x] I have read and followed the principles regarding breaking changes, testing, and code quality.

### PR description

Three fixes to the `livekit_uniffi` Dart package templates, found while doing the manual first publish of 0.1.10 and wiring it into client-sdk-flutter. All ship with the next release.

- **Allow `code_assets` 2.x.** The pubspec capped `code_assets` below 2.0.0, which shipped on Aug 18. Its only breaking change (equality on `OS`/`Architecture`) does not affect the hook, and a cap below the current major makes the package unresolvable next to any dependency that already requires 2.x. Now `>=1.0.0 <3.0.0`. The comment is updated: `hooks 2.2.0` dropped its `meta` dependency, so the Flutter `meta`-pin back-solve that motivated the wide ranges mostly no longer applies, but wide bounded ranges remain the right shape.
- **Stop registering the downloaded library as a hook dependency.** Dependencies are inputs. Registering the downloaded output made the hooks runner print "File modified during build. Build must be rerun." and run the hook, and the download, twice on every fresh consumer build. Local mode keeps its registration, where the library really is an input.
- **Keep each target's downloaded library in its own directory.** The hook wrote every target's library to the same path under the shared output directory. A universal macOS release build runs the hook once per architecture and then merges the results with `lipo`, so the second download overwrote the first and the build failed with "have the same architectures (x86_64) and can't be in the same fat output file" (livekit/client-sdk-flutter#1160's macOS CI job). The directory is now keyed by target triple, which is also how the `hooks` package documents the shared directory should be used.

### Breaking changes

None.

### MSRV

No changes.

### Testing

From this branch, `cargo make dart-package` in both profiles:

- Dev profile (local library): resolves `code_assets 2.0.0` + `hooks 2.2.0`, 5/5 FFI tests pass.
- Release profile, copied outside the repo like the publish workflow does: fresh `dart test` downloads the real 0.1.10 library from the release, the "File modified during build" rerun is gone, 5/5 tests pass, and `dart pub publish --dry-run` reports 0 warnings.
- Universal build: the client-sdk-flutter example pointed at the regenerated package with a path override, `flutter build macos --release`. Builds, `lipo -info` on the bundled `livekit_uniffi.framework` reports `x86_64 arm64`, and the hook produced separate `aarch64-apple-darwin` and `x86_64-apple-darwin` output directories. Debug builds are single-architecture and cannot catch this, which is why it reached CI.
- `code_assets 2.0.0` also adds header validation of the bundled library against the target architecture, which the downloaded 0.1.10 dylib passed.

### Async

No async code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
