### PR TITLE
Enable pub.dev publishing of livekit_uniffi

### DIFF
--- a/.github/workflows/uniffi-dart-publish.yml
+++ b/.github/workflows/uniffi-dart-publish.yml
@@ -17,21 +17,19 @@ name: UniFFI Dart package
 # same run, and the publish job depends on it, so the package can only be
 # published once every asset is on the release.
 #
-# PUBLISHING IS NOT ENABLED YET. Until the steps below are done, every run
-# stops after `dart pub publish --dry-run`. The first live tag confirms that
-# knope-bot's API-created tag fires this push trigger at all (expected for App
-# events, never exercised here; workflow_dispatch is the fallback).
-# Enablement steps:
-#   1. A first manual `dart pub publish` by a livekit.io publisher admin has
-#      created the package on pub.dev (pub.dev only automates existing packages).
-#   2. Automated publishing from GitHub Actions is enabled in the package's
-#      pub.dev admin settings for livekit/rust-sdks with tag pattern
-#      `livekit-uniffi/v{{version}}`, and PUBLISH_ENABLED below is flipped.
+# Publishing is enabled. A tag push runs the whole pipeline and publishes to
+# pub.dev through OIDC (dart-lang/setup-dart exchanges the job token). pub.dev
+# accepts that token only because automated publishing is configured on the
+# package for livekit/rust-sdks with tag pattern `livekit-uniffi/v{{version}}`;
+# if that setting is removed the publish step fails and nothing else changes.
+# The package was created by a manual first publish of 0.1.10 (pub.dev only
+# automates existing packages), and knope-bot's API-created tag was confirmed
+# to fire this push trigger on that release.
 #
 # Recovery: if a run fails, fix the cause and re-run the failed jobs, or
 # dispatch this workflow with the tag. A dispatch rebuilds and re-attaches the
 # assets (with --clobber) and re-validates the package, but never publishes,
-# since pub.dev rejects OIDC tokens from dispatch runs. Set dry_run to skip the
+# since the publish step only runs for push events. Set dry_run to skip the
 # asset upload when only exercising the workflow.
 
 on:
@@ -49,10 +47,11 @@ on:
         default: false
 
 env:
-  # Flip to "true" once the enablement steps in the header are done. Real
-  # publishing additionally requires a tag-push trigger; workflow_dispatch
-  # runs always stop at the dry run (pub.dev rejects their OIDC tokens).
-  PUBLISH_ENABLED: "false"
+  # Set to "false" to pause publishing while keeping asset uploads and
+  # validation. Real publishing also requires a tag-push trigger: publishing
+  # from workflow_dispatch is left disabled on pub.dev, and the publish step
+  # below only runs for push events, so dispatch runs stop at the dry run.
+  PUBLISH_ENABLED: "true"
 
 permissions:
   contents: read


### PR DESCRIPTION
### Before you submit your PR

Make sure the following is true before submitting your PR:

- [x] I have read the [contributing guidelines](https://github.com/livekit/rust-sdks/blob/main/CONTRIBUTING.md) and validated that this PR will be accepted.
- [x] I have read and followed the principles regarding breaking changes, testing, and code quality.

### PR description

Flips `PUBLISH_ENABLED` to `true` in `uniffi-dart-publish.yml`, so livekit-uniffi releases publish `livekit_uniffi` to pub.dev automatically from now on. The header is rewritten from an enablement checklist to a description of what the publish depends on.

Everything the checklist asked for is done:

- `livekit_uniffi` 0.1.10 was published manually (pub.dev only automates packages that already exist) and transferred to the `livekit.io` verified publisher.
- Automated publishing from GitHub Actions is configured on the package for `livekit/rust-sdks` with tag pattern `livekit-uniffi/v{{version}}`, `push` events only.
- The 0.1.10 tag push confirmed knope's API-created tag fires this workflow, attaches all 12 cdylib assets, and produces a clean `pub publish --dry-run`.

`workflow_dispatch` publishing is left disabled on pub.dev and the publish step only runs for push events, so a manual dispatch remains a recovery tool that rebuilds assets without being able to ship a package.

### Breaking changes

None.

### MSRV

No changes.

### Testing

Workflow-only change; actionlint clean. The first real exercise is the next livekit-uniffi release, where the publish step now runs instead of being skipped. If pub.dev rejects it, the step fails with pub.dev's message, the assets and dry run are unaffected, and the version can still be published by hand.

### Async

No async code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
