### PR TITLE
Bound SignalStream::close so a dead signal link cannot hang Room::close()

### DIFF
--- a/.changeset/signal_stream_close_dead_link.md
+++ b/.changeset/signal_stream_close_dead_link.md
@@ -1,0 +1,23 @@
+---
+livekit-signaling: patch
+---
+
+# Bound `SignalStream::close` so a dead signal link cannot hang `Room::close()`
+
+A signal WebSocket can stop delivering data while the socket stays open — no FIN, no
+RST, no ICMP error, which is what a lost cellular or Wi-Fi uplink looks like. The read
+task waits in `conn.recv()`, and nothing could wake it: `NativeConnection::close` closes
+the writer only, and the reader keeps polling a socket that never delivers. Since
+`SignalStream::close` joined the read task's handle, it never returned. That took the
+room down with it: the reconnect never reached `SignalStream::connect` because `restart`
+was waiting on the stream lock, and `Room::close()` never returned from the `Leave` send.
+Devices stayed in a room for hours after the SDK had reported them disconnected.
+
+The read task now selects on a shutdown channel owned by the `SignalStream`, so `close`
+can stop it, and dropping a `SignalStream` without closing it stops its tasks too. A
+`CLOSE_DRAIN_TIMEOUT` backstop bounds the shutdown if a transport stalls some other way
+— a `send` waiting on TCP retransmission, say — and aborts the tasks rather than leaving
+them parked on the socket.
+
+`SignalInner::close` also takes the stream out of the slot before closing it, so the
+write lock is no longer held across the shutdown.

--- a/issue-1407-test-results.md
+++ b/issue-1407-test-results.md
@@ -1,0 +1,98 @@
+# Test results — issue #1407
+
+`Room::close()` does not return when the signal link stops delivering data
+https://github.com/livekit/rust-sdks/issues/1407
+
+## Environment
+
+- Date: 2026-09-10 19:09 UTC
+- Host: Windows 11, x86_64-pc-windows-msvc (linker: VS 2022 Community, MSVC 14.44.35207, Windows SDK 10.0.22621.0)
+- Toolchain: rustc 1.97.1 (8bab26f4f 2026-07-14) — the version pinned by the repo's `rust-toolchain.toml`,
+  installed for this run and removed afterwards
+- Base commit: tests were run at `8a85181c` (Compile all features in ci (#1393)). The branch
+  was later rebased onto `42d6bc5a` (Expose pre-encoded video ingest through FFI (#1418)),
+  which touches no file under `livekit-signaling/`, so the results carry over unchanged.
+- Changed: livekit-signaling/src/signal_stream.rs, livekit-signaling/src/lib.rs
+
+## Summary
+
+| Check | Command | Result |
+| --- | --- | --- |
+| Unit tests | `cargo test -p livekit-signaling --lib` | **42 passed, 0 failed** |
+| Regression proof (pre-fix code) | same, 3 new tests only | **3 failed** — as expected |
+| Formatting | `cargo fmt -p livekit-signaling -- --check` | **clean** (exit 0) |
+| Lints | `cargo clippy -p livekit-signaling --all-targets` | **exit 0**, no new warnings |
+| Feature check | `cargo check -p livekit-signaling --features native --all-targets` | **exit 0** |
+
+## 1. Unit tests, with the fix applied
+
+```
+running 42 tests
+...
+test signal_stream::tests::close_without_notify_returns_on_a_dead_link ... ok
+test signal_stream::tests::close_returns_on_a_dead_link ... ok
+test signal_stream::tests::dropping_the_stream_stops_its_tasks ... ok
+
+test result: ok. 42 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
+```
+
+The whole suite finishes in 0.03s: no test reaches a timeout, so `close()` is
+returning promptly rather than being rescued by the `CLOSE_DRAIN_TIMEOUT` backstop.
+
+## 2. Regression proof — the same tests against pre-fix behaviour
+
+To confirm the tests actually pin the bug, the two production changes were
+temporarily reverted (read task back to a bare `conn.recv().await` with no
+shutdown arm; `close()` back to awaiting both handles unbounded) while keeping
+the new tests. All three failed:
+
+```
+test signal_stream::tests::close_returns_on_a_dead_link ... FAILED
+test signal_stream::tests::close_without_notify_returns_on_a_dead_link ... FAILED
+test signal_stream::tests::dropping_the_stream_stops_its_tasks ... FAILED
+
+---- signal_stream::tests::close_returns_on_a_dead_link stdout ----
+panicked at livekit-signaling\src\signal_stream.rs:256:9:
+SignalStream::close() did not return on a dead link
+
+---- signal_stream::tests::close_without_notify_returns_on_a_dead_link stdout ----
+panicked at livekit-signaling\src\signal_stream.rs:268:9:
+SignalStream::close(false) did not return on a dead link
+
+---- signal_stream::tests::dropping_the_stream_stops_its_tasks stdout ----
+panicked at livekit-signaling\src\signal_stream.rs:281:9:
+a dropped stream left its tasks running
+
+test result: FAILED. 0 passed; 3 failed; 0 ignored; 0 measured; 39 filtered out; finished in 10.02s
+```
+
+`finished in 10.02s` is the tests' own 10s guard expiring — the reproduction the
+issue reports. The source file was then restored from a byte-identical backup
+(md5 `8889f60fb9a7d1e0b74ea97fff60f3fd`, verified after restore).
+
+## 3. Clippy
+
+`cargo clippy -p livekit-signaling --all-targets` exits 0. `livekit-signaling`
+emits 4 lib warnings + 3 test warnings, all pre-existing and none in the changed
+code:
+
+| Warning | Location | Mine? |
+| --- | --- | --- |
+| large size difference between variants | `signal_stream.rs:25` (`InternalMessage` enum) | no — untouched |
+| `to_string` in `error!` args | `lib.rs:259` | no |
+| `clone` on `u32` | `lib.rs:384` | no |
+| too many arguments (8/7) | `lib.rs:816` | no |
+| `std::io::Error::other` | `region_url_provider.rs:356` | no |
+| `.err().expect()` | `lib.rs:1371` | no |
+| field assignment outside initializer | `lib.rs:1440` | no |
+
+## Not covered by this run
+
+- The workspace's other crates were not built. `SignalStream` is `pub(super)`
+  and the public signature of `SignalClient::close` is unchanged, so there is no
+  downstream API impact — but a full `cargo build` needs the WebRTC prebuilts and
+  was not attempted here.
+- The end-to-end test the issue reporter offered (a TCP proxy in front of the
+  signal WebSocket, holding both sockets open while forwarding nothing, against
+  `livekit-server --dev`) was not run. It exercises the real transport rather
+  than a mock and would be worth taking them up on.

--- a/livekit-signaling/src/lib.rs
+++ b/livekit-signaling/src/lib.rs
@@ -343,7 +343,13 @@ impl SignalClient {
         self.inner.send(signal).await
     }
 
-    /// Close the connection to the server
+    /// Close the connection to the server.
+    ///
+    /// Returns even when the link is dead, but not necessarily quickly: a close that
+    /// races an in-flight reconnect waits on the stream lock behind that reconnect's own
+    /// close drain (2s), [`SIGNAL_CONNECT_TIMEOUT`] and [`JOIN_RESPONSE_TIMEOUT`] before
+    /// it can take the stream, and then drains its own stream. Callers that need a
+    /// deadline should impose their own.
     pub async fn close(&self) {
         self.inner.close(true).await;
 
@@ -613,9 +619,15 @@ impl SignalInner {
         self.flush_queue().await;
     }
 
-    /// Close the connection
+    /// Close the connection.
+    ///
+    /// The stream comes out of the slot before it is closed, so the write lock is not
+    /// held across the shutdown: `restart` and pass-through sends would otherwise queue
+    /// behind a network operation. This is the one path where the lock protects nothing,
+    /// since the stream is already on its way out.
     pub async fn close(&self, notify_close: bool) {
-        if let Some(stream) = self.stream.write().await.take() {
+        let stream = self.stream.write().await.take();
+        if let Some(stream) = stream {
             stream.close(notify_close).await;
         }
     }

--- a/livekit-signaling/src/signal_stream.rs
+++ b/livekit-signaling/src/signal_stream.rs
@@ -30,12 +30,24 @@ enum InternalMessage {
     Close,
 }
 
+/// Grace period for the read and write tasks to stop during [`SignalStream::close`].
+///
+/// A link that dies without FIN or RST (a lost cellular or Wi-Fi uplink) leaves the
+/// transport parked with nothing to wake it: `recv` never returns and `send` waits on
+/// TCP retransmission. `close` runs on the room teardown and reconnect paths, so it has
+/// to stay bounded whatever the peer does.
+const CLOSE_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
+
 /// SignalStream holds the WebSocket connection (via `WsConnection`).
 ///
 /// It is replaced by [SignalClient] at each reconnection.
 #[derive(Debug)]
 pub(super) struct SignalStream {
     internal_tx: mpsc::Sender<InternalMessage>,
+    /// Dropped to stop `read_task`, which is otherwise parked in a `recv()` that a dead
+    /// link never completes. Held by value, so dropping the `SignalStream` without
+    /// calling [`SignalStream::close`] stops the reader too.
+    shutdown_tx: oneshot::Sender<()>,
     read_handle: JoinHandle<()>,
     write_handle: JoinHandle<()>,
 }
@@ -75,20 +87,52 @@ impl SignalStream {
 
         let (emitter, events) = mpsc::unbounded_channel();
         let (internal_tx, internal_rx) = mpsc::channel::<InternalMessage>(8);
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let write_handle = tokio::spawn(Self::write_task(internal_rx, conn.clone()));
-        let read_handle = tokio::spawn(Self::read_task(internal_tx.clone(), conn, emitter));
+        let read_handle =
+            tokio::spawn(Self::read_task(internal_tx.clone(), conn, emitter, shutdown_rx));
 
-        Ok((Self { internal_tx, read_handle, write_handle }, events))
+        Ok((Self { internal_tx, shutdown_tx, read_handle, write_handle }, events))
     }
 
     /// Close the websocket.
     /// It sends a Close message before closing.
+    ///
+    /// Bounded by [`CLOSE_DRAIN_TIMEOUT`]: callers hold the stream lock across this call
+    /// and the room teardown goes through it, so it must not depend on the peer. A link
+    /// that dies without FIN or RST never delivers the close the read task waits for, so
+    /// stop that task instead of waiting for the transport.
     pub async fn close(self, notify_close: bool) {
+        let Self { internal_tx, shutdown_tx, mut read_handle, mut write_handle } = self;
+
         if notify_close {
-            let _ = self.internal_tx.send(InternalMessage::Close).await;
+            // Best effort: the peer may already be unreachable, and the channel has a
+            // capacity of 8 that a stalled write task can fill.
+            let _ =
+                tokio::time::timeout(CLOSE_DRAIN_TIMEOUT, internal_tx.send(InternalMessage::Close))
+                    .await;
         }
-        let _ = self.write_handle.await;
-        let _ = self.read_handle.await;
+
+        // Stop the read task first: it holds a clone of `internal_tx`, so the write
+        // task's channel only closes once the read task is gone.
+        drop(shutdown_tx);
+        drop(internal_tx);
+
+        let drained = tokio::time::timeout(CLOSE_DRAIN_TIMEOUT, async {
+            let _ = (&mut read_handle).await;
+            let _ = (&mut write_handle).await;
+        })
+        .await;
+
+        if drained.is_err() {
+            // A transport that stops responding some other way (a `send` waiting on TCP
+            // retransmission, say) would otherwise keep the task, and with it the last
+            // references to the connection, alive after the caller has given up. Stop
+            // them so the socket is dropped rather than leaked.
+            log::warn!("signal stream did not shut down within {:?}", CLOSE_DRAIN_TIMEOUT);
+            read_handle.abort();
+            write_handle.abort();
+        }
     }
 
     /// Send a SignalRequest to the websocket.
@@ -134,9 +178,17 @@ impl SignalStream {
         internal_tx: mpsc::Sender<InternalMessage>,
         conn: Arc<dyn livekit_net::WsConnection>,
         emitter: mpsc::UnboundedSender<Box<proto::signal_response::Message>>,
+        mut shutdown_rx: oneshot::Receiver<()>,
     ) {
         loop {
-            match conn.recv().await {
+            // `recv` never returns on a link that delivers no data: no data, no FIN, no
+            // RST. Without this arm the task outlives its `SignalStream` and blocks
+            // every caller that awaits its `JoinHandle`.
+            let received = tokio::select! {
+                result = conn.recv() => result,
+                _ = &mut shutdown_rx => break,
+            };
+            match received {
                 Ok(Some(bytes)) => {
                     match proto::SignalResponse::decode(bytes.as_slice()) {
                         Ok(res) => {
@@ -162,5 +214,101 @@ impl SignalStream {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use livekit_net::TransportError;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// A transport that delivers no data and never closes the read side, like a cellular
+    /// or Wi-Fi uplink that goes away without FIN or RST. `close` only records the call,
+    /// since `NativeConnection::close` closes the writer alone.
+    struct StalledConn {
+        closed: AtomicBool,
+    }
+
+    #[async_trait::async_trait]
+    impl livekit_net::WsConnection for StalledConn {
+        async fn send(&self, _frame: Vec<u8>) -> Result<(), TransportError> {
+            Ok(())
+        }
+
+        async fn recv(&self) -> Result<Option<Vec<u8>>, TransportError> {
+            std::future::pending().await
+        }
+
+        async fn close(&self) {
+            self.closed.store(true, Ordering::SeqCst);
+        }
+    }
+
+    /// A `SignalStream` wired up exactly as `connect` does, over a stalled transport.
+    fn stalled_stream() -> (SignalStream, Arc<StalledConn>) {
+        let conn = Arc::new(StalledConn { closed: AtomicBool::new(false) });
+        let dyn_conn: Arc<dyn livekit_net::WsConnection> = conn.clone();
+        let (emitter, _events) = mpsc::unbounded_channel();
+        let (internal_tx, internal_rx) = mpsc::channel::<InternalMessage>(8);
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let write_handle = tokio::spawn(SignalStream::write_task(internal_rx, dyn_conn.clone()));
+        let read_handle = tokio::spawn(SignalStream::read_task(
+            internal_tx.clone(),
+            dyn_conn,
+            emitter,
+            shutdown_rx,
+        ));
+        (SignalStream { internal_tx, shutdown_tx, read_handle, write_handle }, conn)
+    }
+
+    /// Wait for the transport to be closed, or give up. The tasks run on other threads,
+    /// so the flag is not set the instant `close` returns.
+    async fn wait_for_close(conn: &Arc<StalledConn>) -> bool {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while !conn.closed.load(Ordering::SeqCst) {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .is_ok()
+    }
+
+    /// The room teardown and the reconnect both go through `close`. A link that stops
+    /// delivering data leaves `recv` parked forever, so without a way to stop the read
+    /// task this join never returns and the caller can neither leave the room nor
+    /// reconnect.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn close_returns_on_a_dead_link() {
+        let (stream, conn) = stalled_stream();
+
+        let result = tokio::time::timeout(Duration::from_secs(10), stream.close(true)).await;
+
+        assert!(result.is_ok(), "SignalStream::close() did not return on a dead link");
+        assert!(wait_for_close(&conn).await, "conn.close() was never called");
+    }
+
+    /// `restart` closes the old stream without notifying the peer. That path has no
+    /// `Close` message to unblock the write task, so it relies on the same shutdown.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn close_without_notify_returns_on_a_dead_link() {
+        let (stream, conn) = stalled_stream();
+
+        let result = tokio::time::timeout(Duration::from_secs(10), stream.close(false)).await;
+
+        assert!(result.is_ok(), "SignalStream::close(false) did not return on a dead link");
+        assert!(wait_for_close(&conn).await, "conn.close() was never called");
+    }
+
+    /// A caller that abandons `close` drops the stream instead. The shutdown sender is
+    /// owned by the stream, so that drop has to stop the tasks as well — otherwise they
+    /// stay parked on the socket for the life of the process.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dropping_the_stream_stops_its_tasks() {
+        let (stream, conn) = stalled_stream();
+
+        drop(stream);
+
+        assert!(wait_for_close(&conn).await, "a dropped stream left its tasks running");
     }
 }


### PR DESCRIPTION
Fixes #1407.

## The bug

A signal WebSocket can stop delivering data while the socket stays open — no FIN, no RST, no ICMP error, which is what a lost cellular or Wi-Fi uplink looks like. `read_task` waits in `conn.recv()`, and nothing could wake it: `NativeConnection::close` closes the writer only, and the reader keeps polling a socket that never delivers. Since `SignalStream::close` joined the read task's handle, **it never returned**.

That took the room down with it:

- `SignalInner::restart` never reached `SignalStream::connect`, because it was waiting on the stream write lock that the hung `close` was holding. The engine sat in `Reconnecting` and logged no connect attempt.
- `Room::close()` never returned from the `Leave` send, which is a pass-through signal and so waits on the same lock.

A caller-side timeout is not a workaround, because `close()` does not return at all. The reporter saw devices stay in a room for hours after their SDK had reported a disconnect.

## The fix

- **`read_task` selects on a shutdown channel** owned by the `SignalStream`, so `close` can stop it. The sender is held by value, so dropping a `SignalStream` without closing it stops its tasks too — no `Drop` impl needed.
- **`CLOSE_DRAIN_TIMEOUT` (2s) bounds the shutdown** if a transport stalls some other way, and aborts the tasks rather than detaching them. A write task parked in `conn.send()` on a half-open socket holds the last references to the connection; detaching would keep the socket alive long after the caller gave up. This also bounds the capacity-8 channel backpressure case from #1335.
- **`SignalInner::close` takes the stream out of the slot before closing it**, so the write lock is not held across a network operation. This is the one path where the lock protects nothing, since the stream is already on its way out.

`SignalClient::close` also picked up a doc note on its upper bound, which the reporter asked for: a close racing an in-flight reconnect still waits behind that reconnect's drain, `SIGNAL_CONNECT_TIMEOUT` and `JOIN_RESPONSE_TIMEOUT`. Callers who need a deadline should impose their own.

## Tests

Three tests over a transport that never delivers data and whose `close` affects only the writer, mirroring `NativeConnection`:

- `close_returns_on_a_dead_link` — the reporter's reproduction
- `close_without_notify_returns_on_a_dead_link` — the `restart` path, which has no `Close` message to unblock the write task
- `dropping_the_stream_stops_its_tasks` — a caller that abandons `close` and drops the room instead

**All three fail against the previous code**, at their 10s guard, with `SignalStream::close() did not return on a dead link`. Verified by temporarily reverting the two production changes while keeping the tests.

With the fix, the full `livekit-signaling` suite is 42 passed / 0 failed in 0.03s — nothing reaches a timeout, so `close()` returns on its own rather than being rescued by the backstop. `cargo fmt --check` and `cargo clippy --all-targets` are clean (the crate's 7 remaining clippy warnings are all pre-existing and outside the changed code). Toolchain: the repo's pinned 1.97.1.

## Not addressed

Two things the issue lists under **Effect** are left alone, as the reporter suggested — they are the reason a slow `close()` became an unleavable room, but they are a separate fix:

- `Room` has no `Drop` impl, so a caller that abandons `close()` cannot drop the room instead.
- `RoomSession::close` takes its task handles on entry, so a cancelled `close()` cannot be retried; the second call returns `AlreadyClosed` and shuts nothing down.

The reporter also offered an end-to-end test that puts a TCP proxy in front of the signal WebSocket and stops it forwarding while holding both sockets open. That exercises the real transport rather than a mock and would be worth taking them up on.
