### PR TITLE
Automatic capture thread join on drop

### DIFF
--- a/.changeset/automatic_capture_thread_join_on_drop.md
+++ b/.changeset/automatic_capture_thread_join_on_drop.md
@@ -1,0 +1,5 @@
+---
+livekit-capture: patch
+---
+
+# Automatic capture thread join on drop

--- a/livekit-capture/src/pixel/pump.rs
+++ b/livekit-capture/src/pixel/pump.rs
@@ -239,28 +239,33 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn running_pump_stops_on_signal() {
-        struct EndlessSource;
+    struct EndlessSource;
 
-        impl PixelVideoSource for EndlessSource {
-            fn resolution(&self) -> VideoResolution {
-                RESOLUTION
-            }
-
-            fn next_frame(
-                &mut self,
-                _stop: &PumpStop,
-            ) -> Result<Option<BoxVideoFrame>, SourceError> {
-                std::thread::sleep(std::time::Duration::from_millis(1));
-                Ok(Some(pixel_frame(0)))
-            }
+    impl PixelVideoSource for EndlessSource {
+        fn resolution(&self) -> VideoResolution {
+            RESOLUTION
         }
 
+        fn next_frame(&mut self, _stop: &PumpStop) -> Result<Option<BoxVideoFrame>, SourceError> {
+            std::thread::sleep(std::time::Duration::from_millis(1));
+            Ok(Some(pixel_frame(0)))
+        }
+    }
+
+    #[tokio::test]
+    async fn running_pump_stops_on_signal() {
         let running = PixelVideoPump::new(EndlessSource).spawn().unwrap();
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
         let stats = running.stop_and_join().await.unwrap();
         assert!(stats.frames_captured > 0);
         assert_eq!(stats.exit, PumpExit::Stopped);
+    }
+
+    #[tokio::test]
+    async fn dropping_running_pump_stops_the_thread() {
+        let running = PixelVideoPump::new(EndlessSource).spawn().unwrap();
+        let stop = running.stop_handle();
+        drop(running);
+        assert!(stop.is_stopped());
     }
 }

--- a/livekit-capture/src/pump.rs
+++ b/livekit-capture/src/pump.rs
@@ -104,7 +104,7 @@ pub(crate) fn spawn_pump(
         result
     })?;
 
-    Ok(RunningPump { stop, thread, finished: finished_rx })
+    Ok(RunningPump { stop, thread: Some(thread), finished: finished_rx })
 }
 
 /// Renders a panic payload for [`PumpError::Panicked`].
@@ -122,12 +122,23 @@ fn panic_message(panic: &(dyn Any + Send)) -> String {
 ///
 /// A stop takes effect between frames: a source that is blocked on its next
 /// frame completes that wait before the pump observes the signal.
+///
+/// Dropping the handle signals the pump to stop, so an endless source does
+/// not keep capturing. The drop does not wait for the thread to exit; use
+/// [`RunningPump::stop_and_join`] to observe the outcome.
 #[derive(Debug)]
 pub struct RunningPump {
     stop: PumpStop,
-    thread: thread::JoinHandle<Result<PumpStats, PumpError>>,
+    // Taken by `join`; `None` only after the thread has been joined.
+    thread: Option<thread::JoinHandle<Result<PumpStats, PumpError>>>,
     // Flipped to true by the pump thread just before it exits.
     finished: tokio::sync::watch::Receiver<bool>,
+}
+
+impl Drop for RunningPump {
+    fn drop(&mut self) {
+        self.stop.stop();
+    }
 }
 
 impl RunningPump {
@@ -143,7 +154,7 @@ impl RunningPump {
 
     /// Returns whether the pump thread exited.
     pub fn is_finished(&self) -> bool {
-        self.thread.is_finished()
+        self.thread.as_ref().map_or(true, |thread| thread.is_finished())
     }
 
     /// Waits for the pump to exit.
@@ -155,7 +166,8 @@ impl RunningPump {
         // An error means the sender dropped, which also implies the pump
         // thread is done; either way the join below returns promptly.
         let _ = self.finished.wait_for(|finished| *finished).await;
-        self.thread.join().unwrap_or_else(|panic| Err(PumpError::Panicked(panic_message(&*panic))))
+        let thread = self.thread.take().expect("pump thread is joined at most once");
+        thread.join().unwrap_or_else(|panic| Err(PumpError::Panicked(panic_message(&*panic))))
     }
 
     /// Signals the pump to stop and waits for it to exit.


### PR DESCRIPTION
When `RunningPump` is dropped, automatically join its thread for additional safety. Prefer `RunningPump::stop_and_join` to join and get exit stats.