### PR TITLE
livekit: do not answer a server-initiated Leave with a client Leave

### DIFF
--- a/.changeset/skip-leave-on-server-disconnect.md
+++ b/.changeset/skip-leave-on-server-disconnect.md
@@ -1,0 +1,5 @@
+---
+livekit: patch
+---
+
+Stop answering a server-initiated Leave (room deleted, duplicate identity) with a client Leave. The server has already ended the session and is closing the signalling socket, so the reply only ever produced the warning "dropping pass-through signal — no stream available" on every such disconnect.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3605,6 +3605,7 @@ dependencies = [
  "lazy_static",
  "libloading 0.8.9",
  "libwebrtc",
+ "livekit-api",
  "livekit-common",
  "livekit-data-stream",
  "livekit-datatrack",

--- a/livekit/Cargo.toml
+++ b/livekit/Cargo.toml
@@ -78,6 +78,8 @@ base64 = "0.22"
 
 [dev-dependencies]
 livekit-token = { workspace = true }
+# Room service client, so an e2e test can delete the room it joined.
+livekit-api = { workspace = true, default-features = false, features = ["services"] }
 # Enable data-stream test constructors (e.g. TextStreamReader::new_for_test) for our test suites.
 livekit-data-stream = { workspace = true, features = ["test-utils"] }
 # Async test runtime + timers, needed by the peer_transport deadlock reproducer.

--- a/livekit/src/rtc_engine/rtc_session.rs
+++ b/livekit/src/rtc_engine/rtc_session.rs
@@ -2025,13 +2025,17 @@ impl SessionInner {
             sub_pc.close();
         }
 
-        self.signal_client
-            .send(proto::signal_request::Message::Leave(proto::LeaveRequest {
-                action: proto::leave_request::Action::Disconnect.into(),
-                reason: reason as i32,
-                ..Default::default()
-            }))
-            .await;
+        // A server-initiated Leave already ended the session on the server, and the socket it
+        // arrived on is closing under us: there is nothing to answer.
+        if !self.disconnecting.load(Ordering::Acquire) {
+            self.signal_client
+                .send(proto::signal_request::Message::Leave(proto::LeaveRequest {
+                    action: proto::leave_request::Action::Disconnect.into(),
+                    reason: reason as i32,
+                    ..Default::default()
+                }))
+                .await;
+        }
 
         self.signal_client.close().await;
     }

--- a/livekit/tests/reconnection_test.rs
+++ b/livekit/tests/reconnection_test.rs
@@ -41,6 +41,7 @@ use {
     common::test_rooms,
     libwebrtc::native::create_random_uuid,
     livekit::{ConnectionState, Room, RoomEvent, RoomOptions, SimulateScenario},
+    livekit_api::services::room::RoomClient,
     livekit_token::{AccessToken, VideoGrants},
     std::{env, net::SocketAddr, time::Duration},
     tokio::{
@@ -371,5 +372,46 @@ async fn test_reconnect_exhaustion_disconnects() -> Result<()> {
         ConnectionState::Disconnected,
         "room must reach Disconnected after reconnection is exhausted, not hang in Reconnecting"
     );
+    Ok(())
+}
+
+// A server-side room deletion is a terminal Leave: the room must report
+// Disconnected { RoomDeleted } without ever entering Reconnecting, and the client
+// has nothing to say back on a signalling socket the server is already closing.
+#[cfg(feature = "__lk-e2e-test")]
+#[test_log::test(tokio::test)]
+async fn test_room_deleted_disconnects_without_reconnect() -> Result<()> {
+    let api_key = env::var("LIVEKIT_API_KEY").unwrap_or_else(|_| "devkey".into());
+    let api_secret = env::var("LIVEKIT_API_SECRET").unwrap_or_else(|_| "secret".into());
+    let server_url = env::var("LIVEKIT_URL").unwrap_or_else(|_| "ws://localhost:7880".into());
+
+    let room_name = format!("test_room_{}", create_random_uuid());
+    let token = AccessToken::with_api_key(&api_key, &api_secret)
+        .with_ttl(Duration::from_secs(30 * 60))
+        .with_grants(VideoGrants { room_join: true, room: room_name.clone(), ..Default::default() })
+        .with_identity("p0")
+        .with_name("Participant 0")
+        .to_jwt()?;
+
+    let (room, mut events) = Room::connect(&server_url, &token, RoomOptions::default()).await?;
+    assert_eq!(room.connection_state(), ConnectionState::Connected);
+
+    let http_url = server_url.replacen("ws", "http", 1);
+    RoomClient::with_api_key(&http_url, &api_key, &api_secret).delete_room(&room_name).await?;
+
+    let observe = async {
+        while let Some(event) = events.recv().await {
+            match event {
+                RoomEvent::Reconnecting => bail!("a deleted room must not be reconnected to"),
+                RoomEvent::Disconnected { reason } => return Ok(reason),
+                _ => {}
+            }
+        }
+        bail!("event stream ended before the room reported Disconnected");
+    };
+    let reason = timeout(Duration::from_secs(30), observe).await??;
+
+    assert_eq!(reason, livekit::DisconnectReason::RoomDeleted);
+    assert_eq!(room.connection_state(), ConnectionState::Disconnected);
     Ok(())
 }


### PR DESCRIPTION
## Problem

Every server-initiated disconnect (room deleted, duplicate identity, participant removed) logs at WARN:

```
livekit_signaling - dropping pass-through signal — no stream available
```

Reproduced with the Python SDK by joining a room and running `lk room delete`: the line appears right before `Disconnected from room ... with reason: RoomDeleted`. It also shows up at the end of every `lk agent simulate` job, because the simulation service deletes the room when the job finishes.

Cause: the server sends `Leave{Disconnect}` and closes the websocket. The engine runs `RtcSession::close`, which sends the client's own `Leave` back; the stream is already gone, so the signal client warns. Answering a server-initiated Leave is pointless: the server has already ended the session.

## Fix

`RtcSession::close` skips the outgoing `Leave` when `disconnecting` is set. That flag is already set by `on_session_disconnected` for exactly this case (it guards the "publisher data channel closed unexpectedly" log). Client-initiated disconnects still send their Leave.

## Test

New e2e test `test_room_deleted_disconnects_without_reconnect`: connects, deletes the room through `RoomClient::delete_room`, and asserts the room reports `Disconnected{RoomDeleted}` without a `Reconnecting` event. `livekit-api` (services only) becomes a dev-dependency of `livekit` for it.

Ran against a local `livekit-server` 1.13.5 with `RUST_LOG=warn --nocapture`. Before the fix the run printed the warning; after, three consecutive runs printed none. The full `reconnection_test` file passes (6 tests).

## Not in this PR

The same local repro also prints `publisher data channel '_reliable' closed unexpectedly` at ERROR on every room deletion: the data channels close before the server's Leave is processed, so the `disconnecting` guard is not yet set when the state change fires. Same root cause, separate ordering problem, left for a follow-up.