### PR TITLE
Publish the Dart package without the token on dependency resolution

### DIFF
--- a/.changeset/dart_publish_token_workaround.md
+++ b/.changeset/dart_publish_token_workaround.md
@@ -2,7 +2,7 @@
 livekit-uniffi: patch
 ---
 
-# Publish the Dart package without sending the publishing token on dependency resolution
+Publish the Dart package without sending the publishing token on dependency resolution
 
 pub.dev has started answering 403 to package metadata requests that carry a
 bearer token, and the publishing token was registered for the whole host, so

--- a/.changeset/dart_publish_token_workaround.md
+++ b/.changeset/dart_publish_token_workaround.md
@@ -1,0 +1,10 @@
+---
+livekit-uniffi: patch
+---
+
+# Publish the Dart package without sending the publishing token on dependency resolution
+
+pub.dev has started answering 403 to package metadata requests that carry a
+bearer token, and the publishing token was registered for the whole host, so
+`dart pub get` failed before the upload could start. Resolution and validation
+now run without the token, which is added back only for the upload.

--- a/.github/workflows/uniffi-dart-publish.yml
+++ b/.github/workflows/uniffi-dart-publish.yml
@@ -188,13 +188,23 @@ jobs:
             exit 1
           fi
 
+      # pub.dev currently answers 403 to package metadata requests that carry a
+      # bearer token (dart-lang/pub-dev#9576), and setup-dart registers the
+      # publishing token for the whole host, so dependency resolution has to run
+      # without it. The token is added back right before the upload, the only
+      # request that needs it, and client-side validation is skipped there
+      # because this step just did it. Collapse back to plain `dart pub get`,
+      # `--dry-run` and `--force` once the issue is fixed.
       - name: Validate package
         working-directory: ${{ runner.temp }}/livekit_uniffi
         run: |
+          dart pub token remove https://pub.dev || true
           dart pub get
           dart pub publish --dry-run
 
       - name: Publish to pub.dev
         if: ${{ env.PUBLISH_ENABLED == 'true' && github.event_name == 'push' }}
         working-directory: ${{ runner.temp }}/livekit_uniffi
-        run: dart pub publish --force
+        run: |
+          dart pub token add https://pub.dev --env-var PUB_TOKEN
+          dart pub publish --force --skip-validation


### PR DESCRIPTION
### PR description

The 0.1.12 release run failed in `Validate package`: `dart pub get` got a 403 from pub.dev and the publish step was skipped. Cause is a pub.dev regression, dart-lang/pub-dev#9576: package metadata endpoints now return 403 for any request carrying an `Authorization: Bearer` header (reproducible with `curl -H 'Authorization: Bearer abc' https://pub.dev/api/packages/test`), and setup-dart registers the OIDC token for the whole host, so `pub get` sends it on every request.

Workaround, as documented in that issue:

- `Validate package` removes the token first, so `pub get` and `--dry-run` resolve without it.
- `Publish to pub.dev` re-adds the token from `PUB_TOKEN` and runs `dart pub publish --force --skip-validation`. `--skip-validation` skips dependency resolution, so the upload is the only credentialed request.

Includes a `livekit-uniffi: patch` changeset so the next release exercises the fixed path. The comment notes to collapse back to the plain commands once pub.dev fixes the issue.

### Breaking changes

None.

### Testing

actionlint clean. The 403 was reproduced locally against pub.dev with and without the header. The publish path itself can only be exercised by the next tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
